### PR TITLE
Measure clock difference across instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - GraphQL API for clusterwide configuration management.
 
+- Measure clock difference across instances and provide `clock_delta`
+  in GraphQL `servers` query and in `admin.get_servers()` Lua API.
+
 ### Changed
 
 - WebUI now uses `edit_topology` mutation instead of deprecated ones.

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -12,7 +12,7 @@ dependencies = {
     'lulpeg == 0.1.2-1',
     'errors == 2.1.1-1',
     'vshard == 0.1.14-1',
-    'membership == 2.1.4-1',
+    'membership == 2.2.0-1',
     'frontend-core == 6.2.0-1',
 }
 

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -93,6 +93,13 @@ local gql_type_server = gql_types.object {
             kind = gql_types.int,
             description = 'Failover priority within the replica set',
         },
+        clock_delta = {
+            kind = gql_types.float,
+            description = 'Difference between remote clock and the' ..
+                ' current one. Obtained from the membership module' ..
+                ' (SWIM protocol). Positive values mean remote clock' ..
+                ' are ahead of local, and vice versa. In seconds.',
+        },
         replicaset = gql_type_replicaset,
         statistics = gql_stat_schema,
         boxinfo = gql_boxinfo_schema,
@@ -265,7 +272,6 @@ end
 local function set_failover_enabled(_, args)
     return admin.set_failover_enabled(args.enabled)
 end
-
 
 local function init(graphql)
 

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Dec 13 2019 15:47:25 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Dec 16 2019 03:05:54 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -232,14 +232,21 @@ type Server {
   status: String!
   uuid: String!
   replicaset: Replicaset
-  uri: String!
   alias: String
-  disabled: Boolean
+  uri: String!
+  labels: [Label]
   message: String!
+  disabled: Boolean
 
   """Failover priority within the replica set"""
   priority: Int
-  labels: [Label]
+
+  """
+  Difference between remote clock and the current one. Obtained from the
+  membership module (SWIM protocol). Positive values mean remote clock are ahead
+  of local, and vice versa. In seconds.
+  """
+  clock_delta: Float
 }
 
 """Server information and configuration."""

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -57,6 +57,12 @@ function g.test_uninitialized()
         uri = 'localhost:13301',
         replicaset = box.NULL
     })
+    t.assert_almost_equals(
+        g.server:graphql({
+            query = [[{ servers { uri clock_delta } }]]
+        }).data.servers[1].clock_delta,
+        0, 1e-2
+    )
 
     local replicasets = resp['data']['replicasets']
     t.assert_equals(#replicasets, 0)

--- a/test/integration/clock_delta_test.lua
+++ b/test/integration/clock_delta_test.lua
@@ -1,0 +1,91 @@
+local log = require('log')
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('clock_delta')
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+g.before_all = function()
+    g.servers = {}
+    for i = 1, 3 do
+        g.servers[i] = helpers.Server:new({
+            workdir = fio.tempdir(),
+            alias = 's' .. tostring(i),
+            command = test_helper.server_command,
+            replicaset_uuid = helpers.uuid('a'),
+            instance_uuid = helpers.uuid('a', 'a', i),
+            http_port = 8080 + i,
+            cluster_cookie = 'test-cluster-cookie',
+            advertise_port = ({13301, 13303, 13305})[i],
+            env = {
+                ['CLOCK_DELTA'] = ({0, -7, 3})[i]
+            }
+        })
+        g.servers[i]:start()
+    end
+
+    for _, server in pairs(g.servers) do
+        t.helpers.retrying({timeout = 5}, function()
+            server:connect_net_box()
+        end)
+        server.net_box:eval([[
+            local fiber = require('fiber')
+            local _time64 = fiber.time64
+            local delta = tonumber(os.getenv('CLOCK_DELTA'))
+            function fiber.time64()
+                return _time64() + delta * 1e6
+            end
+        ]])
+    end
+end
+
+g.after_all = function()
+    for _, server in pairs(g.servers) do
+        server:stop()
+        fio.rmtree(server.workdir)
+    end
+end
+
+function g.test_clock_delta()
+    g.servers[1].net_box:eval([[
+        local membership = require('membership')
+        for _, uri in pairs({...}) do
+            assert(membership.probe_uri(uri))
+        end
+    ]], {
+        g.servers[2].advertise_uri,
+        g.servers[3].advertise_uri,
+    })
+
+    -- full mesh isn't established yet
+    local resp = g.servers[2]:graphql({
+        query = [[{ servers { uri clock_delta } }]]
+    }).data.servers
+    t.assert_equals(#resp, 2)
+
+    for i, observer in pairs(g.servers) do
+        ::retry::
+        log.info('Observing servers[%s]', i, observer.advertise_uri)
+        local resp = observer:graphql({
+            query = [[{ servers { uri clock_delta } }]]
+        }).data.servers
+        for _, peer in pairs(g.servers) do
+            local clock_delta = test_helper.table_find_by_attr(
+                resp, 'uri', peer.advertise_uri
+            ).clock_delta
+            if clock_delta == nil then
+                observer.net_box:eval([[
+                    local membership = require('membership')
+                    assert(membership.probe_uri(...))
+                ]], {peer.advertise_uri})
+                goto retry
+            end
+            t.assert_almost_equals(
+                clock_delta,
+                peer.env.CLOCK_DELTA - observer.env.CLOCK_DELTA, 1e-2,
+                string.format("Observer %s, peer %s", observer.alias, peer.alias)
+            )
+        end
+    end
+end


### PR DESCRIPTION
Provide `clock_delta` in GraphQL `servers` query and in `admin.get_servers()` Lua API.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #301
