### PR TITLE
Add ability to set vshard options via graphql.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Similar API is implemented in a GraphQL mutation `cluster{edit_topology()}`.
 
+- New GraphQL mutation `cluster { edit_vshard_options }` is suitable for
+  fine-tuning vshard options: `rebalancer_max_receiving`, `collect_lua_garbage`,
+  `sync_timeout`, `collect_bucket_garbage_interval`,
+  `rebalancer_disbalance_threshold`.
+
 ### Changed
 
 - Both bootstrapping from scratch and patching topology in clusterwide config automatically probe

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -73,7 +73,7 @@ end
 
 --- Common `cartridge.cfg` options.
 --
--- Options, which are not listed here (like `roles` and `bucket_count`)
+-- Options, which are not listed here (like `roles`)
 -- can't be modified with argparse and should be configured in code.
 --
 -- @table cluster_opts

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Tue Sep 17 2019 17:25:19 GMT+0300 (Moscow Standard Time)
+# timestamp: Fri Sep 20 2019 19:44:06 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -99,6 +99,7 @@ type Mutation {
 
 """Cluster management"""
 type MutationApicluster {
+  edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
   auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
 
   """Remove user"""
@@ -110,11 +111,11 @@ type MutationApicluster {
   """Edit cluster topology"""
   edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
 
-  """Enable or disable automatic failover. Returns new state."""
-  failover(enabled: Boolean!): Boolean!
-
   """Create a new user"""
   add_user(password: String!, username: String!, fullname: String, email: String): User
+
+  """Enable or disable automatic failover. Returns new state."""
+  failover(enabled: Boolean!): Boolean!
 
   """Disable listed servers by uuid"""
   disable_servers(uuids: [String!]): [Server]
@@ -384,12 +385,33 @@ type UserManagementAPI {
 
 """Group of replicasets sharding the same dataset"""
 type VshardGroup {
+  """
+  The maximum number of buckets that can be received in parallel by a single replica set in the storage group
+  """
+  rebalancer_max_receiving: Int!
+
   """Virtual buckets count in the group"""
   bucket_count: Int!
+
+  """The interval between garbage collector actions, in seconds"""
+  collect_bucket_garbage_interval: Float!
+
+  """Whethe the group is ready to operate"""
+  bootstrapped: Boolean!
+
+  """
+  If set to true, the Lua collectgarbage() function is called periodically
+  """
+  collect_lua_garbage: Boolean!
+
+  """A maximum bucket disbalance threshold, in percent"""
+  rebalancer_disbalance_threshold: Float!
 
   """Group name"""
   name: String!
 
-  """Whethe the group is ready to operate"""
-  bootstrapped: Boolean!
+  """
+  Timeout to wait for synchronization of the old master with replicas before demotion
+  """
+  sync_timeout: Float!
 }

--- a/test/integration/test_multisharding_one.py
+++ b/test/integration/test_multisharding_one.py
@@ -27,6 +27,67 @@ unconfigured = [
     )
 ]
 
+
+def get_vshard_groups(cluster):
+    req = """
+        query {
+            cluster {
+                vshard_groups {
+                    name
+                    bucket_count
+                    bootstrapped
+                    rebalancer_max_receiving
+                    collect_lua_garbage
+                    sync_timeout
+                    collect_bucket_garbage_interval
+                    rebalancer_disbalance_threshold
+                }
+            }
+        }
+        """
+    obj = cluster['router'].graphql(req)
+    assert 'errors' not in obj, obj['errors'][0]['message']
+    return obj['data']['cluster']['vshard_groups']
+
+
+def edit_vshard_group(cluster, check = True, **kwargs):
+    req = """
+        mutation(
+            $rebalancer_max_receiving: Int
+            $group: String!
+            $collect_lua_garbage: Boolean
+            $sync_timeout: Float
+            $collect_bucket_garbage_interval: Float,
+            $rebalancer_disbalance_threshold: Float
+        ) {
+            cluster {
+                edit_vshard_options(
+                    name: $group
+                    rebalancer_max_receiving: $rebalancer_max_receiving
+                    collect_lua_garbage: $collect_lua_garbage
+                    sync_timeout: $sync_timeout
+                    collect_bucket_garbage_interval: $collect_bucket_garbage_interval
+                    rebalancer_disbalance_threshold: $rebalancer_disbalance_threshold
+                ) {
+                    name
+                    bucket_count
+                    bootstrapped
+                    rebalancer_max_receiving
+                    collect_lua_garbage
+                    sync_timeout
+                    collect_bucket_garbage_interval
+                    rebalancer_disbalance_threshold
+                }
+            }
+        }
+    """
+
+    obj = cluster['router'].graphql(req, variables=kwargs)
+    if check:
+        assert 'errors' not in obj, obj['errors'][0]['message']
+    return obj
+
+
 def test_api(cluster):
     req = """
         {
@@ -39,6 +100,11 @@ def test_api(cluster):
                     name
                     bucket_count
                     bootstrapped
+                    rebalancer_max_receiving
+                    collect_lua_garbage
+                    sync_timeout
+                    collect_bucket_garbage_interval
+                    rebalancer_disbalance_threshold
                 }
             }
         }
@@ -52,6 +118,11 @@ def test_api(cluster):
     assert obj['data']['cluster']['vshard_known_groups'] == ['default']
     assert obj['data']['cluster']['vshard_groups'] == [
         {
+            'collect_bucket_garbage_interval': 0.5,
+            'collect_lua_garbage': False,
+            'rebalancer_disbalance_threshold': 1,
+            'rebalancer_max_receiving': 100,
+            'sync_timeout': 1,
             'name': 'default',
             'bucket_count': 3000,
             'bootstrapped': True,
@@ -66,6 +137,11 @@ def test_api(cluster):
     assert obj['data']['cluster']['vshard_known_groups'] == ['default']
     assert obj['data']['cluster']['vshard_groups'] == [
         {
+            'collect_bucket_garbage_interval': 0.5,
+            'collect_lua_garbage': False,
+            'rebalancer_disbalance_threshold': 1,
+            'rebalancer_max_receiving': 100,
+            'sync_timeout': 1,
             'name': 'default',
             'bucket_count': 3000,
             'bootstrapped': False,
@@ -74,7 +150,6 @@ def test_api(cluster):
 
 
 def test_router_role(cluster):
-
     resp = cluster['router'].conn.eval("""
         local vshard = require('vshard')
         local cartridge = require('cartridge')
@@ -93,3 +168,72 @@ def test_router_role(cluster):
         'static': 'aaaaaaaa-aaaa-4000-b000-000000000001',
         'default': 'aaaaaaaa-aaaa-4000-b000-000000000001'
     }
+
+
+def test_set_vshard_options_positive(cluster):
+    assert edit_vshard_group(cluster,
+                             group = "default",
+                             rebalancer_max_receiving = 42,
+                             collect_lua_garbage = True,
+                             sync_timeout = 24,
+                             collect_bucket_garbage_interval = 42.24,
+                             rebalancer_disbalance_threshold = 14
+                             )['data']['cluster']['edit_vshard_options'] == \
+           {
+               'collect_bucket_garbage_interval': 42.24,
+               'collect_lua_garbage': True,
+               'rebalancer_disbalance_threshold': 14,
+               'rebalancer_max_receiving': 42,
+               'sync_timeout': 24,
+               'name': 'default',
+               'bucket_count': 3000,
+               'bootstrapped': True,
+           }
+
+    assert edit_vshard_group(cluster,
+                             group = "default",
+                             rebalancer_max_receiving = None,
+                             sync_timeout = 25,
+                             )['data']['cluster']['edit_vshard_options'] == \
+           {
+               'collect_bucket_garbage_interval': 42.24,
+               'collect_lua_garbage': True,
+               'rebalancer_disbalance_threshold': 14,
+               'rebalancer_max_receiving': 42,
+               'sync_timeout': 25,
+               'name': 'default',
+               'bucket_count': 3000,
+               'bootstrapped': True,
+           }
+
+    assert get_vshard_groups(cluster) == \
+        [
+           {
+               'collect_bucket_garbage_interval': 42.24,
+               'collect_lua_garbage': True,
+               'rebalancer_disbalance_threshold': 14,
+               'rebalancer_max_receiving': 42,
+               'sync_timeout': 25,
+               'name': 'default',
+               'bucket_count': 3000,
+               'bootstrapped': True,
+           }
+        ]
+
+
+def test_set_vshard_options_negative(cluster):
+    obj = edit_vshard_group(cluster, False, group = "undef", rebalancer_max_receiving = 42)
+    assert obj['errors'][0]['message'] == 'vshard-group "undef" doesn\'t exist'
+
+    obj = edit_vshard_group(cluster, False, group = "default", rebalancer_max_receiving = -42)
+    assert obj['errors'][0]['message'] == 'vshard.rebalancer_max_receiving must be positive'
+
+    obj = edit_vshard_group(cluster, False, group = "default", sync_timeout = -24)
+    assert obj['errors'][0]['message'] == 'vshard.sync_timeout must be non-negative'
+
+    obj = edit_vshard_group(cluster, False, group = "default", collect_bucket_garbage_interval = -42.24)
+    assert obj['errors'][0]['message'] == 'vshard.collect_bucket_garbage_interval must be positive'
+
+    obj = edit_vshard_group(cluster, False, group = "default", rebalancer_disbalance_threshold = -14)
+    assert obj['errors'][0]['message'] == \
+           'vshard.rebalancer_disbalance_threshold must be non-negative'

--- a/test/integration/vshardless_test.lua
+++ b/test/integration/vshardless_test.lua
@@ -82,7 +82,10 @@ function g.test_config()
         return cartridge.config_get_readonly('vshard')
     ]])
 
-    t.assert_equals(resp, {bucket_count = 30000, bootstrapped = false})
+    t.assert_equals(resp, {
+        bootstrapped=false,
+        bucket_count=30000
+    })
 
     local resp = server_conn:eval([[
         local cartridge = require('cartridge')

--- a/test/unit/test_vshard_config.lua
+++ b/test/unit/test_vshard_config.lua
@@ -56,7 +56,7 @@ local topology = require('cartridge.topology')
 local vshard_utils = require('cartridge.vshard-utils')
 local test = tap.test('vshard.config')
 
-test:plan(12)
+test:plan(21)
 
 local function check_config(result, raw_new, raw_old)
     local conf_new = raw_new and yaml.decode(raw_new) or {}
@@ -115,6 +115,87 @@ vshard_groups:
   global:
     bucket_count: 200
     bootstrapped: false
+...]])
+
+check_config('vshard_groups["global"].rebalancer_max_receiving must be a number',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    rebalancer_max_receiving: value
+...]])
+
+check_config('vshard_groups["global"].rebalancer_max_receiving must be positive',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    rebalancer_max_receiving: 0
+...]])
+
+check_config('vshard_groups["global"].collect_lua_garbage must be a boolean',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    collect_lua_garbage: value
+...]])
+
+check_config('vshard_groups["global"].sync_timeout must be a number',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    sync_timeout: value
+...]])
+
+check_config('vshard_groups["global"].sync_timeout must be non-negative',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    sync_timeout: -1
+...]])
+
+check_config('vshard_groups["global"].collect_bucket_garbage_interval must be a number',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    collect_bucket_garbage_interval: value
+...]])
+
+check_config('vshard_groups["global"].collect_bucket_garbage_interval must be positive',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    collect_bucket_garbage_interval: 0
+...]])
+
+check_config('vshard_groups["global"].rebalancer_disbalance_threshold must be a number',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    rebalancer_disbalance_threshold: value
+...]])
+
+check_config('vshard_groups["global"].rebalancer_disbalance_threshold must be non-negative',
+[[---
+vshard_groups:
+  global:
+    bucket_count: 200
+    bootstrapped: false
+    rebalancer_disbalance_threshold: -1
 ...]])
 
 check_config('vshard_groups["global"].bootstrapped must be true or false',


### PR DESCRIPTION
The following vshard options may be modified:
* rebalancer_max_receiving
* collect_lua_garbage
* sync_timeout
* collect_bucket_garbage_interval
* rebalancer_disbalance_threshold

The new GraphQL mutation added:
```GraphQL
edit_vshard_options(
    rebalancer_max_receiving: Int,
    collect_bucket_garbage_interval: Float,
    collect_lua_garbage: Boolean,
    sync_timeout: Float,
    name: String!,
    rebalancer_disbalance_threshold: Float
): VshardGroup!
```

Closes #174 