### PR TITLE
Remove cartridge.bootstrap function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Automatically choose default vshard group in create and edit replicaset modals
+- Automatically choose default vshard group in create and edit
+  replicaset modals.
 
-- Use for frontend part single point of configuration HTTP handlers. As example: you can add your own client HTTP middleware for auth.
+- Use for frontend part single point of configuration HTTP handlers.
+  As example: you can add your own client HTTP middleware for auth.
 
 ### Changed
 
@@ -22,7 +24,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   role available" anymore, empty table is returned instead.
   **(incompatible change)**
 
-- Don't show Users page and move auth switcher to cluster page when only `implements_check_password = true`
+- Hide users page in WebUI when auth backend implements no user management
+  functions. Enable auth switcher is displayed on main cluster page in
+  this case.
+
+### Removed
+
+- Function `cartridge.bootstrap`. Use `admin_edit_topology` interad.
+  **(incompatible change)**
 
 ### Fixed
 
@@ -141,8 +150,10 @@ GraphQL API:
   all instances in the replicaset as `read_only = false`.
   It can be managed with both GraphQL and Lua API `edit_replicaset`.
 
-- Remote Control server - a partial replacement for the `box.cfg({listen})`, independent on `box.cfg`.
-  The server is only to be used internally for bootstrapping new instances.
+- Remote Control server - a replacement for the `box.cfg({listen})`,
+  with limited functionality, independent on `box.cfg`.
+  The server is only to be used internally for bootstrapping new
+  instances.
 
 - New module `argparse` for gathering configuration options from
   command-line arguments, environment variables, and configuration files.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -513,49 +513,10 @@ local function cfg(opts, box_opts)
     return true
 end
 
---- Bootstrap a new cluster.
---
--- It is bootstrapped with the only (current) instance.
--- Later, you can join other instances using `cartridge.admin`.
---
--- @function bootstrap
--- @local
--- @tparam {string,...} roles
---   roles to be enabled on the current instance
--- @tparam table uuids
--- @tparam ?string uuids.instance_uuid
---   bootstrap current instance with specified uuid
--- @tparam ?string uuids.replicaset_uuid
---   assign replicaset uuid to the current instance
--- @tparam {[string]=string,...} labels
---   labels for the current instance
--- @tparam string vshard_group
---   which vshard storage group to join to
---   (for multi-group configuration only)
-local function bootstrap_from_scratch(roles, uuids, labels, vshard_group)
-    checks('?table', {
-        instance_uuid = '?uuid_str',
-        replicaset_uuid = '?uuid_str',
-        },
-        '?table',
-        '?string'
-    )
-
-    return admin.join_server({
-        uri = membership.myself().uri,
-        instance_uuid = uuids and uuids.instance_uuid,
-        replicaset_uuid = uuids and uuids.replicaset_uuid,
-        roles = roles,
-        labels = labels,
-        vshard_group = vshard_group,
-    })
-end
-
 return {
     VERSION = VERSION,
 
     cfg = cfg,
-    bootstrap = bootstrap_from_scratch,
 
     --- .
     -- @refer cartridge.topology.cluster_is_healthy


### PR DESCRIPTION
We decided some time ago that it's useless and its argument are defective.
Instead we offer using `edit_topology` API. It's suitable for bootstrap too.