### PR TITLE
Fix race between failover and two-phase commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Race condition when creating working directory.
 
+- Race calling `apply_config` between failover and two-phase commit.
+
 - Don't cache remote-control connection so that `pool.connect` switches
   to the full-featured iproto as soon as it's up.
 

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -195,7 +195,7 @@ local function cfg(clusterwide_config)
 
     local new_mode = topology_cfg.failover and 'eventual' or 'disabled'
     if vars.mode ~= new_mode then
-        log.info('Failover mode set to %q', vars.mode)
+        log.info('Failover mode set to %q', new_mode)
     end
 
     vars.clusterwide_config = clusterwide_config

--- a/test/integration/myrole_failover_test.lua
+++ b/test/integration/myrole_failover_test.lua
@@ -11,28 +11,30 @@ g.before_all = function()
     g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = test_helper.server_command,
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {'myrole'},
-                servers = {
-                    {
-                        alias = 'master',
-                        http_port = 8081,
-                        advertise_port = 13301,
-                        instance_uuid = helpers.uuid('a', 'a', 1)
-                    },
-                    {
-                        alias = 'slave',
-                        http_port = 8082,
-                        advertise_port = 13302,
-                        instance_uuid = helpers.uuid('a', 'a', 2)
-                    }
-                },
+        replicasets = {{
+            uuid = helpers.uuid('a'),
+            roles = {'myrole'},
+            servers = {{
+                alias = 'master',
+                instance_uuid = helpers.uuid('a', 'a', 1)
             },
-        },
+            {
+                alias = 'slave',
+                instance_uuid = helpers.uuid('a', 'a', 2)
+            }},
+        }},
     })
     g.cluster:start()
+
+    g.cluster.main_server:graphql({query = [[
+        mutation {
+            cluster { failover(enabled: true) }
+        }
+    ]]})
+    log.warn('Failover enabled')
+
+    g.master = g.cluster:server('master')
+    g.slave = g.cluster:server('slave')
 end
 
 g.after_all = function()
@@ -41,33 +43,103 @@ g.after_all = function()
 end
 
 function g.test_failover()
-    g.cluster:server('master'):graphql({query = [[
-        mutation {
-            cluster { failover(enabled: true) }
-        }
-    ]]})
-    log.warn('Failover enabled')
+    local function _ro_map()
+        local resp = g.cluster:server('slave'):graphql({query = [[{
+            servers { alias boxinfo { general {ro} } }
+        }]]})
 
-    g.cluster:server('slave').net_box:eval([[
+        local ret = {}
+        for _, srv in pairs(resp.data.servers) do
+            if srv.boxinfo == nil then
+                ret[srv.alias] = box.NULL
+            else
+                ret[srv.alias] = srv.boxinfo.general.ro
+            end
+        end
+
+        return ret
+    end
+
+    --------------------------------------------------------------------
+    g.slave.net_box:eval([[
         assert(package.loaded['mymodule'].is_master() == false)
     ]])
+    t.assert_equals(_ro_map(), {
+        master = false,
+        slave = true,
+    })
 
-    g.cluster:server('master').net_box:eval([[
-        assert(box.cfg.read_only == false)
-    ]])
+    --------------------------------------------------------------------
+    g.master:stop()
+    log.warn('Master killed')
 
-    g.cluster:server('slave').net_box:eval([[
-        assert(box.cfg.read_only == true)
-    ]])
-
-    g.cluster:server('master'):stop()
     t.helpers.retrying({}, function()
-        g.cluster:server('slave').net_box:eval([[
+        g.slave.net_box:eval([[
             assert(package.loaded['mymodule'].is_master() == true)
         ]])
     end)
+    t.assert_equals(_ro_map(), {
+        master = box.NULL,
+        slave = false,
+    })
 
-    g.cluster:server('slave').net_box:eval([[
-        assert(box.cfg.read_only == false)
+    --------------------------------------------------------------------
+    log.warn('Restarting master')
+    g.master:start()
+    g.cluster:retrying({}, function() g.master:connect_net_box() end)
+
+    t.helpers.retrying({}, function()
+        g.slave.net_box:eval([[
+            assert(package.loaded['mymodule'].is_master() == false)
+        ]])
+    end)
+    t.assert_equals(_ro_map(), {
+        master = false,
+        slave = true,
+    })
+end
+
+function g.test_confapplier_race()
+    -- Monkeypatch validate_config to trigger failover
+    -- Monkeypatch apply_config to be slower
+    g.master.net_box:eval('f, arg = ...; loadstring(f)(arg)', {
+        string.dump(function(uri)
+            local myrole = require('mymodule')
+
+            myrole._validate_config_backup = myrole.validate_config
+            myrole.validate_config = function()
+                local member = require('membership').get_member(uri)
+                require('membership.events').generate(
+                    member.uri,
+                    require('membership.options').DEAD,
+                    member.incarnation+1,
+                    member.payload
+                )
+                return true
+            end
+
+            myrole._apply_config_backup = myrole.apply_config
+            myrole.apply_config = function()
+                require('fiber').sleep(0.5)
+            end
+        end),
+        g.slave.advertise_uri
+    })
+
+    -- Trigger patch_clusterwide
+    g.master:graphql({query = [[
+        mutation{ cluster{
+            config(sections: [{filename: "x.txt", content: "XD"}]){}
+        }}
+    ]]})
+
+    g.master.net_box:eval([[
+        local myrole = require('mymodule')
+        if myrole._validate_config_backup ~= nil then
+            myrole.validate_config = myrole._validate_config_backup
+        end
+        if myrole._apply_config_backup ~= nil then
+            myrole.apply_config = myrole._apply_config_backup
+        end
     ]])
 end


### PR DESCRIPTION
Some roles may yield during `apply_config`. Others may take some time
to finish applying configuration.

At that moment two-phase commit may race and return an error.
The sequence is following:

- RolesConfigured
- prepare_2pc() passes
- failover tiriggers
- state changes to ConfiguringRoles
- myrole.apply_config() yields
- commit_2pc() fails

This patch introduces internal method `confapplier.wish_state()` which
tries to satisfy desires state even if it differs at the moment.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #417 
