### PR TITLE
Fix 2pc backward compatibility with 1.2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,19 @@ integration-ce-2.2:
     IMAGE_NAME: *IMAGE_NAME_CE_2_2
   when: manual
 
+compatibility:
+  <<: *test-template
+  variables:
+    IMAGE_NAME: *IMAGE_NAME_EE
+    CARTRIDGE_ELDER_PATH: /tmp/cartridge-1.2.0
+  before_script:
+    - tarantoolctl rocks make
+    - mkdir -p $CARTRIDGE_ELDER_PATH
+    - cd $CARTRIDGE_ELDER_PATH
+    - tarantoolctl rocks install cartridge 1.2.0-1
+  script:
+    - luatest -v -c -p compatibility.upgrade
+
 cypress:
   <<: *test-template
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,14 +119,13 @@ compatibility:
   <<: *test-template
   variables:
     IMAGE_NAME: *IMAGE_NAME_EE
-    CARTRIDGE_ELDER_PATH: /tmp/cartridge-1.2.0
+    CARTRIDGE_OLDER_PATH: /tmp/cartridge-1.2.0
   before_script:
     - tarantoolctl rocks make
-    - mkdir -p $CARTRIDGE_ELDER_PATH
-    - cd $CARTRIDGE_ELDER_PATH
-    - tarantoolctl rocks install cartridge 1.2.0-1
+    - mkdir -p $CARTRIDGE_OLDER_PATH
+    - (cd $CARTRIDGE_OLDER_PATH; tarantoolctl rocks install cartridge 1.2.0-1)
   script:
-    - luatest -v -c -p compatibility.upgrade
+    - luatest -v -p compatibility.upgrade
 
 cypress:
   <<: *test-template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix GraphQL `servers` query compatibility with old cartridge versions.
 
+- Two-phase commit backward compatibility with v1.2.0.
+
 ## [2.0.0] - 2019-12-27
 
 ### Added

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -438,6 +438,23 @@ _G.__cartridge_clusterwide_config_prepare_2pc = function(...) return errors.pcal
 _G.__cartridge_clusterwide_config_commit_2pc = function(...) return errors.pcall('E', commit_2pc, ...) end
 _G.__cartridge_clusterwide_config_abort_2pc = function(...) return errors.pcall('E', abort_2pc, ...) end
 
+-- Keep backward compatibility with the good old cartridge 1.2.0.
+_G.__cluster_confapplier_prepare_2pc = function(conf)
+    local tempdir = fio.tempdir()
+    local path = fio.pathjoin(tempdir, 'config.yml')
+    local ok, err = utils.file_write(path, yaml.encode(conf))
+    if not ok then
+        return nil, err
+    end
+
+    local clusterwide_config = ClusterwideConfig.load(path)
+    fio.rmtree(tempdir)
+
+    return errors.pcall('E', prepare_2pc, clusterwide_config:get_plaintext())
+end
+_G.__cluster_confapplier_commit_2pc = function(...) return errors.pcall('E', commit_2pc, ...) end
+_G.__cluster_confapplier_abort_2pc = function(...) return errors.pcall('E', abort_2pc, ...) end
+
 return {
     get_schema = get_schema,
     set_schema = set_schema,

--- a/test/compatibility/upgrade_test.lua
+++ b/test/compatibility/upgrade_test.lua
@@ -1,0 +1,209 @@
+local fio = require('fio')
+local log = require('log')
+local yaml = require('yaml')
+local fiber = require('fiber')
+local errors = require('errors')
+local t = require('luatest')
+local g = t.group()
+
+local test_helper = require('test.helper')
+local helpers = require('cartridge.test-helpers')
+
+g.before_all = function()
+    g.tempdir = fio.tempdir()
+end
+
+g.after_all = function()
+    if g.cluster ~= nil then
+        g.cluster:stop()
+    end
+    if g.tempdir ~= nil then
+        fio.rmtree(g.tempdir)
+        g.tempdir = nil
+    end
+end
+
+local function version(srv)
+    local version = srv.net_box:call('require', {'cartridge.VERSION'})
+    local cwd = srv.net_box:call('package.loaded.fio.cwd')
+    log.info('Check %s version: %s (from %s)', srv.alias, version, cwd)
+    return version
+end
+
+local function upstream_info(srv)
+    local info = srv.net_box:call('box.info')
+    for _, v in pairs(info.replication) do
+        if v.uuid ~= srv.instance_uuid then
+            return {
+                status = v.upstream.status,
+                message = v.upstream.message,
+            }
+        end
+    end
+end
+
+local function wish_state(srv, desired_state)
+    g.cluster:retrying({}, function()
+        srv.net_box:eval([[
+            local confapplier = require('cartridge.confapplier')
+            local desired_state = ...
+            local state = confapplier.wish_state(desired_state)
+            assert(
+                state == desired_state,
+                string.format('Inappropriate state %q ~= desired %q',
+                state, desired_state)
+            )
+        ]], {desired_state})
+    end)
+end
+
+--- Test upgrading form old version to the current one
+function g.test_upgrade()
+    local cartridge_elder_path = os.getenv('CARTRIDGE_ELDER_PATH')
+    t.skip_if(
+        cartridge_elder_path == nil,
+        'No elder version provided. Skipping'
+    )
+
+    g.cluster = helpers.Cluster:new({
+        datadir = g.tempdir,
+        server_command = fio.pathjoin(
+            test_helper.root, 'test', 'integration', 'srv_basic.lua'
+        ),
+        use_vshard = true,
+        cookie = 'test-cluster-cookie',
+        replicasets = {{
+            uuid = helpers.uuid('a'),
+            roles = {'vshard-router', 'vshard-storage'},
+            servers = {{
+                alias = 'leader',
+                instance_uuid = helpers.uuid('a', 'a', 1),
+                advertise_port = 13301,
+                http_port = 8081,
+                chdir = cartridge_elder_path,
+            }, {
+                alias = 'replica',
+                instance_uuid = helpers.uuid('a', 'a', 2),
+                advertise_port = 13302,
+                http_port = 8082,
+                chdir = cartridge_elder_path,
+            }},
+        }}
+    })
+
+    local leader = g.cluster:server('leader')
+    local replica = g.cluster:server('replica')
+    g.cluster.main_server = leader
+    for _, srv in pairs(g.cluster.servers) do
+        require('luatest.server').start(srv)
+        g.cluster:retrying({}, function() srv:graphql({query = '{}'}) end)
+        srv:join_cluster(g.cluster.main_server)
+        g.cluster:retrying({}, function() srv:connect_net_box() end)
+    end
+    g.cluster.main_server:setup_replicaset(g.cluster.replicasets[1])
+    g.cluster:bootstrap_vshard()
+    g.cluster:wait_until_healthy()
+
+    t.assert_not_equals(version(leader), 'scm-1')
+    t.assert_not_equals(version(replica), 'scm-1')
+
+    -- Setup data model
+    leader.net_box:eval([[
+        box.schema.space.create('test', {
+            format = {
+                {name = 'bucket_id', type = 'unsigned', is_nullable = false},
+                {name = 'record_id', type = 'unsigned', is_nullable = false},
+                {name = 'alias', type = 'string', is_nullable = false},
+            }
+        })
+
+        box.space.test:create_index('primary', {
+            unique = true,
+            parts = {{'record_id', 'unsigned', is_nullable = false}},
+        })
+        box.space.test:create_index('bucket_id', {
+            unique = false,
+            parts = {{'bucket_id', 'unsigned', is_nullable = false}},
+        })
+    ]])
+
+    -- Start streaming
+    local reference = {}
+    local function _insert(cnt)
+        local ret, err = g.cluster.main_server.net_box:eval([[
+            return package.loaded.vshard.router.callrw(
+                1, 'box.space.test:insert', {{1, ...}}
+            )
+        ]], {cnt, g.cluster.main_server.alias})
+
+        if ret == nil then
+            log.error('CNT %d: %s', cnt, yaml.encode(err))
+        else
+            table.insert(reference, ret)
+        end
+        return true
+    end
+    local highload_cnt = 0
+
+
+    local highload_fiber = fiber.new(function()
+        log.warn('Highload started >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>')
+        while true do
+            highload_cnt = highload_cnt + 1
+            local ok, err = errors.pcall('E', _insert, highload_cnt)
+            if ok == nil then
+                log.error('CNT %d: %s', highload_cnt, err)
+            end
+            fiber.sleep(0.01)
+        end
+    end)
+    highload_fiber:name('test.highload')
+    fiber.sleep(0.2)
+
+    -- Upgrade replica
+    replica:stop()
+    replica.chdir = nil
+    replica:start()
+    g.cluster:retrying({}, function() replica:connect_net_box() end)
+    wish_state(replica, 'RolesConfigured')
+
+    t.assert_not_equals(version(leader), 'scm-1')
+    t.assert_equals(version(replica), 'scm-1')
+    t.assert_equals(upstream_info(replica), {status = 'follow'})
+
+    -- Switch the leadership
+    leader.net_box:eval([[
+        local errors = require('errors')
+        local cartridge = require('cartridge')
+        errors.assert('E', cartridge.admin_edit_topology(...))
+    ]], {{
+        replicasets = {{
+            uuid = leader.replicaset_uuid,
+            failover_priority = {replica.instance_uuid},
+        }}
+    }})
+    g.cluster.main_server = replica
+
+    fiber.sleep(0.2)
+
+    -- Upgrade leader
+    leader:stop()
+    leader.chdir = nil
+    leader:start()
+    g.cluster:retrying({}, function() leader:connect_net_box() end)
+    g.cluster:wait_until_healthy()
+
+    t.assert_equals(version(leader), 'scm-1')
+    t.assert_equals(version(replica), 'scm-1')
+    t.assert_equals(upstream_info(leader), {status = 'follow'})
+
+    highload_fiber:cancel()
+    t.assert_equals(
+        g.cluster.main_server.net_box:call(
+            'package.loaded.vshard.router.callrw', {
+                1, 'box.space.test:select'
+            }
+        ),
+        reference
+    )
+end


### PR DESCRIPTION
To update cartridge without downtime it's necessary to perform rolling
upgrade: restart half a cluster with new version, switch leaders, then
restart the other half.

In #331 we've changed naming of two-phase commit internal functions,
so compatibility between old and new version was broken and it was
impossible to switch the leadership during upgrade.

This patch brings the compatibility back and covers rolling upgrade
scenario with luatest.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)
