### PR TITLE
Properly trigger failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Displaying boolean values in server details.
 
+- Arrange proper failover triggering: don't miss events, don't trigger
+  if nothing changed.
+
 ## [1.2.0] - 2019-10-21
 
 ### Added

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -87,7 +87,7 @@ local state_transitions = {
 -- normal operation
     ['ConnectingFullmesh'] = {'ConfiguringRoles', 'OperationError'},
     ['ConfiguringRoles'] = {'RolesConfigured', 'OperationError'},
-    ['RolesConfigured'] = {'ConnectingFullmesh'},
+    ['RolesConfigured'] = {'ConnectingFullmesh', 'ConfiguringRoles'},
 
 -- errors
     ['InitError'] = {},
@@ -501,6 +501,7 @@ return {
     get_readonly = get_readonly,
     get_deepcopy = get_deepcopy,
 
+    set_state = set_state,
     get_state = function() return vars.state, vars.error end,
     get_workdir = function() return vars.workdir end,
     get_instance_uuid = function() return vars.instance_uuid end,

--- a/test/integration/failover_test.lua
+++ b/test/integration/failover_test.lua
@@ -105,7 +105,10 @@ end
 local function check_all_box_rw()
     for _, server in pairs(cluster.servers) do
         if server.net_box ~= nil then
-            t.assert_equals(server.net_box:eval('return box.cfg.read_only'), false)
+            t.assert_equals(
+                {[server.alias] = server.net_box:eval('return box.cfg.read_only')},
+                {[server.alias] = false}
+            )
         end
     end
 end


### PR DESCRIPTION
1. There was a bug: failover wasn't triggered if membership braodacted a
  change while connfapplier was reconfiguring roles

2. Don't trigger failover if nothing changed. By "nothing" it means each
  replicaset leader and each instans status (good/bad)

I didn't forget about

- [ ] Tests (No ideas how to catch it)
- [x] Changelog
- [x] Documentation (not needed)

Close #85
Close #42
