### PR TITLE
Implement multi-file clusterwide config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Enhance WebUI modals scrolling.
 
-- Scroll behavior in Modals
+- Clusterwide configuration is now represented with a file tree.
+  All sections that were tables are saved to separate `.yml` files.
+  Compatibility with the old-style configuration is preserved.
+  Accessing unmarshalled sections with `get_readonly/deepcopy` methods
+  is provided without `.yml` extension as earlier.
+
+- Update `ddl` dependency to 1.0.0.
 
 ### Removed
 

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,7 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
-    'ddl == 0.0.2-1',
+    'ddl == 1.0.0-1',
     'http == 1.0.5-1',
     'checks == 3.0.1-1',
     'lulpeg == 0.1.2-1',

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -2,14 +2,64 @@
 
 --- The abstraction, representing clusterwide configuration.
 --
+-- Clusterwide configuration is more than just a lua table. It's an
+-- object in terms of OOP paradigm.
+--
+-- On filesystem clusterwide config is represented by a file tree.
+--
+-- In Lua it's represented as an object which holds both plaintext files
+-- content and unmarshalled lua tables. Unmarshalling is implicit and
+-- performed automatically for the sections with `.yml` file extension.
+--
+-- To access plaintext content there are two functions: `get_plaintext`
+-- and `set_plaintext`.
+--
+-- Unmarshalled lua tables are accessed without `.yml` extension by
+-- `get_readonly` and `get_deepcopy`. Plaintext serves for
+-- accessing unmarshalled representation of corresponding sections.
+--
+-- To avoid ambiguity it's prohibited to keep both `<FILENAME>` and
+-- `<FILENAME>.yml` in the configuration. An attempt to do so would
+-- result in `return nil, err` from `new()` and `load()`, and an attempt
+-- to call `get_readonly/deepcopy` would raise an error.
+-- Nevertheless one can keep any other extensions because they aren't
+-- unmarshalled implicitly.
+--
 -- (**Added** in v1.2.0-17)
+--
+-- @usage
+-- tarantool> cfg = ClusterwideConfig.new({
+--          >     -- two files
+--          >     ['forex.yml'] = '{EURRUB_TOM: 70.33, USDRUB_TOM: 63.18}',
+--          >     ['text'] = 'Lorem ipsum dolor sit amet',
+--          > })
+-- ---
+-- ...
+--
+-- tarantool> cfg:get_plaintext()
+-- ---
+-- - text: Lorem ipsum dolor sit amet
+--   forex.yml: '{EURRUB_TOM: 70.33, USDRUB_TOM: 63.18}'
+-- ...
+--
+-- tarantool> cfg:get_readonly()
+-- ---
+-- - forex.yml: '{EURRUB_TOM: 70.33, USDRUB_TOM: 63.18}'
+--   forex:
+--     EURRUB_TOM: 70.33
+--     USDRUB_TOM: 63.18
+--   text: Lorem ipsum dolor sit amet
+-- ...
 --
 -- @module cartridge.clusterwide-config
 -- @local
 
+local log = require('log')
 local fio = require('fio')
 local yaml = require('yaml').new()
 local checks = require('checks')
+local digest = require('digest')
+local errno = require('errno')
 local errors = require('errors')
 
 local utils = require('cartridge.utils')
@@ -20,7 +70,77 @@ yaml.cfg({
 })
 
 local LoadConfigError = errors.new_class('LoadConfigError')
-local DecodeYamlError = errors.new_class('DecodeYamlError')
+local SaveConfigError = errors.new_class('SaveConfigError')
+local RemoveConfigError = errors.new_class('RemoveConfigError')
+
+local function update_luatables(clusterwide_config)
+    checks('ClusterwideConfig')
+
+    local root = {}
+    for section, content in pairs(clusterwide_config._plaintext) do
+        root[section] = content
+        if clusterwide_config._plaintext[section .. '.yml'] ~= nil then
+            local err = LoadConfigError:new(
+                'Ambiguous sections %q and %q',
+                section, section .. '.yml'
+            )
+            return nil, err
+        end
+
+        local fname = string.match(section, "^(.+)%.yml$")
+        if not fname or fio.basename(fname) == '' then
+            goto continue
+        end
+
+        local ok, data = pcall(yaml.decode, content)
+        if not ok then
+            local err = LoadConfigError:new(
+                'Error parsing section %q: %s',
+                section, data
+            )
+            return nil, err
+        end
+        root[fname] = data
+
+        ::continue::
+    end
+
+    local function _load(tbl)
+        local err = nil
+        for k, v in pairs(tbl) do
+            if type(v) ~= 'table' then
+                goto continue
+            end
+
+            if v['__file'] then
+                tbl[k] = clusterwide_config._plaintext[v['__file']]
+                if not tbl[k] then
+                    return nil, LoadConfigError:new(
+                        'Error loading section %q:' ..
+                        ' inclusion %q not found',
+                        k, v['__file']
+                    )
+                end
+            else
+                tbl[k], err = _load(v)
+                if err ~= nil then
+                    return nil, err
+                end
+            end
+            ::continue::
+        end
+        return tbl, err
+    end
+
+    local new_luatables, err = _load(root)
+    if err ~= nil then
+        return nil, err
+    end
+
+    utils.table_setro(new_luatables)
+    rawset(clusterwide_config, '_luatables', new_luatables)
+    return clusterwide_config
+end
 
 local clusterwide_config_mt
 clusterwide_config_mt = {
@@ -38,53 +158,59 @@ clusterwide_config_mt = {
 
         copy = function(self)
             checks('ClusterwideConfig')
-            local data = table.deepcopy(self.data)
+            local _plaintext = table.deepcopy(self._plaintext)
             return setmetatable({
-                data = utils.table_setro(data),
+                _plaintext = utils.table_setro(_plaintext),
                 locked = false,
             }, clusterwide_config_mt)
         end,
 
-        set_content = function(self, section_name, content)
-            checks('ClusterwideConfig', 'string', '?')
+        set_plaintext = function(self, section_name, content)
+            checks('ClusterwideConfig', 'string', '?string')
+
             if self.locked then
                 error("ClusterwideConfig is locked", 2)
             end
 
             if content == box.NULL then
                 content = nil
-            elseif type(content) == 'table' then
-                content = table.deepcopy(content)
-                content = utils.table_setro(content)
             end
 
-            rawset(self.data, section_name, content)
+            rawset(self._plaintext, section_name, content)
+            rawset(self, '_luatables', nil)
             return self
         end,
 
+        get_plaintext = function(self, section_name)
+            checks('ClusterwideConfig', '?string')
+            assert(self._plaintext ~= nil)
+
+            if section_name == nil then
+                return self._plaintext
+            else
+                return self._plaintext[section_name]
+            end
+        end,
 
         get_readonly = function(self, section_name)
             checks('ClusterwideConfig', '?string')
-            assert(self.data ~= nil)
+            assert(self._plaintext ~= nil)
+
+            if self._luatables == nil then
+                LoadConfigError:assert(self:update_luatables())
+            end
+
             if section_name == nil then
-                return self.data
+                return self._luatables
             else
-                return self.data[section_name]
+                return self._luatables[section_name]
             end
         end,
 
         get_deepcopy = function(self, section_name)
             checks('ClusterwideConfig', '?string')
-            assert(self.data ~= nil)
 
-            local ret
-            if section_name == nil then
-                ret = self.data
-            else
-                ret = self.data[section_name]
-            end
-
-            ret = table.deepcopy(ret)
+            local ret = table.deepcopy(self:get_readonly(section_name))
 
             if type(ret) == 'table' then
                 return utils.table_setrw(ret)
@@ -92,107 +218,301 @@ clusterwide_config_mt = {
                 return ret
             end
         end,
+
+        update_luatables = update_luatables,
     }
 }
 
 --- Create new object.
 -- @function new
--- @tparam[opt] table data.
--- @treturn ClusterwideConfig
+-- @tparam[opt] {string=string,...} data
+--   Plaintext content
+-- @treturn[1] ClusterwideConfig
+-- @treturn[2] nil
+-- @treturn[2] table Error description
 local function new(data)
     checks('?table')
     if data == nil then
         data = {}
     end
 
-    return setmetatable({
-        data = utils.table_setro(data),
-        locked = false,
+    for k, v in pairs(data) do
+        if type(k) ~= 'string' then
+            local err = "bad argument #1 to new" ..
+                " (table keys must be strings)"
+            error(err, 2)
+        elseif type(v) ~= 'string' then
+            local err = "bad argument #1 to new" ..
+                " (table values must be strings)"
+            error(err, 2)
+        end
+
+    end
+
+    local cfg = setmetatable({
+        _plaintext = utils.table_setro(data),
+        locked = false
     }, clusterwide_config_mt)
+
+    return cfg:update_luatables()
 end
 
---- Load object from filesystem.
--- Configuration is a YAML file.
--- @function load
+--- Load old-style config from YAML file.
+--
+-- @function load_from_file
 -- @local
 -- @tparam string filename
 --   Filename to load.
 -- @treturn[1] ClusterwideConfig
 -- @treturn[2] nil
 -- @treturn[2] table Error description
-local function load(filename)
-    checks('string')
-
-    if not utils.file_exists(filename) then
-        return nil, LoadConfigError:new('file %q does not exist', filename)
-    end
-
+local function load_from_file(filename)
     local raw, err = utils.file_read(filename)
     if not raw then
         return nil, err
     end
 
-    local confdir = fio.dirname(filename)
-
-    local root, err = DecodeYamlError:pcall(yaml.decode, raw)
-    if not root then
-        if not err then
-            return nil, LoadConfigError:new('file %q is empty', filename)
-        end
-
+    local ok, data = pcall(yaml.decode, raw)
+    if not ok then
+        local err = LoadConfigError:new(
+            'Error parsing %q: %s',
+            filename, data
+        )
         return nil, err
+    elseif data == nil then
+        return nil, LoadConfigError:new(
+            'Error loading %q: File is empty', filename
+        )
     end
 
+    local _plaintext = {}
+    for section, content in pairs(data) do
+        if type(content) == 'string' then
+            _plaintext[section] = content
+        else
+            _plaintext[section .. '.yml'] = yaml.encode(content)
+        end
+    end
+
+    local dirname = fio.dirname(filename)
     local function _load(tbl)
-        for k, v in pairs(tbl) do
-            if type(v) == 'table' then
-                local err
-                if v['__file'] then
-                    tbl[k], err = utils.file_read(confdir .. '/' .. v['__file'])
-                else
-                    tbl[k], err = _load(v)
-                end
-                if err then
+        for _, v in pairs(tbl) do
+            if type(v) ~= 'table' then
+                goto continue
+            elseif v['__file'] == nil then
+                local ok, err = _load(v)
+                if not ok then
                     return nil, err
                 end
+                goto continue
             end
+
+            _plaintext[v['__file']] = utils.file_read(
+                fio.pathjoin(dirname, v['__file'])
+            )
+
+            ::continue::
         end
-        return tbl
+        return true
     end
 
-    local data, err = _load(root)
-    if data == nil then
+    local ok, err = _load(data)
+    if not ok then
         return nil, err
     end
 
-    return new(data)
+    return new(_plaintext)
 end
 
---- Write object to filesystem.
--- @function save
+--- Load new-style config from a directory.
+--
+-- @function load_from_dir
 -- @local
+-- @tparam string path
+--   Path to the config.
+-- @treturn[1] ClusterwideConfig
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function load_from_dir(path)
+    local plaintext = {}
+
+    local function _recursive_load(subdir)
+        local flist = fio.listdir(fio.pathjoin(path, subdir))
+        for _, fname in ipairs(flist) do
+            local relpath = fio.pathjoin(subdir, fname)
+            local abspath = fio.pathjoin(path, relpath)
+
+            if fio.path.is_dir(abspath) then
+                local _, err = _recursive_load(relpath)
+                if err ~= nil then
+                    return nil, err
+                end
+            else
+                local raw, err = utils.file_read(abspath)
+                if not raw then
+                    return nil, err
+                end
+
+                plaintext[relpath] = raw
+            end
+        end
+
+        return true
+    end
+
+    local ok, err = _recursive_load('')
+    if not ok then
+        return nil, err
+    end
+
+    return new(plaintext)
+end
+
+local function randomize(filename)
+    local random = digest.urandom(9)
+    local suffix = digest.base64_encode(random, {urlsafe = true})
+    return filename .. '.' .. suffix
+end
+
+--- Remove config from filesystem atomically.
+--
+-- The atomicity is achieved by splitting it into two phases:
+-- 1. Configuration is saved with a random filename in the same directory
+-- 2. Temporal filename is renamed to the destination
+--
+--
+-- @function remove
+-- @local
+-- @tparam path string
+--  Directory path to remove.
+-- @treturn[1] boolean true
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function remove(path)
+    local random_path = fio.pathjoin(
+        fio.dirname(path),
+        randomize(fio.basename(path))
+    )
+
+    local ok = fio.rename(path, random_path)
+    if not ok then
+        return nil, RemoveConfigError:new(
+            '%s: %s',
+            path, errno.strerror()
+        )
+    end
+
+    local ok, err = fio.rmtree(random_path)
+    if not ok then
+        log.warn(
+            "Error removing %s: %s",
+            random_path, err
+        )
+    end
+
+    return true
+end
+
+--- Write configuration to filesystem.
+--
+-- Write atomicity is achieved by splitting it into two phases:
+-- 1. Configuration is saved with a random filename in the same directory
+-- 2. Temporal filename is renamed to the destination
+--
+-- @function save
 -- @tparam ClusterwideConfig clusterwide_config
---   Filename to load.
 -- @tparam string filename
---   Destination path.
 -- @treturn[1] boolean true
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function save(clusterwide_config, path)
     checks('ClusterwideConfig', 'string')
-    local ok, err = utils.file_write(
-        path, yaml.encode(clusterwide_config.data),
-        {'O_CREAT', 'O_EXCL', 'O_WRONLY'}
+
+    local random_path = fio.pathjoin(
+        fio.dirname(path),
+        randomize(fio.basename(path))
     )
+
+    local ok, err
+
+    ok, err = utils.mktree(random_path)
     if not ok then
         return nil, err
     end
 
-    return true
+    for section, content in pairs(clusterwide_config._plaintext) do
+        local abspath = fio.pathjoin(random_path, section)
+        local dirname = fio.dirname(abspath)
+
+        ok, err = utils.mktree(dirname)
+        if not ok then
+            goto rollback
+        end
+
+        ok, err = utils.file_write(
+            abspath, content,
+            {'O_CREAT', 'O_EXCL', 'O_WRONLY'}
+        )
+        if not ok then
+            goto rollback
+        end
+    end
+
+    ok = fio.rename(random_path, path)
+    if not ok then
+        err = SaveConfigError:new(
+            '%s: %s',
+            path, errno.strerror()
+        )
+        goto rollback
+    else
+        return true
+    end
+
+::rollback::
+    local ok, _err = fio.rmtree(random_path)
+    if not ok then
+        log.warn(
+            "Error removing %s: %s",
+            random_path, _err
+        )
+    end
+
+    return nil, err
+end
+
+--- Load object from filesystem.
+--
+-- This function handles both old-style single YAML and
+-- new-style directory with a file tree.
+--
+-- @function load
+-- @tparam string filename
+-- @treturn[1] ClusterwideConfig
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function load(path)
+    checks('string')
+
+    if not fio.path.lexists(path) then
+        local err = LoadConfigError:new(
+            'Error loading %q: %s',
+            path, errno.strerror(errno.ENOENT)
+        )
+        return nil, err
+    end
+
+    if fio.path.is_dir(path) then
+        return load_from_dir(path)
+    else
+        return load_from_file(path)
+    end
+
 end
 
 return {
     new = new,
     load = load,
     save = save,
+    remove = remove,
 }

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -413,7 +413,10 @@ local function init(opts)
         log.info('Remote control listening on 0.0.0.0:%d', vars.binary_port)
     end
 
-    local config_filename = fio.pathjoin(vars.workdir, 'config.yml')
+    local config_filename = fio.pathjoin(vars.workdir, 'config')
+    if not utils.file_exists(config_filename) then
+        config_filename = config_filename .. '.yml'
+    end
     if not utils.file_exists(config_filename) then
         local snapshots = fio.glob(fio.pathjoin(vars.workdir, '*.snap'))
         if next(snapshots) ~= nil then

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -218,7 +218,11 @@ local function _clusterwide(patch)
         elseif type(v) == 'string' then
             clusterwide_config_new:set_plaintext(k, v)
         else
-            clusterwide_config_new:set_plaintext(k .. '.yml', yaml.encode(v))
+            if not string.endswith(k, '.yml') then
+                k = k .. '.yml'
+            end
+
+            clusterwide_config_new:set_plaintext(k, yaml.encode(v))
         end
     end
 

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -56,7 +56,7 @@ local function prepare_2pc(data)
     end
 
     local workdir = confapplier.get_workdir()
-    local path_prepare = fio.pathjoin(workdir, 'config.prepare.yml')
+    local path_prepare = fio.pathjoin(workdir, 'config.prepare')
 
     if vars.prepared_config ~= nil then
         local err = Prepare2pcError:new('Two-phase commit is locked')
@@ -104,14 +104,14 @@ local function commit_2pc()
     )
 
     local workdir = confapplier.get_workdir()
-    local path_prepare = fio.pathjoin(workdir, 'config.prepare.yml')
-    local path_backup = fio.pathjoin(workdir, 'config.backup.yml')
-    local path_active = fio.pathjoin(workdir, 'config.yml')
+    local path_prepare = fio.pathjoin(workdir, 'config.prepare')
+    local path_backup = fio.pathjoin(workdir, 'config.backup')
+    local path_active = fio.pathjoin(workdir, 'config')
 
-    fio.unlink(path_backup)
+    ClusterwideConfig.remove(path_backup)
 
     if fio.path.exists(path_active) then
-        local ok = fio.link(path_active, path_backup)
+        local ok = fio.rename(path_active, path_backup)
         if ok then
             log.info('Backup of active config created: %q', path_backup)
         else
@@ -150,8 +150,8 @@ end
 -- @treturn boolean true
 local function abort_2pc()
     local workdir = confapplier.get_workdir()
-    local path_prepare = fio.pathjoin(workdir, 'config.prepare.yml')
-    fio.unlink(path_prepare)
+    local path_prepare = fio.pathjoin(workdir, 'config.prepare')
+    ClusterwideConfig.remove(path_prepare)
     vars.prepared_config = nil
     return true
 end
@@ -185,7 +185,7 @@ end
 local function _clusterwide(patch)
     checks('table')
     if patch.__type == 'ClusterwideConfig' then
-        local err = "Bad argument #1 to patch_clusterwide" ..
+        local err = "bad argument #1 to patch_clusterwide" ..
             " (table expected, got ClusterwideConfig)"
         error(err, 2)
     end
@@ -194,17 +194,37 @@ local function _clusterwide(patch)
 
     local clusterwide_config_old = confapplier.get_active_config()
     local vshard_utils = require('cartridge.vshard-utils')
+
     if clusterwide_config_old == nil then
         local auth = require('cartridge.auth')
         clusterwide_config_old = ClusterwideConfig.new({
-            auth = auth.get_params(),
-            vshard_groups = vshard_utils.get_known_groups(),
+            ['auth.yml'] = yaml.encode(auth.get_params()),
+            ['vshard_groups.yml'] = yaml.encode(vshard_utils.get_known_groups()),
         }):lock()
     end
 
     local clusterwide_config_new = clusterwide_config_old:copy()
     for k, v in pairs(patch) do
-        clusterwide_config_new:set_content(k, v)
+        if patch[k] ~= nil and patch[k .. '.yml'] ~= nil then
+            local err = PatchClusterwideError:new(
+                'Ambiguous sections %q and %q',
+                k, k .. '.yml'
+            )
+            return nil, err
+        end
+        if v == nil then
+            clusterwide_config_new:set_plaintext(k, v)
+            clusterwide_config_new:set_plaintext(k .. '.yml', patch[k .. '.yml'])
+        elseif type(v) == 'string' then
+            clusterwide_config_new:set_plaintext(k, v)
+        else
+            clusterwide_config_new:set_plaintext(k .. '.yml', yaml.encode(v))
+        end
+    end
+
+    local _, err = clusterwide_config_new:update_luatables()
+    if err ~= nil then
+        return nil, err
     end
     clusterwide_config_new:lock()
     -- log.info('%s', yaml.encode(clusterwide_config_new:get_readonly()))
@@ -214,7 +234,10 @@ local function _clusterwide(patch)
 
     topology.probe_missing_members(topology_new.servers)
 
-    if utils.deepcmp(clusterwide_config_new, clusterwide_config_old) then
+    if utils.deepcmp(
+        clusterwide_config_new:get_plaintext(),
+        clusterwide_config_old:get_plaintext()
+    ) then
         log.warn("Clusterwide config didn't change, skipping")
         return true
     end
@@ -253,7 +276,7 @@ local function _clusterwide(patch)
         log.warn('(2PC) Preparation stage...')
 
         local retmap, errmap = pool.map_call(
-            '_G.__cartridge_clusterwide_config_prepare_2pc', {clusterwide_config_new:get_readonly()},
+            '_G.__cartridge_clusterwide_config_prepare_2pc', {clusterwide_config_new:get_plaintext()},
             {uri_list = uri_list, timeout = 5}
         )
 

--- a/test/integration/bootstrap_test.lua
+++ b/test/integration/bootstrap_test.lua
@@ -136,10 +136,7 @@ function g.test_workdir_collision()
     g.cluster:start()
 
     t.assert_error_msg_contains(
-        string.format('%s: %s',
-            fio.pathjoin(g.tempdir, 'config.prepare.yml'),
-            errno.strerror(errno.EEXIST)
-        ),
+        g.tempdir .. '/config.prepare: ',
         helpers.Cluster.join_server, g.cluster, g.server
     )
     g.cluster:wait_until_healthy()

--- a/test/integration/config_test.lua
+++ b/test/integration/config_test.lua
@@ -176,11 +176,20 @@ test_remotely('test_patch_clusterwide', function()
 
     --------------------------------------------------------------------
     local ok, err = _patch({
-        ['data.yml'] = '{tomorow: saturday}',
+        -- test that .yml extension isn't added twice
+        ['data.yml'] = {tomorow = 'saturday'},
     })
     t.assert_equals(err, nil)
     t.assert_equals(ok, true)
     t.assert_equals(_get_ro('data'), {tomorow = 'saturday'})
+
+    local ok, err = _patch({
+        ['data.yml'] = '{tomorow: saturday} # so excited',
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), {tomorow = 'saturday'})
+    t.assert_equals(_get_ro('data.yml'), '{tomorow: saturday} # so excited')
 
     --------------------------------------------------------------------
     local ok, err = _patch({

--- a/test/integration/config_test.lua
+++ b/test/integration/config_test.lua
@@ -48,6 +48,8 @@ function g.test_upload_good()
         }
     }
     g.cluster:upload_config(custom_config)
+    g.cluster:upload_config({['custom_config.yml'] = '{spoiled: true}'})
+    g.cluster:upload_config(custom_config)
 
     g.cluster.main_server.net_box:eval([[
         local confapplier = package.loaded['cartridge.confapplier']
@@ -82,9 +84,16 @@ end
 
 function g.test_upload_fail()
     local system_sections = {
+        'auth',
+        'auth.yml',
         'topology',
-        'vshard', 'vshard_groups',
-        'auth', 'users_acl'
+        'topology.yml',
+        'users_acl',
+        'users_acl.yml',
+        'vshard',
+        'vshard.yml',
+        'vshard_groups',
+        'vshard_groups.yml',
     }
 
     local server = g.cluster.main_server
@@ -105,8 +114,128 @@ function g.test_upload_fail()
     t.assert_equals(resp.json['class_name'], 'Decoding YAML failed')
     t.assert_equals(resp.json['err'], 'unexpected END event')
 
-    local resp = server:http_request('put', '/admin/config', {body = 'Lorem ipsum dolor', raw = true})
+    local resp = server:http_request('put', '/admin/config',
+        {body = 'Lorem ipsum dolor', raw = true}
+    )
     t.assert_equals(resp.status, 400)
     t.assert_equals(resp.json['class_name'], 'Config upload failed')
     t.assert_equals(resp.json['err'], 'Config must be a table')
+
+    local function check_err(body)
+        local resp = server:http_request('put', '/admin/config',
+            {body = body, raw = true}
+        )
+        t.assert_equals(resp.status, 400)
+        t.assert_equals(resp.json['class_name'], 'Config upload failed')
+        t.assert_equals(resp.json['err'],
+            'ambiguous sections "conflict" and "conflict.yml"'
+        )
+    end
+
+    check_err([[
+        conflict: "one"
+        conflict.yml: "two"
+    ]])
+    check_err([[
+        conflict: "one"
+        conflict.yml: null
+    ]])
+    check_err([[
+        conflict: null
+        conflict.yml: null
+    ]])
 end
+
+local M = {}
+local function test_remotely(fn_name, fn)
+    M[fn_name] = fn
+    g[fn_name] = function()
+        g.cluster.main_server.net_box:eval([[
+            local test = require('test.integration.config_test')
+            test[...]()
+        ]], {fn_name})
+    end
+end
+test_remotely('test_patch_clusterwide', function()
+    local cartridge = package.loaded['cartridge']
+    local twophase = package.loaded['cartridge.twophase']
+    local confapplier = package.loaded['cartridge.confapplier']
+    t.assert_is(cartridge.config_get_readonly, confapplier.get_readonly)
+    t.assert_is(cartridge.config_get_deepcopy, confapplier.get_deepcopy)
+    t.assert_is(cartridge.config_patch_clusterwide, twophase.patch_clusterwide)
+    local _patch = cartridge.config_patch_clusterwide
+    local _get_ro = cartridge.config_get_readonly
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
+        ['data'] = {today = "friday"},
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), {today = 'friday'})
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
+        ['data.yml'] = '{tomorow: saturday}',
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), {tomorow = 'saturday'})
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
+        ['data'] = box.NULL,
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), nil)
+    t.assert_equals(_get_ro('data.yml'), nil)
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
+        ['data.yml'] = '{afterwards: sunday}',
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), {afterwards = 'sunday'})
+    t.assert_equals(_get_ro('data.yml'), '{afterwards: sunday}')
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({['data'] = "Fun, fun, fun, fun",})
+    t.assert_equals(ok, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err, 'Ambiguous sections "data" and "data.yml"')
+    local ok, err = _patch({
+        ['data'] = "Fun, fun, fun, fun",
+        ['data.yml'] = box.NULL,
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), "Fun, fun, fun, fun")
+    t.assert_equals(_get_ro('data.yml'), nil)
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({['data.yml'] = "---\nWeekend\n...",})
+    t.assert_equals(ok, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err, 'Ambiguous sections "data" and "data.yml"')
+    local ok, err = _patch({
+        ['data'] = box.NULL,
+        ['data.yml'] = "---\nWeekend\n...",
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), "Weekend")
+    t.assert_equals(_get_ro('data.yml'), "---\nWeekend\n...")
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
+        ['conflict'] = {},
+        ['conflict.yml'] = "xxx",
+    })
+    t.assert_equals(ok, nil)
+    t.assert_equals(err.class_name, 'PatchClusterwideError')
+    t.assert_equals(err.err, 'Ambiguous sections "conflict" and "conflict.yml"')
+end)
+
+return M

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -203,11 +203,10 @@ function g.test_graphql_errors()
     end
 
     _test('][', 'unexpected END event')
-    _test(1000, 'Section "schema.yml" must be a string, got number')
     _test('42', 'Schema must be a table, got number')
     _test('spaces: false',
         'Bad argument #1 to ddl.check_schema' ..
-        ' invalid schema.spaces (table expected, got boolean)'
+        ' invalid schema.spaces (?table expected, got boolean)'
     )
     _test('spaces: {}',
         'Missing space "test_space" in schema,' ..

--- a/test/integration/myrole_test.lua
+++ b/test/integration/myrole_test.lua
@@ -133,15 +133,17 @@ function g.test_rename()
 
     g.cluster:stop()
 
-    local cfg_path = fio.pathjoin(g.cluster.main_server.workdir, 'config.yml')
-    local data = utils.file_read(cfg_path)
-    local config = yaml.decode(data)
-    local replicasets = config['topology']['replicasets']
+    local topology_cfg_path = fio.pathjoin(
+        g.cluster.main_server.workdir, 'config/topology.yml'
+    )
+    local data = utils.file_read(topology_cfg_path)
+    local topology_cfg = yaml.decode(data)
+    local replicasets = topology_cfg['replicasets']
     local replicaset = replicasets[helpers.uuid('a')]
     replicaset['roles'] = {['myrole-oldname'] = true}
-    local data = yaml.encode(config)
-    utils.file_write(cfg_path, data)
-    log.info('Config hacked: ' .. cfg_path)
+    local data = yaml.encode(topology_cfg)
+    utils.file_write(topology_cfg_path, data)
+    log.info('Config hacked: ' .. topology_cfg_path)
 
     g.cluster:start()
 

--- a/test/integration/reboot_test.lua
+++ b/test/integration/reboot_test.lua
@@ -36,6 +36,10 @@ end
 function g.test_oldstyle_config()
     g.cluster:stop()
 
+    fio.rmtree(
+        fio.pathjoin(g.cluster.main_server.workdir, 'config')
+    )
+
     utils.file_write(
         fio.pathjoin(g.cluster.main_server.workdir, 'config.yml'),
         [[
@@ -81,8 +85,8 @@ function g.test_absent_config()
     g.cluster:stop()
     log.warn('Cluster stopped')
 
-    fio.unlink(
-        fio.pathjoin(g.cluster.main_server.workdir, 'config.yml')
+    fio.rmtree(
+        fio.pathjoin(g.cluster.main_server.workdir, 'config')
     )
     log.warn('Config removed')
 
@@ -139,16 +143,11 @@ function g.test_invalid_config()
     g.cluster:stop()
     log.warn('Cluster stopped')
 
-
     utils.file_write(
-        fio.pathjoin(g.cluster.main_server.workdir, 'config.yml'),
+        fio.pathjoin(g.cluster.main_server.workdir, 'config/topology.yml'),
         [[
-        topology:
             replicasets: {}
             servers: {}
-        vshard:
-            bootstrapped: false
-            bucket_count: 3000
         ]]
     )
 

--- a/test/unit/clusterwide_config_test.lua
+++ b/test/unit/clusterwide_config_test.lua
@@ -1,0 +1,394 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local g = t.group('clusterwide_config')
+local fio = require('fio')
+local yaml = require('yaml')
+local checks = require('checks')
+local errno = require('errno')
+local utils = require('cartridge.utils')
+local ClusterwideConfig = require('cartridge.clusterwide-config')
+
+g.setup = function()
+    g.tempdir = fio.tempdir()
+end
+
+g.teardown = function()
+    fio.rmtree(g.tempdir)
+end
+
+local function table_merge(t1, t2)
+    local ret = table.copy(t1)
+    for k, v in pairs(t2) do
+        ret[k] = v
+    end
+    return ret
+end
+
+local function write_tree(tree)
+    checks('table')
+    for path, content in pairs(tree) do
+        local abspath = fio.pathjoin(g.tempdir, path)
+        utils.mktree(fio.dirname(abspath))
+        utils.file_write(abspath, content)
+    end
+end
+
+function g.test_newstyle_ok()
+    local files = {
+        ['a/b/c/first.txt'] = 'first',
+        ['a/b/c/second.yml'] = 'key: value',
+        ['table.yml'] = '{a: {b: {c: 4}}}',
+        ['table.txt'] = '{a: {b: {c: 5}}}',
+        ['include.yml'] = '__file: a/b/c/first.txt',
+    }
+    write_tree(files)
+
+    local cfg, err = ClusterwideConfig.load(g.tempdir)
+    t.assert_equals(err, nil)
+    t.assert_equals(cfg:get_plaintext(), files)
+    t.assert_equals(cfg:get_readonly(),
+        table_merge(files, {
+            ['a/b/c/second'] = {key = 'value'},
+            ['table'] = {a = {b = {c = 4}}},
+            ['include'] = 'first',
+        })
+    )
+
+end
+
+function g.test_newstyle_err()
+    local cfg, err = ClusterwideConfig.load(
+        fio.pathjoin(g.tempdir, 'not_existing')
+    )
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        string.format(
+            "Error loading %q: %s",
+            fio.pathjoin(g.tempdir, 'not_existing'),
+            errno.strerror(errno.ENOENT)
+        )
+    )
+
+    write_tree({
+        ['cfg1/bad.yml'] = ',',
+    })
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/cfg1')
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        'Error parsing section "bad.yml": unexpected END event'
+    )
+
+    write_tree({
+        ['cfg2/bad.yml'] = '{__file: not_existing.txt}',
+    })
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/cfg2')
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        'Error loading section "bad":' ..
+        ' inclusion "not_existing.txt" not found'
+    )
+end
+
+function g.test_oldstyle_ok()
+    local files = {
+        ['main.yml'] = [[
+            string: "foobar"
+            table: {a: {b: {c: 4}}}
+            number: 42
+            boolean: false
+            colors.yml: "---\n{red: '0xff0000'}\n..."
+            side_config: {__file: 'inclusion.txt'}
+        ]],
+        ['inclusion.txt'] = "Hi it's me",
+        ['redundant.txt'] = "This is just a junk file",
+    }
+    write_tree(files)
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/main.yml')
+    if err ~= nil then
+        error(err)
+    end
+
+    cfg:update_luatables()
+    t.assert_equals(cfg._luatables['string'], 'foobar')
+    t.assert_equals(cfg._luatables['number'], 42)
+    t.assert_equals(cfg._luatables['boolean'], false)
+    t.assert_equals(cfg._luatables['colors'], {red = '0xff0000'})
+    t.assert_equals(cfg._luatables['side_config'], "Hi it's me")
+
+    t.assert_equals(cfg._luatables['string.yml'], nil)
+    t.assert_equals(yaml.decode(cfg._luatables['number.yml']), 42)
+    t.assert_equals(yaml.decode(cfg._luatables['boolean.yml']), false)
+    t.assert_equals(yaml.decode(cfg._luatables['table.yml']), {a = {b = {c = 4}}})
+    t.assert_equals(yaml.decode(cfg._luatables['colors.yml']), {red = '0xff0000'})
+    t.assert_equals(yaml.decode(cfg._luatables['side_config.yml']), {__file = 'inclusion.txt'})
+
+    t.assert_equals(cfg._luatables['inclusion.txt'], "Hi it's me")
+    t.assert_equals(cfg._luatables['redundant.txt'], nil)
+
+    t.assert_equals(cfg._luatables, cfg:get_readonly())
+    t.assert_equals(cfg._luatables, cfg:get_deepcopy())
+
+
+    t.assert_equals(cfg._plaintext, {
+        ['string'] = "foobar",
+        ['table.yml'] = yaml.encode({a = {b = {c = 4}}}),
+        ['number.yml'] = yaml.encode(42),
+        ['boolean.yml'] = yaml.encode(false),
+        ['side_config.yml'] = yaml.encode({__file = 'inclusion.txt'}),
+        ['inclusion.txt'] = "Hi it's me",
+        ['colors.yml'] = "---\n{red: '0xff0000'}\n...",
+    })
+    t.assert_equals(cfg._plaintext, cfg:get_plaintext())
+end
+
+function g.test_oldstyle_err()
+    local cfg, err = ClusterwideConfig.load(
+        fio.pathjoin(g.tempdir, 'not_existing.yml')
+    )
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        string.format(
+            "Error loading %q: %s",
+            fio.pathjoin(g.tempdir, 'not_existing.yml'),
+            errno.strerror(errno.ENOENT)
+        )
+    )
+
+    write_tree({['bad1/main.yml'] = ','})
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/bad1/main.yml')
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        string.format(
+            "Error parsing %q: unexpected END event",
+            fio.pathjoin(g.tempdir, 'bad1/main.yml'),
+            errno.strerror(errno.ENOENT)
+        )
+    )
+
+    write_tree({['bad2/main.yml'] = [[
+        side_config: {__file: 'not_existing.txt'}
+    ]]})
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/bad2/main.yml')
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err,
+        'Error loading section "side_config":' ..
+        ' inclusion "not_existing.txt" not found'
+    )
+end
+
+function g.test_preserving_plaintext()
+    local cfg = ClusterwideConfig.new()
+    local data = '{fizz: buzz} #important comment'
+    cfg:set_plaintext('data.yml', data)
+
+    t.assert_equals(cfg:get_readonly('data'), {fizz = 'buzz'})
+    t.assert_equals(cfg:get_readonly('data.yml'), data)
+    t.assert_equals(cfg:get_plaintext('data.yml'), data)
+end
+
+
+function g.test_delete_plaintext_key()
+    local cfg = ClusterwideConfig.new():set_plaintext('key', 'val')
+    t.assert_equals(cfg:get_plaintext(), {['key'] = 'val'})
+    t.assert_equals(cfg:get_readonly(), {['key'] = 'val'})
+
+    cfg:set_plaintext('key', nil)
+    t.assert_equals(cfg:get_plaintext(), {})
+    t.assert_equals(cfg:get_readonly(), {})
+
+    local cfg = ClusterwideConfig.new():set_plaintext('key', 'val')
+    t.assert_equals(cfg:get_plaintext(), {['key'] = 'val'})
+    t.assert_equals(cfg:get_readonly(), {['key'] = 'val'})
+
+    cfg:set_plaintext('key', box.NULL)
+    t.assert_equals(cfg:get_plaintext(), {})
+    t.assert_equals(cfg:get_readonly(), {})
+end
+
+function g.test_create_err()
+    t.assert_error_msg_contains(
+        'bad argument #1 to new (?table expected, got string)',
+        function() ClusterwideConfig.new('str') end
+    )
+    t.assert_error_msg_contains(
+        'bad argument #1 to new (table keys must be strings)',
+        function() ClusterwideConfig.new({[1] = 'one'}) end
+    )
+    t.assert_error_msg_contains(
+        'bad argument #1 to new (table values must be strings)',
+        function() ClusterwideConfig.new({two = 2}) end
+    )
+
+    local cfg, err = ClusterwideConfig.new({
+        ['x'] = 'foo',
+        ['x.yml'] = 'bar'
+    })
+    t.assert_equals(cfg, nil)
+    t.assert_equals(err.class_name, 'LoadConfigError')
+    t.assert_equals(err.err, 'Ambiguous sections "x" and "x.yml"')
+end
+
+
+function g.test_get_readonly_ok()
+    local data = '{fizz: buzz} #important comment'
+
+    local cfg = ClusterwideConfig.new()
+    t.assert_equals({cfg:get_readonly()}, {{}})
+
+    local cfg = ClusterwideConfig.new():set_plaintext('a',  data)
+    t.assert_equals({cfg:get_readonly('a')}, {data})
+
+    local cfg = ClusterwideConfig.new():set_plaintext('a.txt',  data)
+    t.assert_equals({cfg:get_readonly('a.txt')}, {data})
+
+    local cfg = ClusterwideConfig.new():set_plaintext('a.yml',  data)
+    t.assert_equals({cfg:get_readonly('a.yml')}, {data})
+    t.assert_equals({cfg:get_readonly('a')}, {yaml.decode(data)})
+
+    -- local cfg = ClusterwideConfig.new():set_plaintext('a.yaml', data)
+    -- t.assert_equals({cfg:get_readonly('a.yaml')}, {data})
+    -- t.assert_equals({cfg:get_readonly('a')}, {yaml.decode(data)})
+end
+
+
+function g.test_get_readonly_err()
+    local cfg = ClusterwideConfig.new():set_plaintext('bad.yml', ',')
+    cfg:set_plaintext('bad.yml', ',')
+    t.assert_error_msg_contains(
+        'LoadConfigError: Error parsing section "bad.yml":' ..
+        ' unexpected END event',
+        cfg.get_readonly, cfg
+    )
+
+    local cfg = ClusterwideConfig.new()
+    cfg:set_plaintext('file.yml', '---\n{__file: some.txt}\n...')
+    local _, err = cfg:update_luatables()
+    t.assert_str_icontains(
+        err.str,
+        'LoadConfigError: Error loading section "file":' ..
+        ' inclusion "some.txt" not found'
+    )
+end
+
+function g.test_immutability()
+    t.assert_error_msg_contains(
+        'table is read-only',
+        function()
+            local cfg = ClusterwideConfig.new()
+            cfg:get_readonly()['data'] = 'new_data'
+        end
+    )
+end
+
+function g.test_get_deepcopy_modify()
+    local cfg = ClusterwideConfig.new():get_deepcopy()
+    t.assert_equals(cfg, {})
+
+    cfg['new_key'] = 'new_value'
+    t.assert_equals(cfg, {
+        ['new_key'] = 'new_value'
+    })
+end
+
+function g.test_save_empty_config()
+    local cfg = ClusterwideConfig.new()
+
+    local p1 = g.tempdir .. '/cfg-1'
+    ClusterwideConfig.save(cfg, p1)
+    t.assert_equals({fio.listdir(p1)}, {{}})
+
+    cfg:set_plaintext('data.yml', nil)
+    local p2 = g.tempdir .. '/cfg-2'
+    ClusterwideConfig.save(cfg, p2)
+    t.assert_equals(fio.listdir(p2), {})
+
+    cfg:set_plaintext('data.yml', '')
+    local p3 = g.tempdir .. '/cfg-3'
+    ClusterwideConfig.save(cfg, p3)
+    t.assert_equals(fio.listdir(p3), {'data.yml'})
+    t.assert_equals(utils.file_read(p3 .. '/data.yml'), '')
+    t.assert_equals(cfg:get_readonly('data'), nil)
+    t.assert_equals(cfg:get_readonly('data.yml'), '')
+    t.assert_equals(cfg:get_readonly(), {
+        ['data'] = nil,
+        ['data.yml'] = '',
+    })
+
+    cfg:set_plaintext('data.yml', box.NULL)
+    local p4 = g.tempdir .. '/cfg-4'
+    ClusterwideConfig.save(cfg, p4)
+    t.assert_equals(fio.listdir(p4), {})
+end
+
+
+function g.test_save_err()
+    write_tree({['config'] = '---\n...'})
+
+    local cfg = ClusterwideConfig.new({['b'] = 'b'})
+    local ok, err = ClusterwideConfig.save(cfg, g.tempdir .. '/config')
+    t.assert_equals(ok, nil)
+    t.assert_equals(err.class_name, 'SaveConfigError')
+    t.assert_equals(err.err,
+        string.format(
+            "%s: %s",
+            g.tempdir .. '/config',
+            errno.strerror(errno.ENOTDIR)
+        )
+    )
+    t.assert_equals(utils.file_read(g.tempdir .. '/config'), '---\n...')
+end
+
+function g.test_save_ok()
+    local cfg = ClusterwideConfig.new()
+    local ok, err = ClusterwideConfig.save(cfg, g.tempdir .. '/cfg1')
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(
+        fio.listdir(fio.pathjoin(g.tempdir, 'cfg1')),
+        {}
+    )
+
+    local cfg = ClusterwideConfig.new({
+        ['some.txt'] = 'text',
+        ['a/b/data'] = 'data',
+        ['key.yml'] = '---\n{__file: some.txt}\n...',
+        ['another.yml'] = '---\n{a: "val"}\n...'
+    })
+
+    local ok, err = ClusterwideConfig.save(
+        cfg, fio.pathjoin(g.tempdir, 'cfg2')
+    )
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_items_equals(
+        fio.listdir(fio.pathjoin(g.tempdir, 'cfg2')),
+        {'a', 'some.txt', 'another.yml', 'key.yml'}
+    )
+
+    t.assert_equals(
+        utils.file_read(fio.pathjoin(g.tempdir, 'cfg2/some.txt')),
+        'text'
+    )
+
+    t.assert_equals(
+        utils.file_read(fio.pathjoin(g.tempdir, 'cfg2/a/b/data')),
+        'data'
+    )
+
+    t.assert_equals(
+        utils.file_read(fio.pathjoin(g.tempdir, 'cfg2/key.yml')),
+        '---\n{__file: some.txt}\n...'
+    )
+
+    t.assert_equals(
+        utils.file_read(fio.pathjoin(g.tempdir, 'cfg2/another.yml')),
+        '---\n{a: "val"}\n...'
+    )
+end

--- a/test/unit/test_rpc.lua
+++ b/test/unit/test_rpc.lua
@@ -3,6 +3,7 @@
 local tap = require('tap')
 local rpc = require('cartridge.rpc')
 local checks = require('checks')
+local yaml = require("yaml")
 
 local test = tap.test('cluster.rpc_candidates')
 test:plan(21)
@@ -50,7 +51,9 @@ local function apply_mocks(topology_draft)
 
     local vars = require('cartridge.vars').new('cartridge.confapplier')
     local ClusterwideConfig = require('cartridge.clusterwide-config')
-    vars.clusterwide_config = ClusterwideConfig.new({topology = topology_cfg}):lock()
+    vars.clusterwide_config = ClusterwideConfig.new({
+        ['topology.yml'] = yaml.encode(topology_cfg)
+    }):lock()
     local failover = require('cartridge.failover')
     _G.box = {
         cfg = function() end,
@@ -60,6 +63,7 @@ local function apply_mocks(topology_draft)
         },
     }
     failover.cfg(vars.clusterwide_config)
+
     package.loaded['membership'].get_member = function(uri)
         return members[uri]
     end

--- a/test/unit/test_topology.lua
+++ b/test/unit/test_topology.lua
@@ -62,7 +62,7 @@ local function test_all(test, conf)
 test:plan(54)
 
 local vshard_group
-if conf.vshard then
+if conf['vshard.yml'] then
     vshard_group = "\n    vshard_group: default\n"
 else
     vshard_group = "\n    vshard_group: first\n"
@@ -74,8 +74,8 @@ local function check_config(result, raw_new, raw_old)
 
     local cfg_new = table.deepcopy(conf)
     local cfg_old = table.deepcopy(conf)
-    cfg_new.topology = topology_new
-    cfg_old.topology = topology_old
+    cfg_new['topology.yml'] = yaml.encode(topology_new)
+    cfg_old['topology.yml'] = yaml.encode(topology_old)
 
     local ok, err = topology.validate(topology_new, topology_old)
     if ok then
@@ -372,7 +372,7 @@ replicasets:
 ...]])
 
 local e
-if conf.vshard then
+if conf['vshard.yml'] then
     e = 'At least one vshard-storage (default) must have weight > 0'
 else
     e = 'At least one vshard-storage (first) must have weight > 0'
@@ -752,14 +752,14 @@ end
 test:plan(2)
 
 test:test('single group', test_all, {
-    vshard = {
+    ['vshard.yml'] = yaml.encode({
         bootstrapped = true,
         bucket_count = 1337,
-    }
+    })
 })
 
 test:test('multi-group', test_all, {
-    vshard_groups = {
+    ['vshard_groups.yml'] = yaml.encode({
         first = {
             bootstrapped = true,
             bucket_count = 1337,
@@ -768,7 +768,7 @@ test:test('multi-group', test_all, {
             bootstrapped = true,
             bucket_count = 1337,
         },
-    }
+    })
 })
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Clusterwide configuration is now represented with a file tree. All
sections that were tables are saved to separate `.yml` files.
Compatibility with the old-style configuration is preserved. Accessing
unmarshalled sections with `get_readonly/deepcopy` methods is provided
without `.yml` extension as earlier.

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #329
