### PR TITLE
Fix ambiguity in multifile patch_clusterwide

### DIFF
--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -219,6 +219,7 @@ local function _clusterwide(patch)
             clusterwide_config_new:set_plaintext(k, v)
         else
             if not string.endswith(k, '.yml') then
+                clusterwide_config_new:set_plaintext(k, box.NULL)
                 k = k .. '.yml'
             end
 

--- a/test/integration/config_test.lua
+++ b/test/integration/config_test.lua
@@ -235,6 +235,14 @@ test_remotely('test_patch_clusterwide', function()
 
     --------------------------------------------------------------------
     local ok, err = _patch({
+        ['data'] = "friday",
+    })
+    t.assert_equals(err, nil)
+    t.assert_equals(ok, true)
+    t.assert_equals(_get_ro('data'), 'friday')
+
+    --------------------------------------------------------------------
+    local ok, err = _patch({
         ['data'] = {today = "friday"},
     })
     t.assert_equals(err, nil)


### PR DESCRIPTION
The following two calls sequence is valid and shouldn't be considered ambiguous:

```lua
patch_clusterwide({data = "STRING"})
patch_clusterwide({
    data = {__file: "data.txt"},
    ["data.txt"] = "STRING",
})
```

I didn't forget about

- [x] Tests
- [ ] Changelog (unnecessary)
- [ ] Documentation (unnecessary)