### PR TITLE
Fixed: folder in tree collapsed after renaming

### DIFF
--- a/webui/cypress/integration/code-folder-in-tree.spec.js
+++ b/webui/cypress/integration/code-folder-in-tree.spec.js
@@ -20,7 +20,7 @@ describe('Code page', () => {
   //edit folder name
       cy.get('.meta-test__editFolderInTreeBtn').eq(0).click({ force: true });
       cy.get('.meta-test__enterName').focused().clear().type('edited-folder-name{enter}');
-      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name').click();
+      cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').should('be.visible');
   
   //save changes and full reload code page
       cy.get('button[type="button"]').contains('Apply').click();

--- a/webui/cypress/integration/code-folder-in-tree.spec.js
+++ b/webui/cypress/integration/code-folder-in-tree.spec.js
@@ -20,6 +20,7 @@ describe('Code page', () => {
   //edit folder name
       cy.get('.meta-test__editFolderInTreeBtn').eq(0).click({ force: true });
       cy.get('.meta-test__enterName').focused().clear().type('edited-folder-name{enter}');
+      cy.get('.ScrollbarsCustom-Content').contains('edited-folder-name');
       cy.get('.ScrollbarsCustom-Content').contains('file-in-folder').should('be.visible');
   
   //save changes and full reload code page

--- a/webui/src/components/FileTree/FileTreeElement.js
+++ b/webui/src/components/FileTree/FileTreeElement.js
@@ -89,9 +89,9 @@ type FileTreeElementProps = {
   level?: number,
   onDelete: (id: string) => void,
   onExpand: (id: string) => void,
-  onFileCreate: (parentPath: string) => void,
+  onFileCreate: (file: TreeFileItem) => void,
   onFileOpen: (id: string) => void,
-  onFolderCreate: (parentPath: string) => void,
+  onFolderCreate: (file: TreeFileItem) => void,
   onRename: (id: string) => void
 }
 
@@ -123,7 +123,7 @@ export const FileTreeElement = (
         )}
         onClick={e => {
           file.type === 'folder'
-            ? onExpand(file.path)
+            ? onExpand(file.fileId)
             : onFileOpen(file.fileId)
         }}
         style={{
@@ -156,7 +156,7 @@ export const FileTreeElement = (
                 intent='plain'
                 size='xs'
                 icon={IconCreateFolder}
-                onClick={e => { e.stopPropagation(); onFolderCreate(file.path); }}
+                onClick={e => { e.stopPropagation(); onFolderCreate(file); }}
                 title='Create folder'
               />
               <Button
@@ -164,7 +164,7 @@ export const FileTreeElement = (
                 intent='plain'
                 size='xs'
                 icon={IconCreateFile}
-                onClick={e => { e.stopPropagation(); onFileCreate(file.path); }}
+                onClick={e => { e.stopPropagation(); onFileCreate(file); }}
                 title='Create file'
               />
             </React.Fragment>

--- a/webui/src/components/FileTree/index.js
+++ b/webui/src/components/FileTree/index.js
@@ -51,7 +51,7 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
 
     if (expand !== true && (expand === false || expandedEntries.includes(id))) {
       this.setState({
-        expandedEntries: expandedEntries.filter(i => i !== id )
+        expandedEntries: expandedEntries.filter(i => i !== id)
       });
     } else {
       if (!expandedEntries.includes(id)) {
@@ -62,13 +62,15 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
     }
   }
 
-  handleFolderCreate = (path: string) => {
-    this.expandEntry(path, true);
+  handleFolderCreate = (file: TreeFileItem) => {
+    const { fileId, path } = file;
+    this.expandEntry(fileId, true);
     this.props.onFolderCreate(path);
   }
 
-  handleFileCreate = (path: string) => {
-    this.expandEntry(path, true);
+  handleFileCreate = (file: TreeFileItem) => {
+    const { fileId, path } = file;
+    this.expandEntry(fileId, true);
     this.props.onFileCreate(path);
   }
 
@@ -92,7 +94,7 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
       <ul className={cx(styles.tree, className, 'meta-test__enterName')}>
         {operationObject === '' && ['createFile', 'createFolder'].includes(fileOperation) && (
           <NewTreeElement
-            type={fileOperation === 'createFolder' ? 'folder' : 'file' }
+            type={fileOperation === 'createFolder' ? 'folder' : 'file'}
             level={0}
             onCancel={onOperationCancel}
             onConfirm={onOperationConfirm}
@@ -110,14 +112,12 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
                   <NewTreeElement
                     key={item.path}
                     initialValue={item.fileName}
-                    active={selectedFile ? (selectedFile.path === item.path): false}
+                    active={selectedFile ? (selectedFile.path === item.path) : false}
                     type={item.type}
                     level={level}
-                    childsCount={item.items && item.items.length}
-                    expanded={expandedEntries.includes(item.path)}
+                    expanded={expandedEntries.includes(item.fileId)}
                     onCancel={onOperationCancel}
                     onConfirm={onOperationConfirm}
-                    onExpand={this.expandEntry}
                   >
                     {children}
                   </NewTreeElement>
@@ -128,7 +128,7 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
                     file={item}
                     active={selectedFile ? (selectedFile.path === item.path) : false}
                     level={level}
-                    expanded={expandedEntries.includes(item.path)}
+                    expanded={expandedEntries.includes(item.fileId)}
                     onDelete={onDelete}
                     onExpand={this.expandEntry}
                     onFileCreate={this.handleFileCreate}
@@ -143,7 +143,6 @@ export class FileTree extends React.Component<FileTreeProps, FileTreeState> {
                         level={level + 1}
                         onCancel={onOperationCancel}
                         onConfirm={onOperationConfirm}
-                        onExpand={this.expandEntry}
                       />
                     )}
                     {children}


### PR DESCRIPTION
Fixed: a folder in the tree used to collapse after renaming

Closes #480