### PR TITLE
Fix CI jobs triggering

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,8 +145,8 @@ cypress-auto:
   <<: *cypress
   only:
     changes:
-      - /webui/**/*
-      - /test/cypress/**/*
+      - webui/**/*
+      - test/cypress/**/*
 
 cypress-manual:
   <<: *cypress

--- a/test/cypress/woauth_test.lua
+++ b/test/cypress/woauth_test.lua
@@ -28,7 +28,6 @@ g.setup = function()
     })
 
     g.cluster:start()
-
 end
 
 g.teardown = function()


### PR DESCRIPTION
Cypress tests weren't run automatically due to mistake in wildcard.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Follow-up for #548 
