### PR TITLE
Code page fixes (1): useless editor area, refetched data

### DIFF
--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -93,8 +93,10 @@ export default class MonacoEditor extends React.Component {
       model = setModelByFile(fileId, language, initialValue)
     }
 
-    //TODO is it ok to always set the same model, or should we check current model?
-    editor.setModel(model)
+    if (editor.getModel() !== model) {
+      editor.setModel(model);
+    }
+
     editor.focus()
 
     if (prevProps.theme !== theme) {

--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -15,9 +15,8 @@ const DEF_CURSOR = {}
 
 export default class MonacoEditor extends React.Component {
   static propTypes = {
-    value: PropTypes.string,
     fileId: PropTypes.string,
-    defaultValue: PropTypes.string,
+    initialValue: PropTypes.string,
     language: PropTypes.string,
     theme: PropTypes.string,
     options: PropTypes.object,
@@ -33,8 +32,7 @@ export default class MonacoEditor extends React.Component {
   };
 
   static defaultProps = {
-    value: null,
-    defaultValue: '',
+    initialValue: '',
     language: 'javascript',
     theme: null,
     options: {},
@@ -131,9 +129,9 @@ export default class MonacoEditor extends React.Component {
   }
 
   initMonaco() {
-    const value =
-      this.props.value !== null ? this.props.value : this.props.defaultValue;
-    const { language, theme, options, overrideServices } = this.props;
+    const {
+      initialValue, language, theme, options, overrideServices
+    } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
       Object.assign(options, this.editorWillMount());
@@ -141,7 +139,7 @@ export default class MonacoEditor extends React.Component {
       this.editor = monaco.editor.create(
         this.containerElement,
         {
-          value,
+          value: initialValue,
           language: 'javascript',
           ...options,
           ...(theme ? { theme } : {})

--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -86,16 +86,17 @@ export default class MonacoEditor extends React.Component {
 
     const { editor } = this;
 
-    let model = getModelByFile(fileId);
-    if (!model) {
-      model = setModelByFile(fileId, language, initialValue)
-    }
+    if (fileId) {
+      let model = getModelByFile(fileId);
+      if (!model) {
+        model = setModelByFile(fileId, language, initialValue)
+      }
 
-    if (editor.getModel() !== model) {
-      editor.setModel(model);
+      if (editor.getModel() !== model) {
+        editor.setModel(model);
+        editor.focus()
+      }
     }
-
-    editor.focus()
 
     if (prevProps.theme !== theme) {
       monaco.editor.setTheme(theme);

--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -87,38 +87,15 @@ export default class MonacoEditor extends React.Component {
     } = this.props;
 
     const { editor } = this;
-    let model = editor.getModel(fileId)
 
-    //TODO: potential bugs here: when go to other page, then return to this (editor) page,
-    // focus last file content (editor area), and wrong model will be used
-    // (write something, then select other file, then return to this file — and it has old content.)
-    if (prevProps.fileId !== fileId) {
-      const existedModel = getModelByFile(fileId)
-      if (!existedModel) {
-        model = setModelByFile(fileId, language, initialValue)
-      } else {
-        model = existedModel
-      }
-      editor.setModel(model)
-      editor.focus()
-    } else {
-      // if (this.props.value !== model.getValue()) {
-      //   this._prevent_trigger_change_event = true;
-      //   this.editor.pushUndoStop();
-      //   model.pushEditOperations(
-      //     [],
-      //     [
-      //       {
-      //         range: model.getFullModelRange(),
-      //         text: value
-      //       }
-      //     ]
-      //   );
-      //   this.editor.pushUndoStop();
-      //   this._prevent_trigger_change_event = false;
-      // }
+    let model = getModelByFile(fileId);
+    if (!model) {
+      model = setModelByFile(fileId, language, initialValue)
     }
 
+    //TODO is it ok to always set the same model, or should we check current model?
+    editor.setModel(model)
+    editor.focus()
 
     if (prevProps.theme !== theme) {
       monaco.editor.setTheme(theme);

--- a/webui/src/pages/Code.js
+++ b/webui/src/pages/Code.js
@@ -144,6 +144,10 @@ class Code extends React.Component<CodeProps, CodeState> {
   }
 
   async componentDidMount() {
+    if (this.props.files.length > 0) {
+      return;
+    }
+
     this.props.dispatch(fetchConfigFiles());
     this.setState(() => ({
       loading: false


### PR DESCRIPTION
### What has been done? Why? What problem is being solved?

- Fixed: empty useless editor area when you return from other page (that is, when <MonacoEditor> is remounted).

- Fixed: files were reset (re-fetched from API) when returning to the "Code" page from another page.
 
- Code cleanup/refactoring

------

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation
