### PR TITLE
Gh 451 check cluster cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New option in `rpc_call(..., {uri=...})` to perform a call
   on a particular uri.
 
+- New check for content of `cluster_cookie`. Correct symbols for
+  content are latin letters, digits and \.\_-~
 ### Changed
 
 - `cartridge.rpc_get_candidates()` doesn't return error "No remotes with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - DDL failure if spaces is `null` in input schema.
 
+- Content of `cluster_cookie` is checked for absence of special
+  characters so it doesn't break the authotization.
+  Allowed symbols are `[a-zA-Z0-9_.~-]`.
+
 ## [2.0.1] - 2020-01-15
 
 ### Added
@@ -50,8 +54,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New option in `rpc_call(..., {uri=...})` to perform a call
   on a particular uri.
 
-- New check for content of `cluster_cookie`. Correct symbols for
-  content are latin letters, digits and \.\_-~
 ### Changed
 
 - `cartridge.rpc_get_candidates()` doesn't return error "No remotes with

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -125,6 +125,8 @@ end
 -- @tparam ?string opts.cluster_cookie
 --  secret used to separate unrelated applications, which
 --  prevents them from seeing each other during broadcasts.
+--  It can only consist of latin letters, digits
+--  or symbols there are '_', '-', '~', '.'.
 --  Also used for encrypting internal communication.
 --  (default: "secret-cluster-cookie", overridden by
 --  env `TARANTOOL_CLUSTER_COOKIE`,

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -125,9 +125,9 @@ end
 -- @tparam ?string opts.cluster_cookie
 --  secret used to separate unrelated applications, which
 --  prevents them from seeing each other during broadcasts.
---  It can only consist of latin letters, digits
---  or symbols there are '_', '-', '~', '.'.
---  Also used for encrypting internal communication.
+--  Also used as admin password in HTTP and binary connections and for
+--  encrypting internal communications.
+--  Allowed symbols are `[a-zA-Z0-9_.~-]`.
 --  (default: "secret-cluster-cookie", overridden by
 --  env `TARANTOOL_CLUSTER_COOKIE`,
 --  args `--cluster-cookie`)

--- a/cartridge/cluster-cookie.lua
+++ b/cartridge/cluster-cookie.lua
@@ -96,6 +96,10 @@ local function set_cookie(value)
     if #value > 256 then
         error('Could not set cluster cookie with length more than 256')
     end
+    local bad_symbols = string.match(value, '[^%w%-%.~_]+')
+    if bad_symbols ~= nil then
+        error('Invalid symbol "' .. bad_symbols .. '" in cluster cookie')
+    end
 
     write_file(fio.pathjoin(M.workdir, COOKIEFILE), value)
 

--- a/cartridge/cluster-cookie.lua
+++ b/cartridge/cluster-cookie.lua
@@ -88,17 +88,20 @@ end
 
 local function set_cookie(value)
     if M.workdir == nil then
-        error('Cluster cookie not initialized')
+        error('Cluster cookie not initialized', 2)
     end
     if value == nil then
-        error('Could not set nil cluster cookie')
+        error('Could not set nil cluster cookie', 2)
     end
     if #value > 256 then
-        error('Could not set cluster cookie with length more than 256')
+        error('Could not set cluster cookie with length more than 256', 2)
     end
+
     local bad_symbols = string.match(value, '[^%w%-%.~_]+')
     if bad_symbols ~= nil then
-        error('Invalid symbol "' .. bad_symbols .. '" in cluster cookie')
+        error(string.format(
+            'Invalid symbol %q in cluster cookie', bad_symbols
+        ), 2)
     end
 
     write_file(fio.pathjoin(M.workdir, COOKIEFILE), value)

--- a/test/unit/cluster_cookie_test.lua
+++ b/test/unit/cluster_cookie_test.lua
@@ -1,0 +1,32 @@
+#!/usr/bin/env tarantool
+
+local fio = require('fio')
+
+local t = require('luatest')
+local g = t.group()
+
+local cluster_cookie = require('cartridge.cluster-cookie')
+
+function g.before_all()
+    g.tempdir = fio.tempdir()
+end
+
+function g.after_all()
+    fio.rmtree(g.tempdir)
+end
+
+function g.test_set_cookie()
+	cluster_cookie.init(g.tempdir)
+
+	cluster_cookie.set_cookie('abcd')
+	cluster_cookie.set_cookie('ABCD')
+	cluster_cookie.set_cookie('1234')
+	cluster_cookie.set_cookie('-_.~')
+	cluster_cookie.set_cookie('abcdABCD1234-_.~')
+
+	local err_msg = 'Invalid symbol "%s" in cluster cookie'
+	t.assert_error_msg_contains(string.format(err_msg, 'Ы'), cluster_cookie.set_cookie, 'Ы')
+	t.assert_error_msg_contains(string.format(err_msg, '@'), cluster_cookie.set_cookie, '@')
+	t.assert_error_msg_contains(string.format(err_msg, ':'), cluster_cookie.set_cookie, ':a')
+	t.assert_error_msg_contains(string.format(err_msg, '$'), cluster_cookie.set_cookie, 'a$')
+end

--- a/test/unit/cluster_cookie_test.lua
+++ b/test/unit/cluster_cookie_test.lua
@@ -16,17 +16,23 @@ function g.after_all()
 end
 
 function g.test_set_cookie()
-	cluster_cookie.init(g.tempdir)
+    cluster_cookie.init(g.tempdir)
 
-	cluster_cookie.set_cookie('abcd')
-	cluster_cookie.set_cookie('ABCD')
-	cluster_cookie.set_cookie('1234')
-	cluster_cookie.set_cookie('-_.~')
-	cluster_cookie.set_cookie('abcdABCD1234-_.~')
+    cluster_cookie.set_cookie('abcdABCD1234_.~-')
 
-	local err_msg = 'Invalid symbol "%s" in cluster cookie'
-	t.assert_error_msg_contains(string.format(err_msg, 'Ы'), cluster_cookie.set_cookie, 'Ы')
-	t.assert_error_msg_contains(string.format(err_msg, '@'), cluster_cookie.set_cookie, '@')
-	t.assert_error_msg_contains(string.format(err_msg, ':'), cluster_cookie.set_cookie, ':a')
-	t.assert_error_msg_contains(string.format(err_msg, '$'), cluster_cookie.set_cookie, 'a$')
+    local _assert = t.assert_error_msg_equals
+    local _set = cluster_cookie.set_cookie
+    _assert([[Invalid symbol "\13" in cluster cookie]], _set, '\r')
+    _assert([[Invalid symbol "\"" in cluster cookie]], _set, '"')
+    _assert([[Invalid symbol "'" in cluster cookie]], _set, "'")
+    _assert([[Invalid symbol "😎!" in cluster cookie]], _set, '😎!')
+    _assert([[Invalid symbol "Ы" in cluster cookie]], _set, 'Ы')
+    _assert([[Invalid symbol "@" in cluster cookie]], _set, '@')
+    _assert([[Invalid symbol ":" in cluster cookie]], _set, ':a')
+    _assert([[Invalid symbol "%%" in cluster cookie]], _set, '0%%1')
+    _assert([[Invalid symbol "$" in cluster cookie]], _set, 'a$')
+    _assert([[Could not set nil cluster cookie]], _set, nil)
+    _assert([[Could not set cluster cookie with length more than 256]],
+        _set, string.rep('x', 257)
+    )
 end


### PR DESCRIPTION
Add cheсk for `cluste_cookie` content which doesn't contain special symbols (shoud contains only latin letters or digits) 

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #451 
