### PR TITLE
Fix flaky almost_equals test

### DIFF
--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -426,6 +426,6 @@ function g.test_clock_delta()
 
     t.assert_equals(#servers, 4)
     for _, server in pairs(servers) do
-        t.assert_almost_equals(server.clock_delta, 0, 1e-2)
+        t.assert_almost_equals(server.clock_delta, 0, 0.1)
     end
 end

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -65,7 +65,7 @@ function g.test_uninitialized()
         g.server:graphql({
             query = [[{ servers { uri clock_delta } }]]
         }).data.servers[1].clock_delta,
-        0, 1e-2
+        0, 0.1
     )
 
     local replicasets = resp['data']['replicasets']

--- a/test/integration/clock_delta_test.lua
+++ b/test/integration/clock_delta_test.lua
@@ -83,7 +83,7 @@ function g.test_clock_delta()
             end
             t.assert_almost_equals(
                 clock_delta,
-                peer.env.CLOCK_DELTA - observer.env.CLOCK_DELTA, 1e-2,
+                peer.env.CLOCK_DELTA - observer.env.CLOCK_DELTA, 0.1,
                 string.format("Observer %s, peer %s", observer.alias, peer.alias)
             )
         end


### PR DESCRIPTION
Clock_delta tests fail sometimes. See, for example, https://gitlab.com/tarantool/cartridge/-/jobs/420512711:

```log
test/integration/clock_delta_test.lua:84: Observer s1, peer s2
Values are not almost equal
Actual: -7.0128685, expected: -7, delta 0.0128685 above margin of 0.01
```

This patch increases allowed error margins to prevent such failures.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

