### PR TITLE
Add all_rw replicaset flag to test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Validate YAML in code editor WebUI.
 
-- Exposing membership options with argparse
+- Expose membership options with argparse.
+
+- Allow specifying `all_rw` replicaset flag in luatest helpers.
 
 ### Changed
 

--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -50,6 +50,7 @@ function Cluster:new(object)
     -- @string uuid Replicaset uuid.
     -- @tparam {string} roles List of roles for servers in the replicaset.
     -- @tparam ?string vshard_group Name of vshard group.
+    -- @tparam ?boolan all_rw Make all replicas writable.
     -- @tab servers List of objects to build `Server`s with.
     for _, replicaset in pairs(object.replicasets) do
         (function(_) checks({
@@ -58,6 +59,7 @@ function Cluster:new(object)
             roles = 'table',
             vshard_group = '?string',
             servers = 'table',
+            all_rw = '?boolean',
         }) end)(replicaset)
     end
 

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -28,6 +28,7 @@ g.before_all = function()
             }, {
                 uuid = helpers.uuid('b'),
                 roles = {'vshard-storage'},
+                all_rw = true,
                 servers = {
                     {
                         alias = 'storage',
@@ -383,7 +384,7 @@ function g.test_replicasets()
             master = {uuid = helpers.uuid('b', 'b', 1)},
             active_master = {uuid = helpers.uuid('b', 'b', 1)},
             weight = 1,
-            all_rw = false,
+            all_rw = true,
             servers = {
                 {uri = 'localhost:13302', priority = 1},
                 {uri = 'localhost:13304', priority = 2},


### PR DESCRIPTION
Allow specifying `all_rw` replicaset flag in luatest helpers.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

