### PR TITLE
Fixes #496: new files that never opened could not be saved

### DIFF
--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -83,10 +83,6 @@ local function cypress_run(spec)
     t.assert_equals(code, 0)
 end
 
-function g.test_code()
-    cypress_run('code.spec.js')
-end
-
 function g.test_default_group()
     g.cluster.main_server:graphql({
         query = [[mutation {
@@ -133,6 +129,16 @@ end
 
 function g.test_schema_editor()
     cypress_run('schema-editor.spec.js')
+end
+
+function g.test_code()
+    local code = os.execute(
+        "cd webui && npx cypress run --spec" ..
+        ' cypress/integration/code-empty-page.spec.js' ..
+        ' cypress/integration/code-file-in-tree.spec.js' ..
+        ' cypress/integration/code-folder-in-tree.spec.js'
+    )
+    t.assert_equals(code, 0)
 end
 
 function g.test_uninitialized()

--- a/webui/cypress/integration/code-empty-page.spec.js
+++ b/webui/cypress/integration/code-empty-page.spec.js
@@ -1,0 +1,13 @@
+describe('Code page', () => {
+
+    it('Empty code page', () => {
+      const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
+      //const defaultText = 'Please select a file';
+  
+      cy.visit(Cypress.config('baseUrl')+"/admin/cluster/code");
+      cy.get('#root').contains('Please select a file');
+      cy.get('button[type="button"]').contains('Apply').click();
+      cy.get('#root').contains('Files successfuly applied');
+    });
+  });
+  

--- a/webui/cypress/integration/code-file-in-tree.spec.js
+++ b/webui/cypress/integration/code-file-in-tree.spec.js
@@ -98,6 +98,7 @@ describe('Code page', () => {
       cy.get('.ScrollbarsCustom-Content').contains('edited-file-name2');
       //apply
       cy.get('.meta-test__deleteFolderInTreeBtn').eq(0).click({ force: true });
+      cy.get('.meta-test__deleteModal').should('be.visible');
       cy.get('.meta-test__deleteModal button[type="button"]').contains('Ok').click();
       cy.get('button[type="button"]').contains('Apply').click();
       cy.get('button[type="button"]').contains('Reload').click();

--- a/webui/cypress/integration/code-file-in-tree.spec.js
+++ b/webui/cypress/integration/code-file-in-tree.spec.js
@@ -77,6 +77,7 @@ describe('Code page', () => {
        //file contents
       cy.get('.ScrollbarsCustom-Content').contains('edited-file-name2').click();
       cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
+      cy.get('.monaco-editor textarea').type('a{backspace}'); //без этого не работает
       cy.get('.monaco-editor textarea').should('have.value', '');
    
       cy.get('button[type="button"]').contains('Reload').click();

--- a/webui/cypress/integration/code-file-in-tree.spec.js
+++ b/webui/cypress/integration/code-file-in-tree.spec.js
@@ -1,34 +1,25 @@
-describe('Code page: files', () => {
+describe('Code page', () => {
 
-    it('Empty code page', () => {
+    it('File in tree', () => {
       const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
-      //const defaultText = 'Please select a file';
   
       cy.visit(Cypress.config('baseUrl')+"/admin/cluster/code");
-      cy.get('#root').contains('Please select a file');
-      cy.get('button[type="button"]').contains('Apply').click();
-      cy.get('#root').contains('Files successfuly applied');
-    });
-  
-  it('File in tree', () => {
-      const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
-  
+
   //create file and file contents
       cy.get('.meta-test__addFileBtn').click();
-      cy.get('.meta-test__enterName').focused().type('file-in-tree1{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree1').click();
+      cy.get('.meta-test__enterName').focused().type('file-in-tree{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree');
       //reload
       cy.get('button[type="button"]').contains('Reload').click();
       cy.get('button[type="button"]').contains('Ok').click();
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree1').should('not.exist');
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree').should('not.exist');
       //apply
       cy.get('.meta-test__addFileBtn').click();
       cy.get('.meta-test__enterName').focused().type('file-in-tree2{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree2').click();
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree2');
       cy.get('button[type="button"]').contains('Apply').click();
       cy.get('button[type="button"]').contains('Reload').click();
       cy.get('button[type="button"]').contains('Ok').click();
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-tree2');
       //file contents
       cy.get('.ScrollbarsCustom-Content').contains('file-in-tree2').click();
       cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
@@ -52,7 +43,7 @@ describe('Code page: files', () => {
   //edit file and file contents
       cy.get('.meta-test__editFolderInTreeBtn').eq(0).click({ force: true });
       cy.get('.meta-test__enterName').focused().clear().type('edited-file-name{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('edited-file-name').click();
+      cy.get('.ScrollbarsCustom-Content').contains('edited-file-name');
       //reload
       cy.get('button[type="button"]').contains('Reload').click();
       cy.get('button[type="button"]').contains('Ok').click();
@@ -112,43 +103,6 @@ describe('Code page: files', () => {
       cy.get('button[type="button"]').contains('Reload').click();
       cy.get('button[type="button"]').contains('Ok').click();
       cy.get('.ScrollbarsCustom-Content').contains('edited-file-name2').should('not.exist');
-       });
-  
-    it('Folder in tree', () => {
-  //create folder
-      cy.get('.meta-test__addFolderBtn').click();
-      cy.get('.meta-test__enterName').focused().type('folder-in-tree{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('folder-in-tree');
-  //create folder in folder
-      cy.get('.meta-test__createFolderInTreeBtn').click({ force: true });
-      cy.get('.meta-test__enterName').focused().type('folder-in-folder{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('folder-in-folder');
-  //create file in folder
-      cy.get('.meta-test__createFileInTreeBtn').eq(0).click({ force: true });
-      cy.get('.meta-test__enterName').focused().type('file-in-folder{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').click();
-      cy.get('#root').contains('folder-in-tree/file-in-folder');
-      cy.get('.monaco-editor textarea').type('new test code');
-  
-  //edit folder name
-      cy.get('.meta-test__editFolderInTreeBtn').eq(0).click({ force: true });
-      cy.get('.meta-test__enterName').focused().clear().type('edited-folder-name{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').click();
-  
-  //save changes and full reload code page
-      cy.get('button[type="button"]').contains('Apply').click();
-      cy.reload();
-      cy.get('#root').contains('edited-folder-name').click();
-      cy.get('.ScrollbarsCustom-Content').contains('folder-in-folder').should('not.exist');
-      cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').click();
-      cy.get('#root').contains('edited-folder-name/file-in-folder');
-      cy.get('.monaco-editor textarea').should('have.value', 'new test code');
-  
-  //delete folder
-      cy.get('.meta-test__deleteFolderInTreeBtn').eq(0).click({ force: true });
-      cy.get('.meta-test__deleteModal button[type="button"]').contains('Ok').click();
-      cy.get('button[type="button"]').contains('Apply').click();
-      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').should('not.exist');
     });
-  });
+});
   

--- a/webui/cypress/integration/code-folder-in-tree.spec.js
+++ b/webui/cypress/integration/code-folder-in-tree.spec.js
@@ -1,0 +1,41 @@
+describe('Code page', () => {
+
+    it('Folder in tree', () => {
+      cy.visit(Cypress.config('baseUrl')+"/admin/cluster/code");
+  //create folder
+      cy.get('.meta-test__addFolderBtn').click();
+      cy.get('.meta-test__enterName').focused().type('folder-in-tree{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('folder-in-tree');
+  //create folder in folder
+      cy.get('.meta-test__createFolderInTreeBtn').click({ force: true });
+      cy.get('.meta-test__enterName').focused().type('folder-in-folder{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('folder-in-folder');
+  //create file in folder
+      cy.get('.meta-test__createFileInTreeBtn').eq(0).click({ force: true });
+      cy.get('.meta-test__enterName').focused().type('file-in-folder{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').click();
+      cy.get('#root').contains('folder-in-tree/file-in-folder');
+      cy.get('.monaco-editor textarea').type('new test code');
+  
+  //edit folder name
+      cy.get('.meta-test__editFolderInTreeBtn').eq(0).click({ force: true });
+      cy.get('.meta-test__enterName').focused().clear().type('edited-folder-name{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').click();
+  
+  //save changes and full reload code page
+      cy.get('button[type="button"]').contains('Apply').click();
+      cy.reload();
+      cy.get('#root').contains('edited-folder-name').click();
+      cy.get('.ScrollbarsCustom-Content').contains('folder-in-folder').should('not.exist');
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').click();
+      cy.get('#root').contains('edited-folder-name/file-in-folder');
+      cy.get('.monaco-editor textarea').should('have.value', 'new test code');
+  
+  //delete folder
+      cy.get('.meta-test__deleteFolderInTreeBtn').eq(0).click({ force: true });
+      cy.get('.meta-test__deleteModal button[type="button"]').contains('Ok').click();
+      cy.get('button[type="button"]').contains('Apply').click();
+      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').should('not.exist');
+    });
+  });
+  

--- a/webui/cypress/integration/code-folder-in-tree.spec.js
+++ b/webui/cypress/integration/code-folder-in-tree.spec.js
@@ -33,6 +33,7 @@ describe('Code page', () => {
   
   //delete folder
       cy.get('.meta-test__deleteFolderInTreeBtn').eq(0).click({ force: true });
+      cy.get('.meta-test__deleteModal').should('be.visible');
       cy.get('.meta-test__deleteModal button[type="button"]').contains('Ok').click();
       cy.get('button[type="button"]').contains('Apply').click();
       cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').should('not.exist');

--- a/webui/src/store/saga/files.saga.js
+++ b/webui/src/store/saga/files.saga.js
@@ -34,7 +34,7 @@ function* applyFilesSaga() {
 
       // We don't keep all content in Redux store anymore. Get it from Monaco models:
       const contentIfEdited = getModelValueByFile(getFileIdForMonaco(fileId));
-      const content = contentIfEdited !== null ? contentIfEdited : initialContent;
+      const content = (contentIfEdited !== null ? contentIfEdited : initialContent) || '';
 
       if (type === 'file') {
         if (initialContent !== '' || saved) { // Filter new files


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Bugfix. Close #496
(The sending file content now defaults to '' (empty string), not null)