### PR TITLE
Make GraphQL errors prettier

### DIFF
--- a/cartridge/graphql.lua
+++ b/cartridge/graphql.lua
@@ -295,7 +295,11 @@ local function _execute_graphql(req)
             and err.file ~= nil
             and err.class_name ~= nil
         ) then
-            err = e_graphql_execute:new('%s', err or "Unknown error")
+            err = e_graphql_execute:new(err or "Unknown error")
+        end
+
+        if type(err.err) ~= 'string' then
+            err.err = json.encode(err.err)
         end
 
         log.error('%s', err)
@@ -303,7 +307,7 @@ local function _execute_graphql(req)
         -- Specification: https://spec.graphql.org/June2018/#sec-Errors
         return http_finalize({
             errors = {{
-                message = tostring(err.err),
+                message = err.err,
                 extensions = {
                     ['io.tarantool.errors.class_name']  = err.class_name,
                     ['io.tarantool.errors.stack'] = err.stack,


### PR DESCRIPTION
Sometimes GraphQL can return custom table instead of an error.
This case is handled properly now (using json.encode) and covered
with tests.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Follow-up for #491 
