### PR TITLE
Create file/folder when input loses focus

### DIFF
--- a/webui/cypress/integration/code-file-in-tree.spec.js
+++ b/webui/cypress/integration/code-file-in-tree.spec.js
@@ -7,7 +7,8 @@ describe('Code page', () => {
 
   //create file and file contents
       cy.get('.meta-test__addFileBtn').click();
-      cy.get('.meta-test__enterName').focused().type('file-in-tree{enter}');
+      cy.get('.meta-test__enterName').focused().type('file-in-tree');
+      cy.get('#root').contains('Tarantool').click();
       cy.get('.ScrollbarsCustom-Content').contains('file-in-tree');
       //reload
       cy.get('button[type="button"]').contains('Reload').click();

--- a/webui/cypress/integration/code-folder-in-tree.spec.js
+++ b/webui/cypress/integration/code-folder-in-tree.spec.js
@@ -4,7 +4,8 @@ describe('Code page', () => {
       cy.visit(Cypress.config('baseUrl')+"/admin/cluster/code");
   //create folder
       cy.get('.meta-test__addFolderBtn').click();
-      cy.get('.meta-test__enterName').focused().type('folder-in-tree{enter}');
+      cy.get('.meta-test__enterName').focused().type('folder-in-tree');
+      cy.get('#root').contains('Tarantool').click();
       cy.get('.ScrollbarsCustom-Content').contains('folder-in-tree');
   //create folder in folder
       cy.get('.meta-test__createFolderInTreeBtn').click({ force: true });

--- a/webui/src/components/FileTree/NewTreeElement.js
+++ b/webui/src/components/FileTree/NewTreeElement.js
@@ -96,6 +96,12 @@ export class NewTreeElement extends React.Component<NewTreeElementProps, NewTree
     }
   }
 
+  handleBlur = (event: FocusEvent) => {
+    const { value } = this.state;
+
+    this.props.onConfirm(value);
+  }
+
   handleKeyPress = (event: KeyboardEvent) => {
     const { value } = this.state;
     const { type } = this.props;
@@ -158,7 +164,7 @@ export class NewTreeElement extends React.Component<NewTreeElementProps, NewTree
             ref={this.inputRef}
             value={value}
             onChange={this.handleChange}
-            onBlur={this.props.onCancel}
+            onBlur={this.handleBlur}
             onKeyDown={this.handleKeyPress}
           />
         </li>


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Now, when the input loses focus, the creation of a new file / folder is not canceled, but applied

Closes #505 
