### PR TITLE
Adjust leader behavior during recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   netbox connection, even to connect self. It never tries to perform
   call locally.
 
+- After an old leader restarts it'll try to sync with an active one
+  before taking the leadership again so that failover doesn't switch too
+  early before leader finishes recovery. If replication setup fails the
+  instance enters the `OperationError` state, which can be avoided by
+  explicitly specifying `replication_connect_quorum = 1` (or 0).
+
 ### Removed
 
 - Function `cartridge.bootstrap` is removed. Use `admin_edit_topology`

--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -920,8 +920,10 @@ local function join_server(args)
         if (member ~= nil)
         and (member.status == 'alive')
         and (member.payload.uuid == args.instance_uuid)
-        and (member.payload.error == nil)
-        then
+        and (
+            member.payload.state == 'ConfiguringRoles' or
+            member.payload.state == 'RolesConfigured'
+        ) then
             conn = pool.connect(args.uri)
         end
     end

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -533,10 +533,11 @@ local function cluster_is_healthy()
                 '%s uuid mismatch: expected %s, have %s',
                 server.uri, instance_uuid, member.payload.uuid
             )
-        elseif (member.payload.error ~= nil) then
+        elseif member.payload.state ~= 'ConfiguringRoles'
+        and member.payload.state ~= 'RolesConfigured' then
             return nil, string.format(
-                '%s: %s',
-                server.uri, member.payload.error
+                '%s state %s',
+                server.uri, member.payload.state
             )
         end
     end


### PR DESCRIPTION
Adjust leader recovery behavior

* After restart don't take leadership until replication is synced
* If replication setup fails enter OperationError state
* Orphan state can be avoided by explicitly specifying quorum = 1

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)
