### PR TITLE
Tweak PHP example in DemoInfo.js

### DIFF
--- a/webui/src/components/DemoInfo.js
+++ b/webui/src/components/DemoInfo.js
@@ -78,10 +78,10 @@ use Tarantool\\Client\\Schema\\Criteria;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$client = Client::fromDsn(':demo_uri:');
+$client = Client::fromDsn('tcp://:demo_uri:');
 $space = $client->getSpace('customer');
 $space->insert([222, 'Michael Bryan']);
-$result = $space->select(Criteria::index(0));
+$result = $space->select(Criteria::key([222]));
 
 print_r($result);
 \`\`\`


### PR DESCRIPTION
Provide a [valid DSN connection string](https://github.com/tarantool-php/client#dsn-string) and limit the number of tuples returned by `select()`.

More details [here](https://github.com/tarantool/cartridge/pull/498#issuecomment-578044206) and [here](https://github.com/tarantool/cartridge/pull/498#issuecomment-577909320).