### PR TITLE
API for setting and querying DDL 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use for frontend part single point of configuration HTTP handlers.
   As example: you can add your own client HTTP middleware for auth.
 
+- Built-in DDL schema management. Schema is a part of clusterwide
+  configuration. It's applied to every instance in cluster.
+
 ### Changed
 
 - WebUI now uses `edit_topology` mutation instead of deprecated ones.

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,6 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
+    'ddl == 0.0.2-1',
     'http == 1.0.5-1',
     'checks == 3.0.1-1',
     'lulpeg == 0.1.2-1',
@@ -42,6 +43,7 @@ build = {
             ['cartridge.utils'] = 'cartridge/utils.lua',
             ['cartridge.roles'] = 'cartridge/roles.lua',
             ['cartridge.webui'] = 'cartridge/webui.lua',
+            ['cartridge.webui.api-ddl'] = 'cartridge/webui/api-ddl.lua',
             ['cartridge.webui.api-auth'] = 'cartridge/webui/api-auth.lua',
             ['cartridge.webui.api-config'] = 'cartridge/webui/api-config.lua',
             ['cartridge.webui.api-vshard'] = 'cartridge/webui/api-vshard.lua',
@@ -58,6 +60,7 @@ build = {
             ['cartridge.cluster-cookie'] = 'cartridge/cluster-cookie.lua',
             ['cartridge.service-registry'] = 'cartridge/service-registry.lua',
             ['cartridge.label-utils'] = 'cartridge/label-utils.lua',
+            ['cartridge.ddl-manager'] = 'cartridge/ddl-manager.lua',
 
             ['cartridge.vshard-utils'] = 'cartridge/vshard-utils.lua',
             ['cartridge.roles.vshard-router'] = 'cartridge/roles/vshard-router.lua',

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -523,6 +523,27 @@ return {
     -- @function is_healthy
     is_healthy = topology.cluster_is_healthy,
 
+--- Global functions.
+-- @section globals
+
+    --- Get clusterwide DDL schema.
+    --
+    -- (**Added** in v1.2.0-27)
+    -- @function _G.cartridge_get_schema
+    -- @treturn[1] boolean true
+    -- @treturn[2] nil
+    -- @treturn[2] table Error description
+
+    --- Apply clusterwide DDL schema.
+    --
+    -- (**Added** in v1.2.0-27)
+    -- @function _G.cartridge_set_schema
+    -- @param table schema
+    -- @treturn[1] boolean true
+    -- @treturn[2] nil
+    -- @treturn[2] table Error description
+
+
 --- Cluster administration.
 -- @refer cartridge.admin
 -- @section admin

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -513,6 +513,9 @@ local function cfg(opts, box_opts)
     return true
 end
 
+_G.cartridge_get_schema = twophase.get_schema
+_G.cartridge_set_schema = twophase.set_schema
+
 return {
     VERSION = VERSION,
 
@@ -526,23 +529,13 @@ return {
 --- Global functions.
 -- @section globals
 
-    --- Get clusterwide DDL schema.
-    --
-    -- (**Added** in v1.2.0-27)
+    --- .
+    -- @refer cartridge.twophase.get_schema
     -- @function _G.cartridge_get_schema
-    -- @treturn[1] boolean true
-    -- @treturn[2] nil
-    -- @treturn[2] table Error description
 
-    --- Apply clusterwide DDL schema.
-    --
-    -- (**Added** in v1.2.0-27)
+    --- .
+    -- @refer cartridge.twophase.set_schema
     -- @function _G.cartridge_set_schema
-    -- @param table schema
-    -- @treturn[1] boolean true
-    -- @treturn[2] nil
-    -- @treturn[2] table Error description
-
 
 --- Cluster administration.
 -- @refer cartridge.admin

--- a/cartridge/ddl-manager.lua
+++ b/cartridge/ddl-manager.lua
@@ -1,0 +1,133 @@
+#!/usr/bin/env tarantool
+
+local log = require('log')
+local ddl = require('ddl')
+local yaml = require('yaml')
+local checks = require('checks')
+local errors = require('errors')
+
+local topology = require('cartridge.topology')
+
+local CheckSchemaError = errors.new_class('CheckSchemaError')
+
+local _section_name = 'schema.yml'
+
+local function _from_yaml(schema_yml)
+    if schema_yml == nil then
+        return {}
+    elseif type(schema_yml) ~= 'string' then
+        local err = CheckSchemaError:new(
+            'Section %q must be a string, got %s',
+            _section_name, type(schema_yml)
+        )
+        return nil, err
+    end
+
+    local ok, schema_tbl = pcall(yaml.decode, schema_yml)
+    if not ok then
+        local err = CheckSchemaError:new(
+            'Invalid YAML: %s',
+            schema_tbl
+        )
+        return nil, err
+    end
+
+    if type(schema_tbl) ~= 'table' then
+        local err = CheckSchemaError:new(
+            'Schema must be a table, got %s',
+            type(schema_tbl)
+        )
+        return nil, err
+    end
+    return schema_tbl
+end
+
+local function apply_config(conf, opts)
+    checks('table', {is_master = 'boolean'})
+
+    if not opts.is_master then
+        return
+    end
+
+    if conf[_section_name] == nil then
+        return
+    end
+
+    local schema, err = _from_yaml(conf[_section_name])
+    if schema == nil then
+        return nil, err
+    end
+
+    local ok, err = ddl.set_schema(schema)
+    if not ok then
+        return nil, err
+    end
+
+    return true
+end
+
+local function validate_config(conf_new, conf_old)
+    checks('table', 'table')
+
+    local schema_new, err = _from_yaml(conf_new[_section_name])
+    if schema_new == nil then
+        return nil, err
+    end
+    local schema_old, err = _from_yaml(conf_old[_section_name])
+    if schema_old == nil then
+        return nil, CheckSchemaError:new(
+            'Error parsing old schema: %s',
+            err.err
+        )
+    end
+
+    if next(schema_new) ~= nil then
+        if type(box.cfg) == 'function' then
+            -- This case is almost impossible today
+            -- because we don't have public API that
+            -- can inject schema into bootstrap_from_scratch
+            log.warn(
+                "Schema validation is impossible because" ..
+                " instance isn't bootstrapped yet." ..
+                " Set it at your own risk"
+            )
+            goto skip
+        end
+
+        local active_masters = topology.get_active_masters()
+        if active_masters[box.info.cluster.uuid] ~= box.info.uuid then
+            log.info(
+                "Schema validation skipped because" ..
+                " instance isn't a leader"
+            )
+            goto skip
+        end
+
+        local ok, err = ddl.check_schema(schema_new)
+        if not ok then
+            return nil, CheckSchemaError:new(err)
+        end
+
+        ::skip::
+    end
+
+    for space_name, _ in pairs(schema_old.spaces or {}) do
+        if schema_new.spaces == nil
+        or schema_new.spaces[space_name] == nil
+        then
+            return nil, CheckSchemaError:new(
+                "Missing space %q in schema," ..
+                " removing spaces is forbidden",
+                space_name
+            )
+        end
+    end
+
+    return true
+end
+
+return {
+    _section_name = _section_name,
+    validate_config = validate_config,
+    apply_config = apply_config,
+}

--- a/cartridge/ddl-manager.lua
+++ b/cartridge/ddl-manager.lua
@@ -9,6 +9,7 @@ local errors = require('errors')
 local topology = require('cartridge.topology')
 
 local CheckSchemaError = errors.new_class('CheckSchemaError')
+local DecodeYamlError = errors.new_class('DecodeYamlError')
 
 local _section_name = 'schema.yml'
 
@@ -23,12 +24,8 @@ local function _from_yaml(schema_yml)
         return nil, err
     end
 
-    local ok, schema_tbl = pcall(yaml.decode, schema_yml)
-    if not ok then
-        local err = CheckSchemaError:new(
-            'Invalid YAML: %s',
-            schema_tbl
-        )
+    local schema_tbl, err = DecodeYamlError:pcall(yaml.decode, schema_yml)
+    if schema_tbl == nil then
         return nil, err
     end
 

--- a/cartridge/webui.lua
+++ b/cartridge/webui.lua
@@ -10,6 +10,7 @@ local api_auth = require('cartridge.webui.api-auth')
 local api_config = require('cartridge.webui.api-config')
 local api_vshard = require('cartridge.webui.api-vshard')
 local api_topology = require('cartridge.webui.api-topology')
+local api_ddl = require('cartridge.webui.api-ddl')
 
 local function init(httpd)
     front.init(httpd)
@@ -24,6 +25,8 @@ local function init(httpd)
 
     -- Config upload/download
     api_config.init(httpd)
+
+    api_ddl.init(graphql)
 
     -- Vshard operations
     api_vshard.init(graphql)

--- a/cartridge/webui/api-ddl.lua
+++ b/cartridge/webui/api-ddl.lua
@@ -1,0 +1,154 @@
+#!/usr/bin/env tarantool
+
+local yaml = require('yaml')
+local errors = require('errors')
+local netbox = require('net.box')
+
+local pool = require('cartridge.pool')
+local topology = require('cartridge.topology')
+local twophase = require('cartridge.twophase')
+local confapplier = require('cartridge.confapplier')
+local ddl_manager = require('cartridge.ddl-manager')
+local gql_types = require('cartridge.graphql.types')
+local module_name = 'cartridge.webui.api-ddl'
+
+local GetSchemaError = errors.new_class('GetSchemaError')
+local CheckSchemaError = errors.new_class('CheckSchemaError')
+local _section_name = ddl_manager._section_name
+
+local gql_type_schema = gql_types.object({
+    name = 'DDLSchema',
+    description = 'The schema',
+    fields = {
+        as_yaml = gql_types.string.nonNull,
+    }
+})
+
+local gql_type_check_result = gql_types.object({
+    name = 'DDLCheckResult',
+    description = 'Result of schema validation',
+    fields = {
+        error = {
+            kind = gql_types.string,
+            description = 'Null if validation passed,' ..
+                ' error message otherwise',
+        },
+    }
+})
+
+local function graphql_get_schema()
+    if confapplier.get_readonly() == nil then
+        return nil, GetSchemaError:new(
+            "Cluster isn't bootstaraped yet"
+        )
+    end
+    local schema_yml = confapplier.get_readonly(_section_name)
+    if schema_yml == nil then
+        schema_yml = yaml.encode({spaces = {}})
+    end
+
+    return {
+        as_yaml = schema_yml,
+    }
+end
+
+local function graphql_set_schema(_, args)
+    local patch = {[_section_name] = args.as_yaml}
+    local ok, err = twophase.patch_clusterwide(patch)
+    if not ok then
+        return nil, err
+    end
+
+    return graphql_get_schema()
+end
+
+local function graphql_check_schema(_, args)
+    local topology_cfg = confapplier.get_readonly('topology')
+    if topology_cfg == nil then
+        return nil, CheckSchemaError:new(
+            "Cluster isn't bootstrapped yet"
+        )
+    end
+
+    local conf_new = {[_section_name] = args.as_yaml}
+    local conf_old = {[_section_name] = confapplier.get_readonly(_section_name)}
+
+    local active_leaders = topology.get_active_masters()
+    local conn, err
+    if active_leaders[box.info.cluster.uuid] == box.info.uuid then
+        conn = netbox.self
+    else
+        for _, leader_uuid in pairs(active_leaders) do
+            local uri = topology_cfg.servers[leader_uuid].uri
+            conn, err = pool.connect(uri)
+            if conn ~= nil then
+                break
+            end
+        end
+    end
+
+    if conn == nil then
+        return nil, err
+    end
+
+    local ret, err = errors.netbox_eval(conn,
+        [[
+            local ddl_manager = require('cartridge.ddl-manager')
+            local ok, err = ddl_manager.validate_config(...)
+            if ok then
+                return { error = box.NULL }
+            else
+                return { error = err.err }
+            end
+        ]],
+        {conf_new, conf_old}
+    )
+
+    if ret == nil then
+        return nil, err
+    end
+
+    return ret
+end
+
+local function init(graphql)
+    graphql.add_callback({
+        prefix = 'cluster',
+        name = 'schema',
+        doc = 'Clusterwide DDL schema',
+        args = {},
+        kind = gql_type_schema.nonNull,
+        callback = module_name .. '.graphql_get_schema',
+    })
+
+    graphql.add_mutation({
+        prefix = 'cluster',
+        name = 'schema',
+        doc = 'Applies DDL schema on cluster',
+        args = {
+            as_yaml = gql_types.string.nonNull,
+        },
+        kind = gql_type_schema.nonNull,
+        callback = module_name .. '.graphql_set_schema',
+    })
+
+    graphql.add_mutation({
+        prefix = 'cluster',
+        name = 'check_schema',
+        doc = 'Checks that schema can be applied on cluster',
+        args = {
+            as_yaml = gql_types.string.nonNull,
+        },
+        kind = gql_type_check_result.nonNull,
+        callback = module_name .. '.graphql_check_schema',
+    })
+
+    return true
+end
+
+return {
+    init = init,
+    graphql_get_schema = graphql_get_schema,
+    graphql_set_schema = graphql_set_schema,
+    graphql_check_schema = graphql_check_schema,
+}

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,16 +1,19 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Tue Oct 15 2019 17:35:02 GMT+0300 (Moscow Standard Time)
+# timestamp: Wed Nov 20 2019 00:48:15 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
   """Get current server"""
   self: ServerShortInfo
 
+  """Clusterwide DDL schema"""
+  schema: DDLSchema!
+
   """Get current failover state."""
   failover: Boolean!
 
-  """Virtual buckets count in cluster"""
-  vshard_bucket_count: Int!
+  """Whether it is reasonble to call bootstrap_vshard mutation"""
+  can_bootstrap_vshard: Boolean!
 
   """List authorized users"""
   users(username: String): [User!]
@@ -23,8 +26,19 @@ type Apicluster {
   vshard_groups: [VshardGroup!]!
   auth_params: UserManagementAPI!
 
-  """Whether it is reasonble to call bootstrap_vshard mutation"""
-  can_bootstrap_vshard: Boolean!
+  """Virtual buckets count in cluster"""
+  vshard_bucket_count: Int!
+}
+
+"""Result of schema validation"""
+type DDLCheckResult {
+  """Null if validation passed, error message otherwise"""
+  error: String
+}
+
+"""The schema"""
+type DDLSchema {
+  as_yaml: String!
 }
 
 """Parameters for editing a replicaset"""
@@ -99,7 +113,14 @@ type Mutation {
 
 """Cluster management"""
 type MutationApicluster {
-  edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
+  """Applies DDL schema on cluster"""
+  schema(as_yaml: String!): DDLSchema!
+
+  """Enable or disable automatic failover. Returns new state."""
+  failover(enabled: Boolean!): Boolean!
+
+  """Checks that schema can be applied on cluster"""
+  check_schema(as_yaml: String!): DDLCheckResult!
   auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
 
   """Remove user"""
@@ -113,9 +134,7 @@ type MutationApicluster {
 
   """Create a new user"""
   add_user(password: String!, username: String!, fullname: String, email: String): User
-
-  """Enable or disable automatic failover. Returns new state."""
-  failover(enabled: Boolean!): Boolean!
+  edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
 
   """Disable listed servers by uuid"""
   disable_servers(uuids: [String!]): [Server]

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -123,22 +123,23 @@ function g.test_luaapi()
     end
 
     log.info('Applying valid schema...')
+    local schema = _schema .. "# P.S. It's fun\n"
 
     t.assert_equals(
-        call('cartridge_set_schema', {yaml.decode(_schema)}),
-        true
+        call('cartridge_set_schema', {schema}),
+        schema
     )
 
     log.info('Reapplying valid schema...')
 
     t.assert_equals(
-        call('cartridge_set_schema', {yaml.decode(_schema)}),
-        true
+        call('cartridge_set_schema', {schema}),
+        schema
     )
 
     t.assert_equals(
         call('cartridge_get_schema'),
-        yaml.decode(_schema)
+        schema
     )
 
     for _, srv in pairs(g.cluster.servers) do
@@ -153,14 +154,14 @@ function g.test_luaapi()
     log.info('Patching with invalid schema...')
 
     t.assert_equals(
-        {call('cartridge_set_schema', {{spaces = {}}})},
+        {call('cartridge_set_schema', {'{"spaces":{}}'})},
         {box.NULL, 'Missing space "test_space" in schema,' ..
         ' removing spaces is forbidden'}
     )
 
     t.assert_equals(
-        yaml.decode(_get_schema(g.cluster.main_server).as_yaml),
-        yaml.decode(_schema)
+        _get_schema(g.cluster.main_server).as_yaml,
+        schema
     )
 end
 

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -206,7 +206,7 @@ function g.test_graphql_errors()
         )
     end
 
-    _test('][', 'Invalid YAML: unexpected END event')
+    _test('][', 'unexpected END event')
     _test(1000, 'Section "schema.yml" must be a string, got number')
     _test('42', 'Schema must be a table, got number')
     _test('spaces: false',

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -1,0 +1,224 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('ddl')
+local log = require('log')
+local yaml = require('yaml')
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+local function _get_schema(server)
+    local ret = server:graphql({query = [[{
+        cluster {
+            schema {
+                as_yaml
+            }
+        }
+    }]]})
+
+    return ret.data.cluster.schema
+end
+
+local function _set_schema(server, as_yaml)
+    local ret = server:graphql({query = [[
+        mutation($yaml: String!) {
+            cluster {
+                schema(as_yaml: $yaml) {
+                    as_yaml
+                }
+            }
+        }]],
+        variables = {yaml = as_yaml}
+    })
+
+    return ret.data.cluster.schema
+end
+
+local function _check_schema(server, as_yaml)
+    local ret = server:graphql({query = [[
+        mutation($yaml: String!) {
+            cluster {
+                check_schema(as_yaml: $yaml) {
+                    error
+                }
+            }
+        }]],
+        variables = {yaml = as_yaml}
+    })
+
+    return ret.data.cluster.check_schema
+end
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = test_helper.server_command,
+        use_vshard = true,
+        cookie = 'test-cluster-cookie',
+
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                roles = {'vshard-router'},
+                servers = {
+                    {
+                        alias = 'router',
+                        instance_uuid = helpers.uuid('a', 'a', 1),
+                        advertise_port = 33001,
+                        http_port = 8081
+                    }
+                }
+            }, {
+                uuid = helpers.uuid('b'),
+                roles = {'vshard-storage'},
+                servers = {
+                    {
+                        alias = 'storage-1',
+                        instance_uuid = helpers.uuid('b', 'b', 1),
+                        advertise_port = 33002,
+                        http_port = 8082
+                    }, {
+                        alias = 'storage-2',
+                        instance_uuid = helpers.uuid('b', 'b', 2),
+                        advertise_port = 33004,
+                        http_port = 8084
+                    }
+                }
+            }
+        }
+    })
+    g.cluster:start()
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+local _schema = [[
+spaces:
+  test_space:
+    engine: memtx
+    is_local: false
+    temporary: false
+    format:
+    - name: x
+      type: unsigned
+      is_nullable: false
+    indexes:
+    - name: pk
+      type: TREE
+      unique: true
+      parts:
+      - path: x
+        is_nullable: false
+        type: unsigned
+]]
+
+--------------------------------------------------------------------------------
+
+function g.test_luaapi()
+    local function call(...)
+        return g.cluster.main_server.net_box:call(...)
+    end
+
+    log.info('Applying valid schema...')
+
+    t.assert_equals(
+        call('cartridge_set_schema', {yaml.decode(_schema)}),
+        true
+    )
+
+    log.info('Reapplying valid schema...')
+
+    t.assert_equals(
+        call('cartridge_set_schema', {yaml.decode(_schema)}),
+        true
+    )
+
+    t.assert_equals(
+        call('cartridge_get_schema'),
+        yaml.decode(_schema)
+    )
+
+    for _, srv in pairs(g.cluster.servers) do
+        t.assert_equals(
+            {[srv.alias] = srv.net_box:eval([[
+                return require('ddl').get_schema().spaces.test_space
+            ]])},
+            {[srv.alias] = yaml.decode(_schema).spaces.test_space}
+        )
+    end
+
+    log.info('Patching with invalid schema...')
+
+    t.assert_equals(
+        {call('cartridge_set_schema', {{spaces = {}}})},
+        {box.NULL, 'Missing space "test_space" in schema,' ..
+        ' removing spaces is forbidden'}
+    )
+
+    t.assert_equals(
+        yaml.decode(_get_schema(g.cluster.main_server).as_yaml),
+        yaml.decode(_schema)
+    )
+end
+
+function g.test_formatting_preserved()
+    -- cartridge should preserve yaml formatting
+    local server = g.cluster.main_server
+    local schema = _schema .. '# I hope my comments are preserved\n'
+
+    t.assert_equals(_check_schema(server, schema), {error = box.NULL})
+    t.assert_equals(_set_schema(server, schema), {as_yaml = schema})
+    t.assert_equals(_get_schema(server), {as_yaml = schema})
+end
+
+function g.test_replicas()
+    -- check_schema should work on read-only replicas
+
+    for _, srv in pairs(g.cluster.servers) do
+        t.assert_equals(
+            {[srv.alias] = _check_schema(srv, _schema)},
+            {[srv.alias] = {error = box.NULL}}
+        )
+
+        t.assert_equals(
+            {[srv.alias] = _check_schema(srv, '---\n...')},
+            {[srv.alias] = {error = 'Schema must be a table, got string'}}
+        )
+    end
+end
+
+function g.test_graphql_errors()
+    local server = g.cluster.main_server
+    _set_schema(server, _schema)
+
+    local function _test(schema, expected_error)
+        t.assert_equals(
+            _check_schema(server, schema),
+            {error = expected_error}
+        )
+        t.assert_error_msg_contains(
+            expected_error,
+            _set_schema, server, schema
+        )
+    end
+
+    _test('][', 'Invalid YAML: unexpected END event')
+    _test(1000, 'Section "schema.yml" must be a string, got number')
+    _test('42', 'Schema must be a table, got number')
+    _test('spaces: false',
+        'Bad argument #1 to ddl.check_schema' ..
+        ' invalid schema.spaces (table expected, got boolean)'
+    )
+    _test('spaces: {}',
+        'Missing space "test_space" in schema,' ..
+        ' removing spaces is forbidden'
+    )
+    _test(_schema:gsub('memtx', 'vinyl'),
+        'Incompatible schema: space["test_space"]' ..
+        ' //engine (expected memtx, got vinyl)'
+    )
+end
+

--- a/test/integration/hidden_roles_test.lua
+++ b/test/integration/hidden_roles_test.lua
@@ -1,6 +1,6 @@
 local fio = require('fio')
 local t = require('luatest')
-local g = t.group('roles_test')
+local g = t.group('hidden_roles_test')
 
 local test_helper = require('test.helper')
 


### PR DESCRIPTION
DDL [schema](https://github.com/tarantool/ddl/blob/dev/README.md) as a rendered YAML string is stored as a section in clusterwide config (with the section name `schema.yml`). Being a part of clusterwide config, it's updated with two-phase commit.

Schema managements doesn't work before the cluster was bootstrapped.

### DDL manager

This patch introduces new module - ddl manager. It's used for config validation and applying in the manner other roles do.

Validation stage calls `ddl.check_schema()` (which checks space existence and checks creation of dummy space). Additionally, validation stage should check that no spaces were removed (in the future it'll be the responsibility of migrations). 

Apply phase calls `ddl.set_schema()` and creates spaces. To avoid replication conflicts schema validation and application are run on leaders only.

### GraphQL API

Cartridge provides GraphQL API for managing the schema:

```graphql
query get_schema {
  cluster {
    schema {
      as_yaml # get yaml representation of the schema
      # accessing spaces one by one may be implemented later, but not now
    }
  }
}
```

```graphql
mutation set_schema($yaml: String!) {
  cluster {
    schema(as_yaml: $yaml) {
      as_yaml # returns new schema
      # return type of mutation must the same graphql type as of get_schema query
    }
  }
}
```

```graphql
mutation check_schema($yaml: String!) {
  cluster {
    check_schema(as_yaml: $yaml) {
      error # null if OK, message string otherwise.
      # other fields e.g. line and column may be added later
      # if we find the way to calculate it
    }
  }
}
```

To support checking schema on read-only nodes it's executed remotely using `netbox` `eval`.

### HTTP API

Cartridge doesn't provide dedicated HTTP methods for the schema management, but user can access it through the clusterwide config - HTTP `/admin/config` [GET](https://github.com/tarantool/cartridge/blob/df444c93d533a82387a999080c83838648de4810/cartridge/webui/api-config.lua#L40) and [PUT](https://github.com/tarantool/cartridge/blob/df444c93d533a82387a999080c83838648de4810/cartridge/webui/api-config.lua#L69) methods.

### Lua API

Cartridge exports two ***global*** Lua functions:

* `_G.cartridge_get_schema()` - retrieves schema from the clusterwide config (the same yaml string)
* `_G.cartridge_set_schema(schema_yml)` - set schema, triggering `patch_clusterwide`. Returns the same schema set.

### Example clusterwide config

```yaml
schema: |
  ---
  spaces:
    A: {"format": ..., "indexes": ...}
    B: ...
  ...
```

Schema specification is described [here](https://github.com/tarantool/ddl/blob/dev/README.md)

Close #312