### PR TITLE
Gh 489 show cartridge version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Network error shows with fixed splash panel instead of notification.
 
+- Test `topology_leader` is rewritten for luatest.
+
 ### Fixed
 
 - DDL failure if spaces is `null` in input schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Code applying error in Code editor.
 
+- New field for `server.boxinfo` of GraphQL request which is shown cartridge version.
+
 ### Changed
 
 - Network error shows with fixed splash panel instead of notification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Network error shows with fixed splash panel instead of notification.
 
-- Test `topology_leader` is rewritten for luatest.
-
 ### Fixed
 
 - DDL failure if spaces is `null` in input schema.

--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -363,6 +363,9 @@ local function get_info(uri)
                 vclock = box_info.vclock,
                 replication_info = {},
             },
+            cartridge = {
+                version = require('cartridge').VERSION
+            },
         }
 
         for i, replica in pairs(box_info.replication) do

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -196,6 +196,15 @@ local boxinfo_schema = {
                     },
                 }
             }).nonNull,
+            cartridge = gql_types.object({
+                name = 'ServerInfoCartridge',
+                fields = {
+                    version = {
+                        kind = gql_types.string.nonNull,
+                        description = 'Cartridge version',
+                    },
+                }
+            }).nonNull,
         }
     }),
     arguments = {},

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Jan 10 2020 01:17:00 GMT+0300 (Moscow Standard Time)
+# timestamp: Fri Jan 31 2020 16:45:00 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -251,10 +251,16 @@ type Server {
 
 """Server information and configuration."""
 type ServerInfo {
+  cartridge: ServerInfoCartridge!
+  storage: ServerInfoStorage!
   network: ServerInfoNetwork!
   general: ServerInfoGeneral!
   replication: ServerInfoReplication!
-  storage: ServerInfoStorage!
+}
+
+type ServerInfoCartridge {
+  """Cartridge version"""
+  version: String!
 }
 
 type ServerInfoGeneral {

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -208,6 +208,9 @@ function g.test_server_info_schema()
             replication_fields: __type(name: "ServerInfoReplication") {
                 fields { name }
             }
+            cartridge_fields: __type(name: "ServerInfoCartridge") {
+                fields { name }
+            }
         }]]
     })
 
@@ -216,6 +219,7 @@ function g.test_server_info_schema()
     local field_name_storage = fields_from_map(data['storage_fields'], 'name')
     local field_name_network = fields_from_map(data['network_fields'], 'name')
     local field_name_replica = fields_from_map(data['replication_fields'], 'name')
+    local field_name_cartridge = fields_from_map(data['cartridge_fields'], 'name')
 
     local resp = router:graphql({
         query = string.format(
@@ -227,6 +231,7 @@ function g.test_server_info_schema()
                             storage { %s }
                             network { %s }
                             replication { %s }
+                            cartridge { %s }
                         }
                     }
                 }
@@ -234,7 +239,8 @@ function g.test_server_info_schema()
             table.concat(field_name_general, ' '),
             table.concat(field_name_storage, ' '),
             table.concat(field_name_network, ' '),
-            table.concat(field_name_replica, ' ')
+            table.concat(field_name_replica, ' '),
+            table.concat(field_name_cartridge, ' ')
         )
     })
     log.info(resp['data']['servers'][1])


### PR DESCRIPTION
Add new field of server info for GraphQL -  cartridge version

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

See #489 
