### PR TITLE
Don't cache remote-control connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Add deduplication for frontend notifications. No more a lot of same messages.
+- Add deduplication for WebUI notifications: no more spam.
+
+- Race condition when creating working directory.
+
+- Don't cache remote-control connection so that `pool.connect` switches
+  to the full-featured iproto as soon as it's up.
 
 ## [1.2.0] - 2019-10-21
 

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -46,7 +46,10 @@ end
 local function _connect(uri, options)
     local conn, err = vars.connections[uri]
 
-    if conn == nil or not conn:is_connected() then
+    if conn == nil
+    or not conn:is_connected()
+    or conn.peer_uuid == "00000000-0000-0000-0000-000000000000"
+    then
         local _uri, _err = format_uri(uri)
         if _uri == nil then
             return nil, _err


### PR DESCRIPTION
Pool module implements connection caching. But we don't want for remote-control connection to be cached, because its functionality is limited. Conn pool should reconnect to full-featured iproto as soon as possible.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (not needed)

