### PR TITLE
Allow argparse coercing numbers to strings

### DIFF
--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -80,7 +80,7 @@ end
 local cluster_opts = {
     alias = 'string', -- **string**
     workdir = 'string', -- **string**
-    http_port = 'string', -- **string**
+    http_port = 'number', -- **number**
     advertise_uri = 'string', -- **string**
     cluster_cookie = 'string', -- **string**
     console_sock = 'string', -- **string**
@@ -379,6 +379,8 @@ local function get_opts(opts)
             -- ignore
         elseif type(value) == opttype then
             ret[optname] = value
+        elseif type(value) == 'number' and opttype == 'string' then
+            ret[optname] = tostring(value)
         elseif type(value) == 'string' then
             local _value
             if opttype == 'number' then

--- a/test/unit/argparse_test.lua
+++ b/test/unit/argparse_test.lua
@@ -309,10 +309,8 @@ function g:test_box_opts()
                 slab_alloc_factor = '1.3', -- string -> number
                 log_nonblock = 'false',    -- string -> bool
                 memtx_memory = 100,        -- number -> number
+                listen = 13301,            -- number -> string
                 read_only = true,          -- bool -> bool
-            },
-            number_to_string = {
-                feedback_host = 0,
             },
             boolean_to_string = {
                 feedback_host = false,
@@ -336,6 +334,7 @@ function g:test_box_opts()
         slab_alloc_factor = 1.3,
         log_nonblock = false,
         memtx_memory = 100,
+        listen = '13301',
         read_only = true,
     })
 
@@ -359,10 +358,6 @@ function g:test_box_opts()
 
     check_err('--read-only 1',
         [[TypeCastError: can't typecast read_only="1" to boolean]]
-    )
-
-    check_err('--cfg ./cfg.yml --instance-name number_to_string',
-        [[TypeCastError: invalid configuration parameter feedback_host (string expected, got number)]]
     )
 
     check_err('--cfg ./cfg.yml --instance-name boolean_to_string',


### PR DESCRIPTION
This is useful for some options which accept both string and number.
Most relatable for advertise_uri, http_port, listen