### PR TITLE
Restrict graphql operation in BootError state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Failover isn't triggered on `suspect` instance state anymore
   **(incompatible change)**
 
+- Functions `admin.get_servers`, `get_replicasets` and similar GraphQL
+  queries now return an error if the instance handling the request is in
+  state `InitError` or `BootError`.
+
 ### Removed
 
 - Function `cartridge.bootstrap` is removed. Use `admin_edit_topology`

--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -99,8 +99,9 @@ local function get_server_info(members, uuid, uri)
 end
 
 local function get_topology()
-    local _, err = confapplier.get_state()
-    if err ~= nil then
+    local state, err = confapplier.get_state()
+    -- OperationError doesn't influence observing topology
+    if state == 'InitError' or state == 'BootError' then
         return nil, err
     end
 
@@ -397,10 +398,12 @@ local function get_self()
 end
 
 --- Get servers list.
--- Optionally filter out the server with given uuid.
+-- Optionally filter out the server with the given uuid.
 -- @function get_servers
 -- @tparam[opt] string uuid
--- @treturn {ServerInfo,...}
+-- @treturn[1] {ServerInfo,...}
+-- @treturn[2] nil
+-- @treturn[2] table Error description
 local function get_servers(uuid)
     checks('?string')
 
@@ -424,7 +427,9 @@ end
 -- Optionally filter out the replicaset with given uuid.
 -- @function get_replicasets
 -- @tparam[opt] string uuid
--- @treturn {ReplicasetInfo,...}
+-- @treturn[1] {ReplicasetInfo,...}
+-- @treturn[2] nil
+-- @treturn[2] table Error description
 local function get_replicasets(uuid)
     checks('?string')
 

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -172,7 +172,10 @@ local gql_type_role = gql_types.object {
 }
 
 local function get_servers(_, args)
-    local servers = admin.get_servers(args.uuid)
+    local servers, err = admin.get_servers(args.uuid)
+    if servers == nil then
+        return nil, err
+    end
     for _, server in pairs(servers) do
         server.labels = convert_labels_to_graphql(server.labels)
     end
@@ -180,7 +183,10 @@ local function get_servers(_, args)
 end
 
 local function get_replicasets(_, args)
-    local replicasets = admin.get_replicasets(args.uuid)
+    local replicasets, err = admin.get_replicasets(args.uuid)
+    if replicasets == nil then
+        return nil, err
+    end
     for _, replicaset in pairs(replicasets) do
         for _, server in pairs(replicaset.servers) do
             server.labels = convert_labels_to_graphql(server.labels)


### PR DESCRIPTION
While instance is in BootError (or InitError) state it can't provide any
reliable information about cluster topology.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

