### PR TITLE
Refresh replicaset list after config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `sync_timeout`, `collect_bucket_garbage_interval`,
   `rebalancer_disbalance_threshold`.
 
+- Refresh replicaset list in UI after topology edit actions: bootstrap, join, expel,
+  probe, replicaset edit.
+
 ### Changed
 
 - Both bootstrapping from scratch and patching topology in clusterwide config automatically probe

--- a/webui/.eslintrc
+++ b/webui/.eslintrc
@@ -67,6 +67,7 @@
         "allowSamePrecedence": true
       }
     ],
+    "space-unary-ops": ["error", {"words": true, "nonwords": false}],
     "react/jsx-first-prop-new-line": ["error", "multiline"],
     "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
     "react/jsx-closing-bracket-location": ["error", "tag-aligned"],

--- a/webui/src/components/AppMessage/AppMessage.js
+++ b/webui/src/components/AppMessage/AppMessage.js
@@ -30,7 +30,7 @@ const ICON_TYPES = {
 };
 
 const prepareUndoneMessages = messages => {
-  return messages.filter(message => ! message.done);
+  return messages.filter(message => !message.done);
 };
 
 class AppMessage extends React.Component {

--- a/webui/src/components/CommonItemList/CommonItemList.js
+++ b/webui/src/components/CommonItemList/CommonItemList.js
@@ -23,7 +23,7 @@ const getRowStyle = column => {
 };
 
 const prepareColumns = columns => {
-  return columns.filter(column => ! column.hidden);
+  return columns.filter(column => !column.hidden);
 };
 
 class CommonItemList extends React.PureComponent {

--- a/webui/src/store/commonRequest.js
+++ b/webui/src/store/commonRequest.js
@@ -153,7 +153,7 @@ const createSaga = (effect, SIGNAL, REQUEST, REQUEST_SUCCESS, REQUEST_ERROR, req
           type: REQUEST_ERROR,
           error,
           requestPayload,
-          __errorMessage: ! noErrorMessage
+          __errorMessage: !noErrorMessage
         });
         indicator && indicator.error();
         return;

--- a/webui/src/store/request/clusterPage.requests.js
+++ b/webui/src/store/request/clusterPage.requests.js
@@ -17,7 +17,7 @@ import type { EditReplicasetMutationVariables } from 'src/generated/graphql-typi
 
 const filterServerStat = response => {
   const serverStat
-    = response.serverStat.filter(stat => stat.uuid && stat.statistics && ! Array.isArray(stat.statistics));
+    = response.serverStat.filter(stat => stat.uuid && stat.statistics && !Array.isArray(stat.statistics));
   return {
     ...response,
     serverStat

--- a/webui/src/store/saga/clusterPage.saga.js
+++ b/webui/src/store/saga/clusterPage.saga.js
@@ -129,43 +129,12 @@ function* refreshListsRequestSaga() {
   }
 }
 
-function* bootstrapVshardRequestSaga() {
-  yield takeLatest(CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST, function* load(action) {
-    const {
-      payload: requestPayload = {},
-      __payload: {
-        noIndicator,
-        noErrorMessage,
-        successMessage
-      } = {}
-    } = action;
-    const indicator = noIndicator ? null : pageRequestIndicator.run();
-
-    let response;
-    try {
-      response = yield call(bootstrapVshard, requestPayload);
-      indicator && indicator.success();
-
-      yield put({
-        type: CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST_SUCCESS,
-        payload: response,
-        requestPayload,
-        __successMessage: successMessage
-      });
-
-      yield refreshListsSaga();
-    } catch (error) {
-      yield put({
-        type: CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST_ERROR,
-        error,
-        requestPayload,
-        __errorMessage: !noErrorMessage
-      });
-      indicator && indicator.error();
-      return;
-    }
-  });
-};
+const bootstrapVshardRequestSaga = getRequestSaga(
+  CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST,
+  CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST_SUCCESS,
+  CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST_ERROR,
+  bootstrapVshard,
+);
 
 const probeServerRequestSaga = function* () {
   yield takeLatest(CLUSTER_PAGE_PROBE_SERVER_REQUEST, function* load(action) {
@@ -184,8 +153,6 @@ const probeServerRequestSaga = function* () {
         payload: response,
         __successMessage: successMessage
       });
-
-      yield refreshListsSaga();
     } catch (error) {
       yield put({
         type: CLUSTER_PAGE_PROBE_SERVER_REQUEST_ERROR,
@@ -198,43 +165,12 @@ const probeServerRequestSaga = function* () {
   });
 };
 
-function* joinServerRequestSaga() {
-  yield takeLatest(CLUSTER_PAGE_JOIN_SERVER_REQUEST, function* load(action) {
-    const {
-      payload: requestPayload = {},
-      __payload: {
-        noIndicator,
-        noErrorMessage,
-        successMessage
-      } = {}
-    } = action;
-    const indicator = noIndicator ? null : pageRequestIndicator.run();
-
-    let response;
-    try {
-      response = yield call(joinServer, requestPayload);
-      indicator && indicator.success();
-
-      yield put({
-        type: CLUSTER_PAGE_JOIN_SERVER_REQUEST_SUCCESS,
-        payload: response,
-        requestPayload,
-        __successMessage: successMessage
-      });
-
-      yield refreshListsSaga();
-    } catch (error) {
-      yield put({
-        type: CLUSTER_PAGE_JOIN_SERVER_REQUEST_ERROR,
-        error,
-        requestPayload,
-        __errorMessage: !noErrorMessage
-      });
-      indicator && indicator.error();
-      return;
-    }
-  });
-};
+const joinServerRequestSaga = getRequestSaga(
+  CLUSTER_PAGE_JOIN_SERVER_REQUEST,
+  CLUSTER_PAGE_JOIN_SERVER_REQUEST_SUCCESS,
+  CLUSTER_PAGE_JOIN_SERVER_REQUEST_ERROR,
+  joinServer,
+);
 
 function* createReplicasetRequestSaga() {
   yield takeLatest(CLUSTER_PAGE_CREATE_REPLICASET_REQUEST, function* load(action) {
@@ -254,8 +190,6 @@ function* createReplicasetRequestSaga() {
       };
 
       yield put({ type: CLUSTER_PAGE_CREATE_REPLICASET_REQUEST_SUCCESS, payload: response, requestPayload });
-
-      yield refreshListsSaga();
     } catch (error) {
       yield put({
         type: CLUSTER_PAGE_CREATE_REPLICASET_REQUEST_ERROR,
@@ -269,81 +203,19 @@ function* createReplicasetRequestSaga() {
   });
 };
 
-function* expelServerRequestSaga() {
-  yield takeLatest(CLUSTER_PAGE_EXPEL_SERVER_REQUEST, function* load(action) {
-    const {
-      payload: requestPayload = {},
-      __payload: {
-        noIndicator,
-        noErrorMessage,
-        successMessage
-      } = {}
-    } = action;
-    const indicator = noIndicator ? null : pageRequestIndicator.run();
+const expelServerRequestSaga = getRequestSaga(
+  CLUSTER_PAGE_EXPEL_SERVER_REQUEST,
+  CLUSTER_PAGE_EXPEL_SERVER_REQUEST_SUCCESS,
+  CLUSTER_PAGE_EXPEL_SERVER_REQUEST_ERROR,
+  expelServer,
+);
 
-    let response;
-    try {
-      response = yield call(expelServer, requestPayload);
-      indicator && indicator.success();
-
-      yield put({
-        type: CLUSTER_PAGE_EXPEL_SERVER_REQUEST_SUCCESS,
-        payload: response,
-        requestPayload,
-        __successMessage: successMessage
-      });
-
-      yield refreshListsSaga();
-    } catch (error) {
-      yield put({
-        type: CLUSTER_PAGE_EXPEL_SERVER_REQUEST_ERROR,
-        error,
-        requestPayload,
-        __errorMessage: !noErrorMessage
-      });
-      indicator && indicator.error();
-      return;
-    }
-  });
-};
-
-function* editReplicasetRequestSaga() {
-  yield takeLatest(CLUSTER_PAGE_REPLICASET_EDIT_REQUEST, function* load(action) {
-    const {
-      payload: requestPayload = {},
-      __payload: {
-        noIndicator,
-        noErrorMessage,
-        successMessage
-      } = {}
-    } = action;
-    const indicator = noIndicator ? null : pageRequestIndicator.run();
-
-    let response;
-    try {
-      response = yield call(editReplicaset, requestPayload);
-      indicator && indicator.success();
-
-      yield put({
-        type: CLUSTER_PAGE_REPLICASET_EDIT_REQUEST_SUCCESS,
-        payload: response,
-        requestPayload,
-        __successMessage: successMessage
-      });
-
-      yield refreshListsSaga();
-    } catch (error) {
-      yield put({
-        type: CLUSTER_PAGE_REPLICASET_EDIT_REQUEST_ERROR,
-        error,
-        requestPayload,
-        __errorMessage: !noErrorMessage
-      });
-      indicator && indicator.error();
-      return;
-    }
-  });
-};
+const editReplicasetRequestSaga = getRequestSaga(
+  CLUSTER_PAGE_REPLICASET_EDIT_REQUEST,
+  CLUSTER_PAGE_REPLICASET_EDIT_REQUEST_SUCCESS,
+  CLUSTER_PAGE_REPLICASET_EDIT_REQUEST_ERROR,
+  editReplicaset,
+);
 
 const uploadConfigRequestSaga = getRequestSaga(
   CLUSTER_PAGE_UPLOAD_CONFIG_REQUEST,
@@ -370,7 +242,21 @@ const updateClusterSelfOnBootstrap = function* () {
         yield delay(2000);
       }
     }
-  })
+  });
+};
+
+const updateListsOnTopologyEdit = function* () {
+  const topologyEditTokens = [
+    CLUSTER_PAGE_BOOTSTRAP_VSHARD_REQUEST_SUCCESS,
+    CLUSTER_PAGE_JOIN_SERVER_REQUEST_SUCCESS,
+    CLUSTER_PAGE_EXPEL_SERVER_REQUEST_SUCCESS,
+    CLUSTER_PAGE_REPLICASET_EDIT_REQUEST_SUCCESS,
+    CLUSTER_PAGE_PROBE_SERVER_REQUEST_SUCCESS
+  ];
+
+  yield takeLatest(topologyEditTokens, function* () {
+    yield refreshListsSaga();
+  });
 }
 
 export const saga = baseSaga(
@@ -385,4 +271,5 @@ export const saga = baseSaga(
   uploadConfigRequestSaga,
   changeFailoverRequestSaga,
   updateClusterSelfOnBootstrap,
+  updateListsOnTopologyEdit
 );


### PR DESCRIPTION
Closes #171 

Refresh replicaset list after topology edit actions:
- bootstrap
- join
- expel
- probe
- replicaset edit

Also add minor eslint rule space-unary-ops