### PR TITLE
Lint everything including tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 What has been done? Why? What problem is being solved?
 
-I did'n forget about
+I didn't forget about
 
 - [ ] Tests
 - [ ] Changelog

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,38 +1,13 @@
 redefined = false
+include_files = {
+    '*.lua',
+    'test/**/*.lua',
+    'cartridge/**/*.lua',
+    '*.rockspec',
+    '.luacheckrc',
+}
 exclude_files = {
+    '.rocks',
     'cartridge/graphql.lua',
     'cartridge/graphql/*.lua',
-    'webui/build/bundle.lua',
-}
-new_read_globals = {
-    'box',
-    '_TARANTOOL',
-    'tonumber64',
-    os = {
-        fields = {
-            'environ',
-        }
-    },
-    string = {
-        fields = {
-            'split',
-        },
-    },
-    table = {
-        fields = {
-            'maxn',
-            'copy',
-            'new',
-            'clear',
-            'move',
-            'foreach',
-            'sort',
-            'remove',
-            'foreachi',
-            'deepcopy',
-            'getn',
-            'concat',
-            'insert',
-        },
-    },
 }

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -496,7 +496,7 @@ local function cfg(opts, box_opts)
 
     -- Emulate support for NOTIFY_SOCKET in old tarantool.
     -- NOTIFY_SOCKET is fully supported in >= 2.2.2
-    local tnt_version = _TARANTOOL:split('.')
+    local tnt_version = string.split(_TARANTOOL, '.')
     local tnt_major = tonumber(tnt_version[1])
     local tnt_minor = tonumber(tnt_version[2])
     local tnt_patch = tonumber(tnt_version[3]:split('-')[1])

--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -271,7 +271,7 @@ local function communicate(s)
 end
 
 local function rc_handle(s)
-    local version = _TARANTOOL:match("^([%d%.]+)") or '???'
+    local version = string.match(_TARANTOOL, "^([%d%.]+)") or '???'
     local salt = digest.urandom(32)
 
     local greeting = string.format(

--- a/run-test.sh
+++ b/run-test.sh
@@ -2,11 +2,12 @@
 
 set -e
 
+# lint
+.rocks/bin/luacheck .
+
+# run tests
 ./taptest.lua
 .rocks/bin/luatest -v
-
-# lint
-.rocks/bin/luacheck cartridge-scm-1.rockspec
 
 # collect coverage
 # .rocks/bin/luacov-console ./cluster

--- a/taptest.lua
+++ b/taptest.lua
@@ -2,17 +2,6 @@
 
 local fio = require('fio')
 
-function merge(t1, t2)
-    for k, v in pairs(t2) do
-        if (type(v) == "table") and (type(t1[k] or false) == "table") then
-            merge(t1[k], t2[k])
-        else
-            t1[k] = v
-        end
-    end
-    return t1
-end
-
 local function find_tests(dir)
     local files = fio.listdir(dir)
     local res = {}

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,5 +1,4 @@
 local fio = require('fio')
-local t = require('luatest')
 
 local helper = {}
 

--- a/test/integration/multiboot_test.lua
+++ b/test/integration/multiboot_test.lua
@@ -1,5 +1,4 @@
 local fio = require('fio')
-local log = require('log')
 local t = require('luatest')
 local g = t.group('multiboot')
 

--- a/test/unit/test_errors.lua
+++ b/test/unit/test_errors.lua
@@ -7,7 +7,6 @@ if not pcall(require, 'cartridge.front-bundle') then
     end
 end
 
-local log = require('log')
 local tap = require('tap')
 local socket = require('socket')
 local cartridge = require('cartridge')
@@ -18,7 +17,7 @@ local test = tap.test('cartridge.cfg')
 test:plan(12)
 
 local function check_error(expected_error, fn, ...)
-    local ok, err = fn(...)
+    local _, err = fn(...)
     if err == nil then
         test:fail(expected_error)
         return
@@ -62,7 +61,7 @@ check_error('Invalid advertise_uri ":1111"',
 )
 
 local _sock = socket('AF_INET', 'SOCK_DGRAM', 'udp')
-local ok = _sock:bind('0.0.0.0', 33001)
+assert(_sock:bind('0.0.0.0', 33001), nil)
 check_error('Socket bind error: Address already in use',
     cartridge.cfg, {
         workdir = './dev',
@@ -71,7 +70,7 @@ check_error('Socket bind error: Address already in use',
     }
 )
 _sock:close()
-_sock = nil
+_sock = nil -- luacheck: no unused
 
 check_error('Can not ping myself: ping was not sent',
     cartridge.cfg, {

--- a/test/unit/test_labels.lua
+++ b/test/unit/test_labels.lua
@@ -7,7 +7,7 @@ local e_label_config = errors.new_class("Label configuration error")
 test:plan(16)
 
 test.throws = function(self, expected_err, f, ...)
-    local ok, err = f(...)
+    local _, err = f(...)
     self:is(err.class_name, expected_err.name)
 end
 

--- a/test/unit/test_roledeps.lua
+++ b/test/unit/test_roledeps.lua
@@ -10,7 +10,7 @@ local test = tap.test('cluster.register_role')
 test:plan(17)
 
 local function check_error(expected_error, fn, ...)
-    local ok, err = fn(...)
+    local _, err = fn(...)
     for _, l in pairs(string.split(tostring(err), '\n')) do
         test:diag('%s', l)
     end

--- a/test/unit/test_topology.lua
+++ b/test/unit/test_topology.lua
@@ -578,7 +578,7 @@ check_config('replicasets[bbbbbbbb-0000-4000-b000-000000000001]'..
   conf_old_with_weight:format(1)
 )
 
-function vshard.storage.buckets_count()
+function _G.vshard.storage.buckets_count()
     return 1
 end
 
@@ -594,7 +594,7 @@ check_config('replicasets[bbbbbbbb-0000-4000-b000-000000000001]'..
   conf_old_with_weight:format(0)
 )
 
-function vshard.storage.buckets_count()
+function _G.vshard.storage.buckets_count()
     return 0
 end
 

--- a/test/unit/test_vshard_config.lua
+++ b/test/unit/test_vshard_config.lua
@@ -1,7 +1,5 @@
 #!/usr/bin/env tarantool
 
-local log = require('log')
-
 local members = {
     ['localhost:3301'] = {
         uri = 'localhost:3301',
@@ -33,7 +31,7 @@ package.loaded['membership'] = {
     get_member = function(uri)
         return members[uri]
     end,
-    myself = function(uri)
+    myself = function()
         return members['localhost:3301']
     end,
 }
@@ -44,7 +42,7 @@ package.loaded['cartridge.pool'] = {
     end,
 }
 
-vshard = {
+_G.vshard = {
     storage = {
         buckets_count = function() end,
     }
@@ -52,7 +50,6 @@ vshard = {
 
 local tap = require('tap')
 local yaml = require('yaml')
-local topology = require('cartridge.topology')
 local vshard_utils = require('cartridge.vshard-utils')
 local test = tap.test('vshard.config')
 


### PR DESCRIPTION
Also rely on luacheck built-in configuration instead of `new_read_globals`

I didn't forget about

- [x] Tests
- [x] Changelog (not needed)
- [x] Documentation (not needed)
