### PR TITLE
Hide users page unless list_users implemented.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   servers, which aren't added to membership yet (earlier it influenced join_server mutation only).
   This is a prerequisite for multijoin api implementation.
 
+- WebUI users page is hidden if auth_backend doesn't provide list_users callback.
+
 ### Fixed
 
 - Protect `users_acl` and `auth` sections when downloading clusterwide config.

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -83,9 +83,9 @@ local function get_auth_params()
         cookie_renew_age = params.cookie_renew_age,
 
         implements_add_user = callbacks.add_user ~= nil,
-        implements_get_user = true,
+        implements_get_user = callbacks.get_user ~= nil,
         implements_edit_user = callbacks.edit_user ~= nil,
-        implements_list_users = true,
+        implements_list_users = callbacks.list_users ~= nil,
         implements_remove_user = callbacks.remove_user ~= nil,
         implements_check_password = true,
     }


### PR DESCRIPTION
WebUI changes controls visiblity depending on cluster.auth.implements_*
values. Thus UX depend on what is implemented in auth backend.

Cartridge provides built-in admin user which is always listed and can be
used to access webui. But users page becomes useless if no other callbacks
are implemented.
In order to hide users page when custom backend doesn't implement any
callbacks we honestly indicate it in api.

Close #1