### PR TITLE
Avoid using netbox.self in RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update `ddl` dependency to 1.0.0.
 
+- Option `{prefer_local=false}` in `rpc_call` avoids netbox.self
+
 ### Removed
 
 - Function `cartridge.bootstrap` is removed. Use `admin_edit_topology`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update `ddl` dependency to 1.0.0.
 
-- Option `{prefer_local=false}` in `rpc_call` avoids netbox.self
+- Option `{prefer_local = false}` in `rpc_call` makes it always use
+  netbox connection, even to connect self. It never tries to perform
+  call locally.
 
 ### Removed
 

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -257,4 +257,3 @@ return {
     get_connection = get_connection,
     call = call_remote,
 }
-

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -145,11 +145,7 @@ local function get_connection(role_name, opts)
         local uri = table.remove(candidates, n)
         num_candidates = num_candidates - 1
 
-        if uri == myself.uri then
-            conn, err = netbox.self, nil
-        else
-            conn, err = pool.connect(uri)
-        end
+        conn, err = pool.connect(uri)
     end
 
     if conn == nil then

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -92,7 +92,7 @@ local function get_candidates(role_name, opts)
         local replicaset_uuid = server.replicaset_uuid
         local replicaset = replicasets[replicaset_uuid]
 
-        if roles.get_enabled_roles(replicaset.roles)[role_name]
+        if roles.get_enabled_roles(replicaset.roles)    [role_name]
         and (not opts.healthy_only or member_is_healthy(server.uri, instance_uuid))
         and (not opts.leader_only or active_leaders[replicaset_uuid] == instance_uuid)
         then
@@ -168,7 +168,8 @@ end
 -- @tparam[opt] table args
 -- @tparam[opt] table opts
 -- @tparam ?boolean opts.prefer_local
---   Don't perform a remote call if possible.
+--   Don't perform a remote call if possible. If this option
+--   is equal false then a call perform in network connection.
 --   (default: **true**)
 -- @tparam ?boolean opts.leader_only
 --   Perform a call only on the replica set leaders.

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -257,3 +257,4 @@ return {
     get_connection = get_connection,
     call = call_remote,
 }
+

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -92,7 +92,7 @@ local function get_candidates(role_name, opts)
         local replicaset_uuid = server.replicaset_uuid
         local replicaset = replicasets[replicaset_uuid]
 
-        if roles.get_enabled_roles(replicaset.roles)    [role_name]
+        if roles.get_enabled_roles(replicaset.roles)[role_name]
         and (not opts.healthy_only or member_is_healthy(server.uri, instance_uuid))
         and (not opts.leader_only or active_leaders[replicaset_uuid] == instance_uuid)
         then
@@ -168,8 +168,11 @@ end
 -- @tparam[opt] table args
 -- @tparam[opt] table opts
 -- @tparam ?boolean opts.prefer_local
---   Don't perform a remote call if possible. If this option
---   is equal false then a call perform in network connection.
+--   Don't perform a remote call if possible. When the role is enabled
+--   locally and current instance is healthy the remote netbox call is
+--   substituted with a local Lua function call. When the option is
+--   disabled it never tries to perform call locally and always uses
+--   netbox connection, even to connect self.
 --   (default: **true**)
 -- @tparam ?boolean opts.leader_only
 --   Perform a call only on the replica set leaders.

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -119,6 +119,13 @@ function g.test_routing()
     t.assert_equals(res.uuid, B2.instance_uuid)
     t.assert_equals(res.peer, B2.net_box:call('box.session.peer'))
 
+    local res, err = rpc_call(B2,
+        'myrole', 'get_session', nil,
+        {prefer_local = false}
+    )
+    t.assert_not(err)
+    t.assert_not_equals(res.peer, B2.net_box:call('box.session.peer'))
+
     -- Test opts.leader_only
     --------------------------------------------------------------------
     local res, err = rpc_call(B2,

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -127,6 +127,7 @@ function g.test_routing()
         {prefer_local = false, leader_only = true}
     )
     t.assert_not(err)
+    t.assert_equals(res.uuid, B1.instance_uuid)
     t.assert_not_equals(res.peer, B1.net_box:call('box.session.peer'))
 
     -- Test opts.leader_only

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -122,7 +122,7 @@ function g.test_routing()
     -- Test opts.leader_only and opts.prefer_local
     --------------------------------------------------------------------
 
-    local res, err = rpc_call(B2,
+    local res, err = rpc_call(B1,
         'myrole', 'get_session', nil,
         {prefer_local = false, leader_only = true}
     )

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -119,12 +119,15 @@ function g.test_routing()
     t.assert_equals(res.uuid, B2.instance_uuid)
     t.assert_equals(res.peer, B2.net_box:call('box.session.peer'))
 
+    -- Test opts.leader_only and opts.prefer_local
+    --------------------------------------------------------------------
+
     local res, err = rpc_call(B2,
         'myrole', 'get_session', nil,
-        {prefer_local = false}
+        {prefer_local = false, leader_only = true}
     )
     t.assert_not(err)
-    t.assert_not_equals(res.peer, B2.net_box:call('box.session.peer'))
+    t.assert_not_equals(res.peer, B1.net_box:call('box.session.peer'))
 
     -- Test opts.leader_only
     --------------------------------------------------------------------


### PR DESCRIPTION
Avoid use `netbox.self` for `{prefer_local=false}` option on `rpc_call`

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #422 
