### PR TITLE
Code page fixes  syntax highlighting by name extention

### DIFF
--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -96,6 +96,10 @@ export default class MonacoEditor extends React.Component {
         editor.setModel(model);
         editor.focus()
       }
+
+      if (prevProps.language !== language) {
+        monaco.editor.setModelLanguage(model, language);
+      }
     }
 
     if (prevProps.theme !== theme) {

--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -145,7 +145,7 @@ export default class MonacoEditor extends React.Component {
         this.containerElement,
         {
           value: initialValue,
-          language: 'javascript',
+          language: language || 'javascript',
           ...options,
           ...(theme ? { theme } : {})
         },

--- a/webui/src/store/reducers/files.reducer.js
+++ b/webui/src/store/reducers/files.reducer.js
@@ -43,13 +43,6 @@ type UpdateObj = {
   saved?: boolean | (FileItem, Object) => boolean,
 }
 
-const toFileItem = (item): FileItem => {
-  return {
-    ...item,
-    loading: false,
-    saved: false
-  }
-}
 
 const ignoreFiles = ['schema.yml']
 

--- a/webui/src/store/reducers/files.reducer.js
+++ b/webui/src/store/reducers/files.reducer.js
@@ -25,7 +25,7 @@ export type FileItem = {
   initialPath?: string,
   parentPath: string,
   fileName: string,
-  initialContent?: string,
+  initialContent?: string | null,
   loading: boolean,
   saved: boolean,
   type: 'file' | 'folder',
@@ -154,7 +154,7 @@ const addFileOrFolder = (list: Array<FileItem>, { parentPath, name }: { parentPa
 
   return [
     ...list,
-    makeFile(parentPath || '', name, type === CREATE_FOLDER)
+    makeFile(parentPath || '', name, type === CREATE_FOLDER, null)
   ];
 }
 

--- a/webui/src/store/reducers/files.reducer.test.js
+++ b/webui/src/store/reducers/files.reducer.test.js
@@ -126,7 +126,7 @@ describe('Creating', () => {
         path: 'file.ext', fileName: 'file.ext',
         parentPath: '',
         type: 'file',
-        initialContent: '',
+        initialContent: null,
         loading: false, saved: false,
         line: 0, column: 0, scrollPosition: 0,
       },
@@ -149,7 +149,7 @@ describe('Creating', () => {
         path: 'folder/folder/newFile.ext', fileName: 'newFile.ext',
         parentPath: parentPath,
         type: 'file',
-        initialContent: '',
+        initialContent: null,
         loading: false, saved: false,
         line: 0, column: 0, scrollPosition: 0,
       }
@@ -177,7 +177,7 @@ describe('Creating', () => {
         path: 'newFile.ext', fileName: 'newFile.ext',
         parentPath: parentPath,
         type: 'file',
-        initialContent: '',
+        initialContent: null,
         loading: false, saved: false,
         line: 0, column: 0, scrollPosition: 0,
       }


### PR DESCRIPTION
### What has been done? Why? What problem is being solved?

- Correct syntax highlighting **after renaming** (corresponds to filename extension)

- Bugfix: new file used to lose the **red dot** indicator, if its content was edited and then deleted 

-----
I didn't forget about
- [x] Tests

- [x] Changelog (not now but already in the coming pull requests))
- [ ] Documentation