### PR TITLE
Enhance compatibility with old versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Notifications in schema editor WebUI.
 
+- Fix GraphQL `servers` query compatibility with old cartridge versions.
+
 ## [2.0.0] - 2019-12-27
 
 ### Added

--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -86,7 +86,7 @@ local function get_server_info(members, uuid, uri)
         ret.message = string.format('Server status is %q', member.status)
     elseif member.payload.uuid == nil then
         ret.status = 'unconfigured'
-        ret.message = member.payload.state
+        ret.message = member.payload.state or ''
     elseif member.payload.state == 'ConfiguringRoles'
     or member.payload.state == 'RolesConfigured' then
         ret.status = 'healthy'
@@ -98,7 +98,7 @@ local function get_server_info(members, uuid, uri)
         ret.message = member.payload.state
     else
         ret.status = 'warning'
-        ret.message = member.payload.state
+        ret.message = member.payload.state or 'UnknownState'
     end
 
     if member and member.status == 'alive' and member.clock_delta ~= nil then


### PR DESCRIPTION
Old versions didn't have state machine so they didn't disseminate it
with membership, which is used for rendering `servers{ status message }`
GraphQL queries.  Thus GraphQL produced an error 'No value provided for
non-null String "message"'.

This patch adds default values to eliminate the problem and fix WebUI
operabiliy.

I didn't forget about

- [ ] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #460