### PR TITLE
Auto-probe new servers on patch_clusterwide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Both bootstrapping from scratch and patching topology in clusterwide config automatically probe
+  servers, which aren't added to membership yet (earlier it influenced join_server mutation only).
+  This is a prerequisite for multijoin api implementation.
+
 ## [1.0.0] - 2019-08-29
 
 ### Added

--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -499,11 +499,6 @@ local function join_server(args)
         }
     end
 
-    local ok, err = probe_server(args.uri)
-    if not ok then
-        return nil, err
-    end
-
     if topology_cfg.servers[args.instance_uuid] ~= nil then
         return nil, e_topology_edit:new(
             'Server %q is already joined',

--- a/cartridge/bootstrap.lua
+++ b/cartridge/bootstrap.lua
@@ -170,6 +170,7 @@ local function bootstrap_from_scratch(conf)
         return nil, err
     end
 
+    topology.probe_missing_members(conf.topology.servers)
     local _, err = topology.validate(conf.topology, {})
     if err then
         membership.set_payload('warning', tostring(err.err or err))

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -723,6 +723,8 @@ local function _clusterwide(patch)
         end
     end
 
+    topology.probe_missing_members(conf_new.topology.servers)
+
     if utils.deepcmp(conf_new, conf_old) then
         return true
     end

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -327,10 +327,6 @@ def cluster(request, confdir, module_tmpdir, helpers):
         )
         request.addfinalizer(srv.kill)
         helpers.wait_for(srv.ping_udp)
-        if bootserv != None:
-            helpers.wait_for(bootserv.conn.eval,
-                ["assert(require('membership').probe_uri(...))", srv.advertise_uri]
-            )
         cluster[srv.alias] = srv
 
     return cluster

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -197,6 +197,10 @@ def test_replication_info_schema(cluster):
 
 
 def test_servers(cluster, expelled, helpers):
+    helpers.wait_for(cluster['router'].conn.eval,
+        ["assert(require('membership').probe_uri('localhost:33003'))"]
+    )
+
     obj = cluster['router'].graphql("""
         {
             servers {

--- a/test/integration/test_labels.py
+++ b/test/integration/test_labels.py
@@ -36,6 +36,10 @@ unconfigured = [
 ]
 
 def test_servers_labels(cluster, helpers):
+    helpers.wait_for(cluster['master'].conn.eval,
+        ["assert(require('membership').probe_uri('localhost:33003'))"]
+    )
+
     req = """
         {
             servers {

--- a/test/integration/test_multijoin.py
+++ b/test/integration/test_multijoin.py
@@ -44,9 +44,6 @@ def test_confapplier(cluster, helpers):
         local cartridge = require('cartridge')
         local membership = require('membership')
 
-        errors.assert('ProbeError', membership.probe_uri("{twin1.advertise_uri}"))
-        errors.assert('ProbeError', membership.probe_uri("{twin2.advertise_uri}"))
-
         local topology = cartridge.config_get_deepcopy('topology')
         topology.servers["{twin1.instance_uuid}"] = {{
             replicaset_uuid = "{twin1.replicaset_uuid}",


### PR DESCRIPTION
Both bootstrapping from scratch and patching topology in clusterwide config automatically probe
  servers, which aren't added to membership yet (earlier it influenced join_server mutation only).
  This is a prerequisite for multijoin api implementation.