### PR TITLE
Gh 535 read cached in graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Apply `custom_proc_title` setting without waiting for `box.cfg`.
 
+- Replace `req:read()` on `req:read_cached()` for GraphQL.
+
 ## [2.0.1] - 2020-01-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Apply `custom_proc_title` setting without waiting for `box.cfg`.
 
-- Replace `req:read()` on `req:read_cached()` for GraphQL.
+- Make GraphQL compatible with `req:read_cached()` call in httpd hooks.
 
 ## [2.0.1] - 2020-01-15
 

--- a/cartridge/graphql.lua
+++ b/cartridge/graphql.lua
@@ -215,7 +215,7 @@ local function _execute_graphql(req)
         })
     end
 
-    local body = req:read()
+    local body = req:read_cached()
 
     if body == nil or body == '' then
         return http_finalize({

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -151,17 +151,7 @@ function g.test_reread_request()
         end)
     ]])
 
-    server:graphql({
-        query = [[
-            {
-                cluster {
-                    self {
-                        uri
-                    }
-                }
-            }
-        ]]
-    })
+    server:graphql({ query = '{}' })
 end
 
 function g.test_fail_validate()

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -141,6 +141,29 @@ g.test_upload = function()
     )
 end
 
+function g.test_reread_request()
+    local server = cluster.main_server
+
+    server.net_box:eval([[
+        local httpd = require('cartridge').service_get('httpd')
+        httpd:hook('before_dispatch', function(self, req)
+            req:read_cached()
+        end)
+    ]])
+
+    server:graphql({
+        query = [[
+            {
+                cluster {
+                    self {
+                        uri
+                    }
+                }
+            }
+        ]]
+    })
+end
+
 function g.test_fail_validate()
     t.assert_error_msg_contains('Field "x" is not defined on type "String"', function()
         cluster.main_server:graphql({


### PR DESCRIPTION
Replace `read` on `read_cached` for GraphQL

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation

Close #535 
