### PR TITLE
Test joining two instances to existing replicaset

### DIFF
--- a/cartridge/bootstrap.lua
+++ b/cartridge/bootstrap.lua
@@ -17,6 +17,7 @@ local confapplier = require('cartridge.confapplier')
 local vshard_utils = require('cartridge.vshard-utils')
 local cluster_cookie = require('cartridge.cluster-cookie')
 
+errors.new_class('BoxError', {log_on_creation = true})
 local e_bootstrap = errors.new_class('Bootstrap failed')
 local e_conflicting_groups = errors.new_class('Conflicting vshard_groups option')
 vars:new('box_opts', nil)
@@ -58,14 +59,20 @@ local function init_box(box_opts)
         end
 
         log.info('Granting replication permissions to %q...', username)
-        box.schema.user.grant(
+
+        errors.pcall('BoxError',
+            box.schema.user.grant,
             username,
             'replication',
             nil, nil, {if_not_exists = true}
         )
 
+
         log.info('Setting password for user %q ...', username)
-        box.schema.user.passwd(username, password)
+        errors.pcall('BoxError',
+            box.schema.user.passwd,
+            username, password
+        )
     end
 
     membership.set_payload('uuid', box.info.uuid)

--- a/test/integration/multijoin_create_test.lua
+++ b/test/integration/multijoin_create_test.lua
@@ -1,6 +1,6 @@
 local fio = require('fio')
 local t = require('luatest')
-local g = t.group('multijoin')
+local g = t.group('multijoin_create')
 
 local test_helper = require('test.helper')
 

--- a/test/integration/multijoin_existing_test.lua
+++ b/test/integration/multijoin_existing_test.lua
@@ -1,0 +1,94 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('multijoin_existing')
+
+local test_helper = require('test.helper')
+
+local helpers = require('cartridge.test-helpers')
+
+local cluster
+local servers
+
+g.before_all = function()
+    cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = test_helper.server_command,
+        replicasets = {
+            {
+                alias = 'firstling',
+                uuid = helpers.uuid('a'),
+                roles = {},
+                servers = {{
+                    http_port = 8081,
+                    advertise_port = 13301,
+                    instance_uuid = helpers.uuid('a', 'a', 1)
+                }},
+            }
+        },
+    })
+
+    servers = {}
+    for i = 2, 3 do
+        local http_port = 8080 + i
+        local advertise_port = 13300 + i
+        local alias = string.format('twin%d', i)
+
+        servers[i] = helpers.Server:new({
+            alias = alias,
+            command = test_helper.server_command,
+            workdir = fio.pathjoin(cluster.datadir, alias),
+            cluster_cookie = cluster.cookie,
+            http_port = http_port,
+            advertise_port = advertise_port,
+            replicaset_uuid = helpers.uuid('a'),
+            instance_uuid = helpers.uuid('a', 'a', i),
+        })
+    end
+
+    for _, server in pairs(servers) do
+        server:start()
+    end
+    cluster:start()
+end
+
+g.after_all = function()
+    for _, server in pairs(servers or {}) do
+        server:stop()
+    end
+    cluster:stop()
+
+    fio.rmtree(cluster.datadir)
+    cluster = nil
+    servers = nil
+end
+
+g.test_patch_topology = function()
+    t.skip("Fails due to https://github.com/tarantool/tarantool/issues/4527")
+
+    cluster.main_server:graphql({
+        query = [[mutation(
+            $replicasets: [EditReplicasetInput!]
+        ){
+            cluster {
+                edit_topology(replicasets:$replicasets){}
+            }
+        }]],
+        variables = {
+            replicasets = {{
+                uuid = cluster.main_server.replicaset_uuid,
+                join_servers = {{
+                    uri = servers[2].advertise_uri,
+                    uuid = servers[2].instance_uuid,
+                }, {
+                    uri = servers[3].advertise_uri,
+                    uuid = servers[3].instance_uuid,
+                }}
+            }}
+        }
+    })
+
+    cluster:retrying({}, function() servers[2]:connect_net_box() end)
+    cluster:retrying({}, function() servers[3]:connect_net_box() end)
+    cluster:wait_until_healthy()
+end


### PR DESCRIPTION
This PR is related to #228. It protects a pair of functions with pcall. Original bug isn't solved yet, but covered with test (failing, thus skipped)