### PR TITLE
Update errors module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   long. During instance recovery remote-controll won't accept any
   connections: clients wait for box.cfg to finish recvovery.
 
+- Update errors rock dependency to 2.1.2: eliminate duplicate stack
+  trace from `error.str` field.
+
 ## [2.0.1] - 2020-01-15
 
 ### Added

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     'http == 1.0.5-1',
     'checks == 3.0.1-1',
     'lulpeg == 0.1.2-1',
-    'errors == 2.1.1-1',
+    'errors == 2.1.2-1',
     'vshard == 0.1.14-1',
     'membership == 2.2.0-1',
     'frontend-core == 6.2.0-1',

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -81,7 +81,7 @@ function g.test_errors()
     t.assert_not(res)
     t.assert_equals(err.err, 'Boo')
     t.assert_equals(err.class_name, 'RemoteCallError')
-    t.assert_str_icontains(err.str, 'during net.box call to localhost:13302')
+    t.assert_str_contains(err.stack, 'during net.box call to localhost:13302')
 
     local res, err = rpc_call(
         g.cluster:server('B1'), 'myrole', 'throw', {'Moo'}, {leader_only=true}
@@ -89,7 +89,7 @@ function g.test_errors()
     t.assert_not(res)
     t.assert_equals(err.err, 'Moo')
     t.assert_equals(err.class_name, 'RemoteCallError')
-    t.assert_not_str_icontains(err.str, 'during net.box call')
+    t.assert_not_str_contains(err.stack, 'during net.box call')
 end
 
 function g.test_routing()


### PR DESCRIPTION
Update errors rock dependency to 2.1.2: eliminate duplicate stack trace in `error.str` field.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Related to #428
