### PR TITLE
New pool.map_call to gather netbox call results

### DIFF
--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -17,7 +17,8 @@ local cluster_cookie = require('cartridge.cluster-cookie')
 
 vars:new('locks', {})
 vars:new('connections', {})
-local e_connect = errors.new_class('Pool connect failed')
+errors.new_class('NetboxConnectError')
+errors.new_class('NetboxMapCallError')
 
 --- Enrich URI with credentials.
 -- Suitable to connect other cluster instances.
@@ -27,10 +28,16 @@ local e_connect = errors.new_class('Pool connect failed')
 -- @tparam string uri `host:port`
 -- @treturn string `username:password@host:port`
 local function format_uri(uri)
-    local uri = uri_lib.parse(uri)
+    local parts = uri_lib.parse(uri)
+    if parts == nil then
+        return nil, errors.new(
+            'FormatURIError',
+            'Invalid URI %q', uri
+        )
+    end
     return uri_lib.format({
-        host = uri.host,
-        service = uri.service,
+        host = parts.host,
+        service = parts.service,
         login = cluster_cookie.username(),
         password = cluster_cookie.cookie()
     }, true)
@@ -40,7 +47,12 @@ local function _connect(uri, options)
     local conn, err = vars.connections[uri]
 
     if conn == nil or not conn:is_connected() then
-        conn, err = e_connect:pcall(netbox.connect, format_uri(uri), options)
+        local _uri, _err = format_uri(uri)
+        if _uri == nil then
+            return nil, _err
+        end
+
+        conn, err = netbox.connect(_uri, options)
     end
 
     if not conn then
@@ -49,7 +61,9 @@ local function _connect(uri, options)
 
     vars.connections[uri] = conn
     if not conn:is_connected() then
-        err = e_connect:new('%q: %s', uri, conn.error)
+        err = errors.new('NetboxConnectError',
+            '%q: %s', uri, conn.error
+        )
         return nil, err
     end
     return conn
@@ -69,13 +83,82 @@ local function connect(uri, options)
         fiber.sleep(0)
     end
     vars.locks[uri] = true
-    local conn, err = e_connect:pcall(_connect, uri, options)
+    local conn, err = errors.pcall('NetboxConnectError', _connect, uri, options)
     vars.locks[uri] = false
 
     return conn, err
 end
 
+local function _gather_netbox_call(ret_map, uri, fn_name, args, opts)
+    local conn, err = connect(uri)
+    if conn == nil then
+        ret_map[uri] = {nil, err}
+        return
+    end
+
+    ret_map[uri] = {errors.netbox_call(conn, fn_name, args, opts)}
+    return
+end
+
+--- Perform a remote call to multiple URIs and map results.
+--
+-- (**Added** in v1.1.0-12)
+-- @function map_call
+-- @local
+--
+-- @tparam string fn_name
+-- @tparam ?table args
+-- @tparam[opt] table opts
+-- @tparam {string,...} opts.uri_list
+--   array of URIs for performing remote call
+-- @tparam ?number opts.timeout
+--   passed to `net.box` `conn:call` options
+--
+-- @treturn {URI=table,...}
+--   Call results mapping for every URI.
+--   Any errors are mapped as `[URI] = {nil, err}`
+local function map_call(fn_name, args, opts)
+    checks('string', '?table', {
+        uri_list = 'table',
+        timeout = '?', -- for net.box.call
+    })
+
+    local i = 0
+    for _, _ in pairs(opts.uri_list) do
+        i = i + 1
+        if type(opts.uri_list[i]) ~= 'string' then
+            error('bad argument opts.uri_list' ..
+                ' to ' .. (debug.getinfo(1, 'nl').name or 'map_call') ..
+                ' (contiguous array of strings expected)', 2
+            )
+        end
+    end
+
+    local ret_map = {}
+    local fibers = {}
+    for _, uri in pairs(opts.uri_list) do
+        local fiber = fiber.new(
+            _gather_netbox_call,
+            ret_map, uri, fn_name, args,
+            {timeout = opts.timeout}
+        )
+        fiber:name('netbox_call_map')
+        fiber:set_joinable(true)
+        fibers[uri] = fiber
+    end
+
+    for _, uri in pairs(opts.uri_list) do
+        local ok, err = fibers[uri]:join()
+        if not ok then
+            ret_map[uri] = {nil, errors.new('NetboxMapCallError', err)}
+        end
+    end
+
+    return ret_map
+end
+
 return {
     connect = connect,
     format_uri = format_uri,
+    map_call = map_call,
 }

--- a/test/integration/pool_map_call_test.lua
+++ b/test/integration/pool_map_call_test.lua
@@ -1,0 +1,188 @@
+#!/usr/bin/env tarantool
+
+local log = require('log')
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('pool_map_call')
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+local pool = require('cartridge.pool')
+local cluster_cookie = require('cartridge.cluster-cookie')
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = test_helper.server_command,
+        use_vshard = false,
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                roles = {},
+                servers = {
+                    {
+                        alias = 'main',
+                        http_port = 8081,
+                        net_box_port = 13301,
+                        instance_uuid = helpers.uuid('a', 'a', 1)
+                    }
+                },
+            },
+        },
+    })
+
+    g.cluster:start()
+    g.cluster.main_server.net_box:eval([[
+        local remote_control = require('cartridge.remote-control')
+        local cluster_cookie = require('cartridge.cluster-cookie')
+        remote_control.start('0.0.0.0', 13302, {
+            username = cluster_cookie.username(),
+            password = cluster_cookie.cookie(),
+        })
+
+        local socket = require('socket')
+        local tcp_discard = socket.tcp_server('0.0.0.0', 13309, {
+            name = 'tcp_discard',
+            handler = function()
+                -- Discard all data, never reply
+            end,
+        })
+    ]])
+
+    cluster_cookie.init(g.cluster.datadir)
+    cluster_cookie.set_cookie(g.cluster.cookie)
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+local function assert_ret_equals(map, uri, expected)
+    local ok, err = pcall(function()
+        t.assert_not_nil(map[uri])
+        t.assert_is_nil(map[uri][1])
+        t.assert_is_table(map[uri][2])
+        t.assert_equals(
+            map[uri][2].class_name .. ': ' .. map[uri][2].err,
+            expected)
+    end)
+
+    if not ok then
+        error(string.format("Unexpected result for %q:\n%s", uri, err), 2)
+    end
+end
+
+function g.test_timeout()
+    local map = pool.map_call('package.loaded.fiber.sleep', {1}, {
+        uri_list = {'localhost:13301'},
+        timeout = 0,
+    })
+
+    assert_ret_equals(map, 'localhost:13301',
+        'Net.box call failed: Timeout exceeded'
+    )
+end
+
+
+function g.test_parallel()
+    local srv = g.cluster.main_server
+    srv.net_box:eval([[
+        local fiber = require('fiber')
+        _G._test_channel = fiber.channel(0)
+
+        function _G.communicate()
+            if not _G._test_channel:has_readers() then
+                return _G._test_channel:get()
+            else
+                return _G._test_channel:put(true)
+            end
+        end
+    ]])
+
+    -- Test that `map_call` makes requests in parallel:
+    --   The first one blocks with channel:get()
+    --   The second one does channel:put()
+    -- Otherwise, if requests are sequential,
+    --   The first fiber isn't unlocked and returns timeout error
+
+    local map = pool.map_call('_G.communicate', nil, {
+        uri_list = {
+            'localhost:13301',
+            'localhost:13302',
+        },
+        timeout = 1,
+    })
+
+    t.assert_equals(map, {
+        ['localhost:13301'] = {true},
+        ['localhost:13302'] = {true},
+    })
+end
+
+
+function g.test_errors()
+    t.assert_error_msg_contains(
+        'bad argument opts.uri_list to fizzbuzz ' ..
+        '(table expected, got nil)',
+        function()
+            local fizzbuzz = pool.map_call
+            fizzbuzz('math.floor', nil)
+        end
+    )
+
+    t.assert_error_msg_contains(
+        'bad argument opts.uri_list to map_call ' ..
+        '(contiguous array of strings expected)',
+        function()
+            pool.map_call('math.floor', nil, {uri_list = {3301}})
+        end
+    )
+
+    t.assert_error_msg_contains(
+        'bad argument opts.uri_list to map_call ' ..
+        '(contiguous array of strings expected)',
+        pool.map_call, 'math.floor', nil, {uri_list = {'a', nil, 'b'}}
+    )
+end
+
+function g.test_negative()
+    local srv = g.cluster.main_server
+    srv.net_box:eval([[
+        function _G.raise_error()
+            error('Too long WAL write')
+        end
+    ]])
+
+    local map = pool.map_call('_G.raise_error', nil, {
+        uri_list = {
+            '!@#$%^&*()',      -- invalid uri
+            'localhost:13301', -- box.listen
+            'localhost:13302', -- remote-control
+            'localhost:13309', -- discard protocol
+            'localhost:9',     -- connection refused
+        },
+        timeout = 1,
+    })
+
+    assert_ret_equals(map, '!@#$%^&*()',      'FormatURIError: Invalid URI "!@#$%^&*()"')
+    assert_ret_equals(map, 'localhost:13301', 'Net.box call failed: eval:2: Too long WAL write')
+    assert_ret_equals(map, 'localhost:13302', 'Net.box call failed: eval:2: Too long WAL write')
+    assert_ret_equals(map, 'localhost:13309', 'NetboxConnectError: "localhost:13309": Invalid greeting')
+    assert_ret_equals(map, 'localhost:9',     'NetboxConnectError: "localhost:9": Connection refused')
+end
+
+function g.test_positive()
+    local map = pool.map_call('math.pow', {2, 4}, {
+        uri_list = {
+            'localhost:13301',
+            'localhost:13302',
+        }
+    })
+
+    t.assert_equals(map, {
+        ['localhost:13301'] = {16},
+        ['localhost:13302'] = {16},
+    })
+end


### PR DESCRIPTION
```lua

--- Perform a remote call to multiple URIs and map results.
--
-- @function map_call
--
-- @tparam string fn_name
-- @tparam ?table args
-- @tparam[opt] table opts
-- @tparam {string,...} opts.uri_list
--   array of URIs for performing remote call
-- @tparam ?number opts.timeout
--   passed to `net.box` `conn:call` options
--
-- @treturn {URI=value,...}
--   Call results mapping for every URI.
-- @treturn nil|{URI=error,...}
--   Errors mapping for every URI.

local function map_call(fn_name, args, opts)
    checks('string', '?table', {
        uri_list = 'table',
        timeout = '?', -- for net.box.call
    })
end
```
