### PR TITLE
Fix errno handling in remote-control

### DIFF
--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -236,7 +236,11 @@ local function communicate(s)
             reply_ok(s, sync, ret)
             return true
         elseif ffi.istype(error_t, ret) then
-            reply_err(s, sync, ret.code, ret.message)
+            local code = ret.code
+            if code == nil and ret.errno ~= nil then
+                code = box.error.SYSTEM
+            end
+            reply_err(s, sync, code, ret.message)
             return true
         else
             reply_err(s, sync, box.error.PROC_LUA, tostring(ret))
@@ -260,7 +264,11 @@ local function communicate(s)
             reply_ok(s, sync, ret)
             return true
         elseif ffi.istype(error_t, ret) then
-            reply_err(s, sync, ret.code, ret.message)
+            local code = ret.code
+            if code == nil and ret.errno ~= nil then
+                code = box.error.SYSTEM
+            end
+            reply_err(s, sync, code, ret.message)
             return true
         else
             reply_err(s, sync, box.error.PROC_LUA, tostring(ret))

--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -507,6 +507,16 @@ function g.test_call()
         t.assert_equals(err.message, 'BoxError')
 
         t.assert_not(conn.error)
+
+        local ok, err = pcall(conn.call, conn,
+            'box.ctl.wait_ro', {0.001}
+        )
+        t.assert_not(ok)
+        t.assert_equals(type(err), 'cdata')
+        t.assert_equals(err.code, box.error.SYSTEM)
+        t.assert_equals(err.message, 'timed out')
+
+        t.assert_not(conn.error)
     end
 
     rc_start(13301)
@@ -571,6 +581,14 @@ function g.test_eval()
         t.assert_equals(type(err), 'cdata')
         t.assert_equals(err.code, box.error.PROTOCOL)
         t.assert_equals(err.message, 'BoxError')
+
+        local ok, err = pcall(conn.eval, conn,
+            'box.ctl.wait_ro(0.001)'
+        )
+        t.assert_not(ok)
+        t.assert_equals(type(err), 'cdata')
+        t.assert_equals(err.code, box.error.SYSTEM)
+        t.assert_equals(err.message, 'timed out')
 
         t.assert_not(conn.error)
     end


### PR DESCRIPTION
I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
