### PR TITLE
Return empty table instead error in get candidates function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update `vshard` dependency to 0.1.13.
 
-- Now `cartridge.rpc_get_candidates()` returns empty table instead error,
-  if there are no candidates to present.
+- `cartridge.rpc_get_candidates()` doesn't return error "No remotes with
+  role available" anymore, empty table is returned instead.
+  **(incompatible change)**
 
 ## [1.2.0] - 2019-10-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update `vshard` dependency to 0.1.13.
 
+- Now `cartridge.rpc_get_candidates()` returns empty table instead error,
+  if there are no candidates to present.
+
 ## [1.2.0] - 2019-10-21
 
 ### Added

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -63,8 +63,6 @@ end
 --   (added in v1.1.0-11, default: **true**)
 --
 -- @treturn[1] {string,...} URIs
--- @treturn[2] nil
--- @treturn[2] table Error description
 local function get_candidates(role_name, opts)
     opts = opts or {}
     if opts.healthy_only == nil then

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -96,9 +96,6 @@ local function get_candidates(role_name, opts)
         end
     end
 
-    if next(candidates) == nil then
-        return nil, RemoteCallError:new('No remotes with role %q available', role_name)
-    end
     return candidates
 end
 
@@ -122,9 +119,9 @@ local function get_connection(role_name, opts)
         leader_only = '?boolean',
     })
 
-    local candidates, err = get_candidates(role_name, {leader_only = opts.leader_only})
-    if not candidates then
-        return nil, err
+    local candidates = get_candidates(role_name, {leader_only = opts.leader_only})
+    if next(candidates) == nil then
+        return nil, RemoteCallError:new('No remotes with role %q available', role_name)
     end
 
     local prefer_local = opts.prefer_local

--- a/test/unit/test_rpc.lua
+++ b/test/unit/test_rpc.lua
@@ -114,7 +114,7 @@ test:diag('all alive')
 
 test_candidates('invalid-role',
     draft, {'invalid-role'},
-    nil
+    {}
 )
 
 test_candidates('-leader',
@@ -148,7 +148,7 @@ test_candidates('+leader -healthy',
 
 test_candidates('+leader +healthy',
     draft, {'target-role', {leader_only = true}},
-    nil
+    {}
 )
 
 -------------------------------------------------------------------------------
@@ -238,7 +238,7 @@ test_candidates('+leader -healthy',
 
 test_candidates('+leader +healthy',
     draft, {'target-role', {leader_only = true}},
-    nil
+    {}
 )
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Before the patch get candidates function return error,
if there are no available candidates for selected role.
But the lack of candidates not always mean an error.
Let's return an empty table in this case.

Closes #325 