### PR TITLE
Restart instances read-only 

### DIFF
--- a/cartridge/bootstrap.lua
+++ b/cartridge/bootstrap.lua
@@ -364,6 +364,9 @@ local function bootstrap_from_snapshot()
     box_opts.wal_dir = vars.boot_opts.workdir
     box_opts.memtx_dir = vars.boot_opts.workdir
     box_opts.vinyl_dir = vars.boot_opts.workdir
+    if box_opts.read_only == nil then
+        box_opts.read_only = true
+    end
 
     membership.set_payload('warning', 'Recovering from snapshot')
     init_box(box_opts)


### PR DESCRIPTION
 When recovering snapshot, instances are started in read-only mode.
It still can be overriden by `argparse` (command line arguments or environment
variables)

Close #253 