### PR TITLE
Fix test-helpers.cluster main server selection

### DIFF
--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -686,7 +686,6 @@ local function edit_topology(args)
         servers = '?table',
     })
 
-    require('log').info('%s', require('yaml').encode(args))
     local args = table.deepcopy(args)
     local topology_cfg = confapplier.get_deepcopy('topology')
     if topology_cfg == nil then


### PR DESCRIPTION
Сluster behavior was changed to default (obvious): the first server
of a cluster becomes cluster.main_server.