### PR TITLE
Fix graphql.validate.getParentFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Leader flag in server details modal
 
+- Graphql `validate.getParentField()` doesn't fail and returns nil, if there 
+  are no fields in parent object
+
 ## [1.1.0] - 2019-09-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Leader flag in server details modal
 
-- Graphql `validate.getParentField()` doesn't fail and returns nil, if there 
-  are no fields in parent object
+- Human-readable error for invalid GrqphQL queries:
+  `Field "x" is not defined on type "String"`
 
 ## [1.1.0] - 2019-09-24
 

--- a/cartridge/graphql/validate.lua
+++ b/cartridge/graphql/validate.lua
@@ -15,7 +15,7 @@ local function getParentField(context, name, count)
     parent = parent.ofType
   end
 
-  return parent.fields[name]
+  return parent.fields and parent.fields[name]
 end
 
 local visitors = {

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -96,3 +96,13 @@ g.test_resolver_error = function()
         server:graphql({query = '{ test(arg:"TEST") }'})
     end)
 end
+
+function g.test_fail_validate()
+    t.assert_error_msg_contains('Field "x" is not defined on type "String"', function()
+        cluster.main_server:graphql({
+            query = [[
+                { cluster { self { uri { x } } } }
+            ]]
+        })
+    end)
+end


### PR DESCRIPTION
Now it doesn't fail and and returns nil, if there are no fields in object