### PR TITLE
Public API for checking http auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refresh replicaset list in UI after topology edit actions: bootstrap, join, expel,
   probe, replicaset edit.
 
+- New Lua API `cartridge.http_authorize_request()` suitable for checking
+  HTTP request headers.
+
+- New Lua API `cartridge.http_render_response()` for generating HTTP
+  response with proper `Set-Cookie` headers.
+
+- New Lua API `cartridge.http_get_username()` to check authorization of
+  active HTTP session.
+
 ### Fixed
 
 - Editing topology with `failover_priority` argument.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -680,6 +680,24 @@ return {
     -- @function rpc_call
     rpc_call = rpc.call,
 
+--- Authentication and authorization.
+-- @section auth
+
+    --- .
+    -- @refer cartridge.auth.authorize_request
+    -- @function http_authorize_request
+    http_authorize_request = auth.authorize_request,
+
+    --- .
+    -- @refer cartridge.auth.render_response
+    -- @function http_render_response
+    http_render_response = auth.render_response,
+
+    --- .
+    -- @refer cartridge.auth.get_session_username
+    -- @function http_get_username
+    http_get_username = auth.get_session_username,
+
 --- Deprecated functions.
 -- @section deprecated
 

--- a/cartridge/auth.lua
+++ b/cartridge/auth.lua
@@ -34,6 +34,7 @@ local ADMIN_USER = {
     fullname = 'Cartridge Administrator'
 }
 
+errors.new_class('RenderHTTPError', {log_on_creation = true})
 local e_check_cookie = errors.new_class('Checking cookie failed')
 local e_check_header = errors.new_class('Checking auth headers failed')
 local e_callback = errors.new_class('Auth callback failed')
@@ -202,7 +203,7 @@ local function hmac(hashfun, blocksize, key, message)
     return hashfun(opad .. hashfun(ipad .. message))
 end
 
-local function create_cookie_headers(uid)
+local function create_cookie(uid)
     checks('string')
     local ts = tostring(fiber.time())
     local key = cluster_cookie.cookie()
@@ -221,12 +222,10 @@ local function create_cookie_headers(uid)
         {nopad = true, nowrap = true, urlsafe = true}
     )
 
-    return {
-        ['set-cookie'] = string.format(
-            'lsid=%s; Max-Age=%d', lsid,
-            get_params().cookie_max_age
-        )
-    }
+    return string.format(
+        'lsid=%s;Max-Age=%d', lsid,
+        get_params().cookie_max_age
+    )
 end
 
 local function get_cookie_uid(raw)
@@ -308,12 +307,13 @@ end
 
 --- Get username for the current HTTP session.
 --
+-- (**Added** in v1.1.0-4)
 -- @function get_session_username
 -- @within Authorizarion
--- @treturn string or nil if no user is logged in
+-- @treturn string|nil
 local function get_session_username()
-    local fiber_storage = fiber.self().storage
-    return fiber_storage['auth_session_username']
+    local http_session = fiber.self().storage['http_session']
+    return http_session and http_session.username
 end
 
 local function login(req)
@@ -325,7 +325,9 @@ local function login(req)
         if password == cluster_cookie.cookie() then
             return {
                 status = 200,
-                headers = create_cookie_headers(username),
+                headers = {
+                    ['set-cookie'] = create_cookie(username),
+                }
             }
         else
             return {
@@ -356,7 +358,9 @@ local function login(req)
     if ok then
         return {
             status = 200,
-            headers = create_cookie_headers(username),
+            headers = {
+                ['set-cookie'] = create_cookie(username),
+            },
         }
     elseif err ~= nil then
         log.error('%s', err)
@@ -372,6 +376,8 @@ local function login(req)
 end
 
 local function logout(_)
+    fiber.self().storage['http_session'] = nil
+
     return {
         status = 200,
         headers = {
@@ -615,42 +621,19 @@ local function remove_user(username)
     end)
 end
 
-local _response_mt = {
-    __index = {
-        finalize = function(self, resp)
-            for k, v in pairs(resp) do
-                if type(self[k]) == 'table'
-                and type(v) == 'table'
-                then
-                    -- merge tables
-                    for tk, tv in pairs(v) do
-                        self[k][tk] = tv
-                    end
-                else
-                    self[k] = v
-                end
-            end
-
-            return self
-        end
-    },
-}
 --- Authorize an HTTP request.
 --
--- Try to get username from cookies or basic HTTP authentication.
+-- Get username from cookies or basic HTTP authentication.
 --
--- @function check_request
+-- (**Added** in v1.1.0-4)
+-- @function authorize_request
 -- @within Authorizarion
--- @param req An HTTP request
+-- @tparam table request
 -- @treturn boolean Access granted
--- @treturn table HTTP response template
-local function check_request(req)
-    local fiber_storage = fiber.self().storage
-    -- clean fiber storage to behave correctly
-    -- when user logouts within keepalive session
-    fiber_storage['auth_session_username'] = nil
-
-    local resp = setmetatable({}, _response_mt)
+local function authorize_request(req)
+    checks('table')
+    local http_session = {}
+    fiber.self().storage['http_session'] = http_session
 
     local auth_cfg = get_params()
     local cookie_raw = req:cookie('lsid')
@@ -666,7 +649,10 @@ local function check_request(req)
             log.error('%s', err)
         end
 
-        local uid, err = e_check_header:pcall(get_basic_auth_uid, req.headers['authorization'])
+        local uid, err = e_check_header:pcall(
+            get_basic_auth_uid,
+            req.headers['authorization']
+        )
         if uid ~= nil then
             username = uid
             break
@@ -683,27 +669,61 @@ local function check_request(req)
     end
 
     if username then
-        fiber_storage['auth_session_username'] = username
+        http_session.username = username
 
         if cookie_ts > 0
         and auth_cfg.cookie_renew_age >= 0
         and fiber.time() - cookie_ts > auth_cfg.cookie_renew_age
         then
-            resp['headers'] = create_cookie_headers(username)
+            http_session.set_cookie = create_cookie(username)
         end
 
-        return true, resp
+        return true
     elseif cookie_raw then
-        resp['headers'] = {
-            ['set-cookie'] = 'lsid=""; Max-Age=0'
-        }
+        http_session.set_cookie = 'lsid="";Max-Age=0'
     end
 
     if not auth_cfg.enabled then
-        return true, resp
+        return true
     else
-        return false, resp
+        return false
     end
+end
+
+--- Render HTTP response.
+--
+-- Inject set-cookie headers into response in order to renew or reset
+-- the cookie.
+--
+-- (**Added** in v1.1.0-4)
+-- @function render_response
+-- @within Authorizarion
+-- @tparam table response
+-- @treturn table The same response with cookies injected
+local function render_response(resp)
+    checks('table')
+    local http_session = fiber.self().storage['http_session']
+    if http_session == nil then
+        local err = errors.new('RenderHTTPError', 2,
+            "Can't render response because request wasn't authorized"
+        )
+        return nil, err
+    end
+
+    if http_session.set_cookie ~= nil then
+        if resp.headers == nil then
+            resp.headers = {}
+        end
+
+        if resp.headers['set-cookie'] == nil then
+            resp.headers['set-cookie'] = http_session.set_cookie
+        else
+            resp.headers['set-cookie'] = resp.headers['set-cookie'] ..
+                ',' .. http_session.set_cookie
+        end
+    end
+
+    return resp
 end
 
 --- Initialize the authentication HTTP API.
@@ -778,8 +798,7 @@ return {
     list_users = list_users,
     remove_user = remove_user,
 
-    -- check_session = check_session,
-    check_request = check_request,
-    -- invalidate_session = invalidate_session,
+    authorize_request = authorize_request,
+    render_response = render_response,
     get_session_username = get_session_username,
 }


### PR DESCRIPTION
New Lua API `cartridge.http_authorize_request()` suitable for checking
  HTTP request headers.

New Lua API `cartridge.http_render_response()` for generating HTTP
  response with proper `Set-Cookie` headers.

New Lua API `cartridge.http_get_username()` to check authorization of
  active HTTP session.

Close #219

