### PR TITLE
Tweak PHP example in DemoInfo.js

### DIFF
--- a/webui/src/components/DemoInfo.js
+++ b/webui/src/components/DemoInfo.js
@@ -72,9 +72,11 @@ composer require tarantool/client
 
 \`\`\`php
 <?php
-include_once('vendor/autoload.php');
+
 use Tarantool\\Client\\Client;
 use Tarantool\\Client\\Schema\\Criteria;
+
+require __DIR__ . '/vendor/autoload.php';
 
 $client = Client::fromDsn(':demo_uri:');
 $space = $client->getSpace('customer');
@@ -82,13 +84,12 @@ $space->insert([222, 'Michael Bryan']);
 $result = $space->select(Criteria::index(0));
 
 print_r($result);
-?>
 \`\`\`
 
 **Run** the script
   
 \`\`\`bash
-php -f example.php
+php example.php
 \`\`\`
 `,
     decomposed: false


### PR DESCRIPTION
The PHP example is adjusted to follow the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style recommendations. Besides, `include_once()` with a relative path is replaced with `require __DIR__` to match composer's [documentation](https://getcomposer.org/doc/01-basic-usage.md#autoloading). Also, the `-f` flag in the CLI command is not necessary, so it's removed.