### PR TITLE
Tests for moved auth switcher

### DIFF
--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -121,7 +121,8 @@ function g.test_users()
         ',cypress/integration/edit-user.spec.js' ..
         ',cypress/integration/remove-user.spec.js' ..
         ',cypress/integration/server-details.spec.js' ..
-        ',cypress/integration/login-and-logout.spec.js'
+        ',cypress/integration/login-and-logout.spec.js'..
+        ',cypress/integration/auth-switcher-not-moved.spec.js'
     )
     t.assert_equals(code, 0)
 end

--- a/test/cypress/withoutUsersPage_test.lua
+++ b/test/cypress/withoutUsersPage_test.lua
@@ -5,7 +5,7 @@ local g = t.group('withoutUsersPage')
 local test_helper = require('test.helper')
 local helpers = require('cartridge.test-helpers')
 
-g.before_all = function()
+g.setup = function()
 	g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = fio.pathjoin(test_helper.root, 'test', 'integration', 'srv_woauth.lua'),

--- a/test/cypress/withoutUsersPage_test.lua
+++ b/test/cypress/withoutUsersPage_test.lua
@@ -1,0 +1,52 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('cypress_basic')
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+g.setup = function()
+	g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = fio.pathjoin(test_helper.root, 'test', 'integration', 'srv_woauth.lua'),
+        use_vshard = false,
+        cookie = 'test-cluster-cookie',
+
+        replicasets = {
+            {
+                alias = 'router1-do-not-use-me',
+                uuid = helpers.uuid('a'),
+                roles = {},
+                servers = {
+                    {
+                        alias = 'router',
+                        instance_uuid = helpers.uuid('a', 'a', 1),
+                    }
+                }
+            }
+        }
+    })
+
+    g.cluster:start()
+
+end
+
+g.teardown = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+local function cypress_run(spec)
+    local code = os.execute(
+        "cd webui && npx cypress run --spec " ..
+        fio.pathjoin('cypress/integration', spec)
+    )
+    if code ~= 0 then
+        error('Cypress spec "' .. spec .. '" failed', 2)
+    end
+    t.assert_equals(code, 0)
+end
+
+function g.test_auth_switcher_moved()
+    cypress_run('auth-switcher-moved.spec.js')
+end

--- a/test/cypress/withoutUsersPage_test.lua
+++ b/test/cypress/withoutUsersPage_test.lua
@@ -1,11 +1,11 @@
 local fio = require('fio')
 local t = require('luatest')
-local g = t.group('cypress_basic')
+local g = t.group('withoutUsersPage')
 
 local test_helper = require('test.helper')
 local helpers = require('cartridge.test-helpers')
 
-g.setup = function()
+g.before_all = function()
 	g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = fio.pathjoin(test_helper.root, 'test', 'integration', 'srv_woauth.lua'),

--- a/webui/cypress/integration/auth-switcher-moved.spec.js
+++ b/webui/cypress/integration/auth-switcher-moved.spec.js
@@ -1,0 +1,27 @@
+describe('Auth switcher moved', () => {
+
+  it('Login and Enable Auth', () => {
+    cy.visit(Cypress.config('baseUrl'));
+    cy.get('.meta-test__LoginBtn').click({ force: true });
+    cy.get('.meta-test__LoginForm input[name="username"]')
+      .type('admin');
+    cy.get('.meta-test__LoginForm input[name="password"]')
+      .type('test-cluster-cookie');
+    cy.get('.meta-test__LoginFormBtn').click();
+    cy.get('.meta-test__AuthToggle').click();
+    cy.get('.meta-test__ConfirmModal').contains('Enable').click({ force: true });
+  })
+
+    it('Login and Disable Auth', () => {
+      cy.visit(Cypress.config('baseUrl'));
+      cy.get('input[name="username"]')
+        .type('admin');
+      cy.get('input[name="password"]')
+        .type('test-cluster-cookie');
+      cy.get('.meta-test__LoginFormBtn').click({ force: true });
+      cy.get('.meta-test__AuthToggle').click();
+      cy.get('.meta-test__ConfirmModal').contains('Disable').click({ force: true });
+     //try to open Users Page: fail
+      cy.get('a[href="/admin/cluster/users"]').should('not.exist');
+    })
+});

--- a/webui/cypress/integration/auth-switcher-not-moved.spec.js
+++ b/webui/cypress/integration/auth-switcher-not-moved.spec.js
@@ -1,0 +1,12 @@
+describe('Auth switcher not moved', () => {
+
+    it('Auth switcher not moved', () => {
+      cy.visit(Cypress.config('baseUrl'));
+      //try to find Auth switcher on Users Page: success
+      cy.get('a[href="/admin/cluster/users"]').click();
+      cy.get('.meta-test__AuthToggle').should('exist');
+      //try to find Auth switcher on Cluster Page: fail
+      cy.get('a[href="/admin/cluster/dashboard"]').click();
+      cy.get('.meta-test__AuthToggle').should('not.exist');
+    })
+});

--- a/webui/cypress/integration/text-inputs-tests.spec.js
+++ b/webui/cypress/integration/text-inputs-tests.spec.js
@@ -59,8 +59,7 @@ describe('Replicaset configuration & Bootstrap Vshard', () => {
     cy.get('.ProbeServerModal input[name="uri"]')
       .type('{selectall}localhost:13301{enter}');
     cy.get('.ProbeServerModal').contains('Probe " " failed: parse error').should('not.exist');
-
-    cy.get('.ProbeServerModal').should('not.exist');
+    cy.get('#root').contains('Probe is OK');
   })
 
   it('3. Edit replicaset dialog',() => {


### PR DESCRIPTION
Add tests on "Enable auth" switcher position.

Follow-up for #334, related to #330.
