### PR TITLE
Make edit_topology graphql args optional

### DIFF
--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -116,8 +116,8 @@ local gql_type_edit_replicaset_input = gql_types.inputObject {
     name = 'EditReplicasetInput',
     description = 'Parameters for editing a replicaset',
     fields = {
-        uuid = gql_types.string.nonNull,
-        alias = gql_types.string.nonNull,
+        uuid = gql_types.string,
+        alias = gql_types.string,
         roles = gql_types.list(gql_types.string.nonNull),
         join_servers = gql_types.list(
             gql_types.inputObject({

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Sep 20 2019 19:44:06 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Oct 07 2019 19:29:45 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -29,12 +29,12 @@ type Apicluster {
 
 """Parameters for editing a replicaset"""
 input EditReplicasetInput {
-  uuid: String!
+  uuid: String
   weight: Float
   vshard_group: String
   join_servers: [JoinServerInput]
   roles: [String!]
-  alias: String!
+  alias: String
   all_rw: Boolean
   failover_priority: [String!]
 }


### PR DESCRIPTION
Uuid is optional when mutation is used to create new replicaset
