### PR TITLE
Optimize graphql resolvers

### DIFF
--- a/cartridge/admin.lua
+++ b/cartridge/admin.lua
@@ -112,6 +112,12 @@ local function get_server_info(members, uuid, uri)
     return ret
 end
 
+--- Get servers and replicasets lists.
+-- @function get_topology
+-- @local
+-- @treturn[1] {servers={ServerInfo,...},replicasets={ReplicasetInfo,...}}
+-- @treturn[2] nil
+-- @treturn[2] table Error description
 local function get_topology()
     local state, err = confapplier.get_state()
     -- OperationError doesn't influence observing topology
@@ -1128,6 +1134,7 @@ return {
     get_self = get_self,
     get_servers = get_servers,
     get_replicasets = get_replicasets,
+    get_topology = get_topology,
 
     edit_topology = edit_topology,
     probe_server = probe_server,

--- a/cartridge/graphql/execute.lua
+++ b/cartridge/graphql/execute.lua
@@ -91,6 +91,7 @@ local function buildContext(schema, tree, rootValue, variables, operationName)
     operation = nil,
     fragmentMap = {},
     defaultValues = {},
+    request_cache = {},
   }
 
   for _, definition in ipairs(tree.definitions) do
@@ -261,6 +262,7 @@ local function getFieldEntry(objectType, object, fields, context)
   arguments = setmetatable(arguments, {__index=positions})
 
   local info = {
+    context = context,
     fieldName = fieldName,
     fieldASTs = fields,
     returnType = fieldType.kind,

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -194,8 +194,8 @@ local function get_topology(_, _, info)
     end
 
     local ret = {
-        servers = setmetatable({}, {_index = topology.servers}),
-        replicasets = setmetatable({}, {_index = topology.replicasets}),
+        servers = setmetatable({}, {__index = topology.servers}),
+        replicasets = setmetatable({}, {__index = topology.replicasets}),
     }
 
     for _, server in pairs(topology.servers) do
@@ -215,7 +215,10 @@ local function get_servers(_, args, info)
         return nil, err
     end
 
+    local cache = info.context.request_cache
     if args.uuid ~= nil then
+        -- Turn off optimization for single-instance query
+        cache.disable_stat_optimization = true
         return {topology.servers[args.uuid]}
     else
         return topology.servers

--- a/cartridge/webui/gql-stat.lua
+++ b/cartridge/webui/gql-stat.lua
@@ -1,6 +1,7 @@
 #!/usr/bin/env tarantool
 
 local pool = require('cartridge.pool')
+local admin = require('cartridge.admin')
 local gql_types = require('cartridge.graphql.types')
 
 local statistics_schema = {
@@ -82,6 +83,8 @@ local statistics_schema = {
 
         if cache.servers_stat ~= nil then
             return cache.servers_stat[root.uri]
+        elseif cache.disable_stat_optimization then
+            return admin.get_stat(root.uri), nil
         end
 
         local uri_list = {}

--- a/test/integration/api_edit_test.lua
+++ b/test/integration/api_edit_test.lua
@@ -212,15 +212,14 @@ function g.test_edit_replicaset()
     local resp = get_replicaset()
     local replicasets = resp['data']['replicasets']
 
-    t.assert_equals(#replicasets, 1)
-    t.assert_equals(replicasets[1], {
+    t.assert_equals(replicasets, {{
         uuid = helpers.uuid('b'),
         roles = {'vshard-storage', 'vshard-router'},
         status = 'healthy',
         weight = 2,
         all_rw = false,
         servers = {{uri = 'localhost:13302'}, {uri = 'localhost:13304'}}
-    })
+    }})
 
     router:graphql({
         query = [[mutation {

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -328,6 +328,20 @@ function g.test_servers()
     )
 
     t.assert_equals(
+        test_helper.table_find_by_attr(servers, 'uri', 'localhost:13304'),
+        {
+            uri = 'localhost:13304',
+            uuid = helpers.uuid('b', 'b', 2),
+            alias = 'storage-2',
+            labels = {},
+            priority = 2,
+            disabled = false,
+            statistics = {vshard_buckets_count = 3000},
+            replicaset = {roles = {'vshard-storage'}}
+        }
+    )
+
+    t.assert_equals(
         test_helper.table_find_by_attr(servers, 'uri', 'localhost:13303'),
         {
             uri = 'localhost:13303',
@@ -437,35 +451,46 @@ function g.test_clock_delta()
     end
 end
 
-function g.test_caching()
-    -- In this test we protect `admin.get_stat` and `get_topology`
-    -- functions from being executed twice in the same request
-    -- and query same data with different aliases
+function g.test_topology_caching()
+    -- In this test we protect `admin.get_topology` function from being
+    -- executed twice in the same request and query same data with
+    -- different aliases
     g.cluster.main_server.net_box:eval([[
         local fiber = require('fiber')
         local admin = require('cartridge.admin')
-        local admin_get_stat = admin.get_stat
-        admin.get_stat = function(...)
-            assert(not fiber.self().storage.get_stat_wasted, "Excess get_stat call")
-            fiber.self().storage.get_stat_wasted = true
-            return admin_get_stat(...)
-        end
         local admin_get_topology = admin.get_topology
         admin.get_topology = function()
-            assert(not fiber.self().storage.get_topology_wasted, "Excess get_topology call")
+            assert(
+                not fiber.self().storage.get_topology_wasted,
+                "Excess get_topology call"
+            )
             fiber.self().storage.get_topology_wasted = true
             return admin_get_topology()
         end
     ]])
+
     local resp = g.cluster.main_server:graphql({
         query = [[{
-            s1: servers {alias statistics {}}
-            s2: servers {alias statistics {}}
-            r1: replicasets {servers {statistics{} replicaset {servers {statistics {}}}}}
-            r2: replicasets {servers {statistics{} replicaset {servers {statistics {}}}}}
+            s1: servers {alias}
+            s2: servers {alias}
+            replicasets {servers {}}
         }]],
     })
 
     t.assert_equals(resp.data.s1, resp.data.s2)
+
+    local resp = g.cluster.main_server:graphql({
+        query = [[{
+            r1: replicasets {servers {replicaset {servers { uuid }}}}
+            r2: replicasets {servers {replicaset {servers { uuid }}}}
+        }]],
+    })
+
     t.assert_equals(resp.data.r1, resp.data.r2)
 end
+
+
+-- function g.test_statistics_caching()
+    -- 1. statistics query should be performed with pool.map_call
+    -- 2. filtered query should be performed without optimization
+-- end


### PR DESCRIPTION
Optimize GraphQL topology queries
    
WebUI usually polls server list using the following GraphQL request:

```graphql
query {
  ReplicasetList: replicasets {...}
  ServerList: servers {...}
  ServerStat: servers {statistics {...}}
}
```

Functions `get_servers` and `get_replicaset` internally use one common
`get_topology` method. But due to the nature of GraphQL resolvers, each
of them calls `get_topology` independently and they can't share a
result.

Similar problem affects statistics requests: it requires additional
netbox call to every server in list, and all that calls are executed
sequentially one after another. It's harmful for the WebUI performance
and responsivness.

Moreover, it can also produce inconsistent results since netbox calls
yield and instance status may change in the mean time.

This patch adds caching mechanism for the GraphQL requests: the cache is
shared across all resolvers within the request. It makes possible to
avoid excess calculations and to make netbox requests concurrent.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation
