### PR TITLE
Add tarantool-lsp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - New GraphQL API fields in `cluster{ self }`: `app_name`, `instance_name`.
 
+- Add LSP (language server protocol) support, which provides Lua
+  autocompletion in WebUI code editor. It's enabled with
+  `cartridge.cfg({lsp_enabled = false})`.
+
 ### Changed
 
 - Network error shows with fixed splash panel instead of notification.

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -14,6 +14,7 @@ dependencies = {
     'vshard == 0.1.15-1',
     'membership == 2.2.0-1',
     'frontend-core == 6.3.0-1',
+    'tarantool-lsp == 0.0.2',
 }
 
 external_dependencies = {

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -187,6 +187,13 @@ end
 --   List of pages to be hidden in WebUI.
 --   (**Added** in v2.0.1-54, default: `{}`)
 --
+-- @tparam ?boolean opts.lsp_enabled
+--   whether LSP support should be enabled. LSP (language server
+--   protocol) provides Lua autocompletion in WebUI code editor.
+--   (**Added** in v2.0.1-72, default: `false`, overridden by
+--   env `TARANTOOL_LSP_ENABLED`,
+--   args `--lsp_enabled`)
+--
 -- @tparam ?table box_opts
 --   tarantool extra box.cfg options (e.g. memtx_memory),
 --   that may require additional tuning
@@ -209,6 +216,7 @@ local function cfg(opts, box_opts)
         vshard_groups = '?table',
         console_sock = '?string',
         webui_blacklist = '?table',
+        lsp_enabled = '?boolean',
     }, '?table')
 
     if opts.webui_blacklist ~= nil then
@@ -462,10 +470,13 @@ local function cfg(opts, box_opts)
             return nil, err
         end
 
-        local ok, err = HttpInitError:pcall(webui.init, httpd)
+        local ok, err = HttpInitError:pcall(webui.init, httpd, {
+            lsp_enabled = opts.lsp_enabled
+        })
         if not ok then
             return nil, err
         end
+
 
         local ok, err = CartridgeCfgError:pcall(auth.init, httpd)
         if not ok then

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -91,6 +91,7 @@ local cluster_opts = {
     console_sock = 'string', -- **string**
     auth_enabled = 'boolean', -- **boolean**
     bucket_count = 'number', -- **number**
+    lsp_enabled = 'boolean', -- **boolean**
 }
 
 --- Common [box.cfg](https://www.tarantool.io/en/doc/latest/reference/configuration/) tuning options.

--- a/cartridge/webui.lua
+++ b/cartridge/webui.lua
@@ -1,9 +1,14 @@
 #!/usr/bin/env tarantool
 
--- local log = require('log')
+local log = require('log')
+local lsp = require('tarantool-lsp')
+local json = require('json').new()
 local front = require('frontend-core')
+local checks = require('checks')
+local errors = require('errors')
 
 local vars = require('cartridge.vars').new('cartridge.webui')
+local auth = require('cartridge.auth')
 local graphql = require('cartridge.graphql')
 local front_bundle = require('cartridge.front-bundle')
 
@@ -16,6 +21,11 @@ local api_failover = require('cartridge.webui.api-failover')
 local api_ddl = require('cartridge.webui.api-ddl')
 local gql_types = require('cartridge.graphql.types')
 
+json.cfg({
+    encode_use_tostring = true,
+})
+
+local LspError = errors.new_class('LspError')
 local module_name = 'cartridge.webui'
 
 vars:new('blacklist', {})
@@ -28,7 +38,23 @@ local function get_blacklist()
     return vars.blacklist
 end
 
-local function init(httpd)
+local function http_finalize_error(http_code, err)
+    log.error('%s', err)
+
+    return auth.render_response({
+        status = http_code,
+        headers = {
+            ['content-type'] = "application/json; charset=utf-8"
+        },
+        body = json.encode(err),
+    })
+end
+
+local function init(httpd, options)
+    checks('?', {
+        lsp_enabled = '?boolean',
+    })
+
     front.init(httpd)
     front.add('cluster', front_bundle)
 
@@ -62,6 +88,29 @@ local function init(httpd)
         kind = gql_types.list(gql_types.string.nonNull),
         callback = module_name .. '.get_blacklist',
     })
+
+    -- LSP
+    local lsp_handler
+    if options.lsp_enabled == true then
+        lsp_handler = lsp.create_websocket_handler()
+    else
+        lsp_handler = function()
+            local err = LspError:new('LSP support is disabled')
+            return http_finalize_error(501, err)
+        end
+    end
+
+    httpd:route({
+        path = '/admin/lsp',
+        method = 'GET'
+    }, function(req)
+        if not auth.authorize_request(req) then
+            local err = errors.new('LspError', 'Unauthorized')
+            return http_finalize_error(401, err)
+        end
+
+        return lsp_handler(req)
+    end)
 
     return true
 end

--- a/cartridge/webui.lua
+++ b/cartridge/webui.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env tarantool
 
 local log = require('log')
-local lsp = require('tarantool-lsp')
 local json = require('json').new()
 local front = require('frontend-core')
 local checks = require('checks')
@@ -92,6 +91,7 @@ local function init(httpd, options)
     -- LSP
     local lsp_handler
     if options.lsp_enabled == true then
+        local lsp = require('tarantool-lsp')
         lsp_handler = lsp.create_websocket_handler()
     else
         lsp_handler = function()

--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -165,4 +165,3 @@ end
 function g.test_offline_splash()
     cypress_run('network-error-splash.spec.js')
 end
-

--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -21,7 +21,8 @@ g.setup = function()
                         alias = 'router',
                         instance_uuid = helpers.uuid('a', 'a', 1),
                         advertise_port = 13301,
-                        http_port = 8081
+                        http_port = 8081,
+                        env = {TARANTOOL_LSP_ENABLED = "true"},
                     }
                 }
             }, {
@@ -144,7 +145,8 @@ function g.test_code()
         "cd webui && npx cypress run --spec" ..
         ' cypress/integration/code-empty-page.spec.js' ..
         ',cypress/integration/code-file-in-tree.spec.js' ..
-        ',cypress/integration/code-folder-in-tree.spec.js'
+        ',cypress/integration/code-folder-in-tree.spec.js' ..
+        ',cypress/integration/code-lsp.spec.js'
     )
     t.assert_equals(code, 0)
 end
@@ -163,3 +165,4 @@ end
 function g.test_offline_splash()
     cypress_run('network-error-splash.spec.js')
 end
+

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -4,7 +4,6 @@ local g = t.group()
 
 local helpers = require('test.helper')
 local log = require('log')
-local fun = require('fun')
 
 g.before_all = function()
     g.cluster = helpers.Cluster:new({
@@ -588,22 +587,10 @@ end
 
 function g.test_lsp_disabled()
     if os.getenv('TARANTOOL_LSP_ENABLED') ~= nil then
-        t.fail('Please unset TARANTOOL_LSP_ENABLED and run test again')
+        t.skip('Please unset TARANTOOL_LSP_ENABLED and run test again')
     end
 
-    local function check_lsp_disabled(server)
-        return server.net_box:eval('return package.loaded["tarantool-lsp"] ~= nil')
-    end
-
-    local alive_servers = fun.filter(function(server)
-        if server.alias ~= 'expelled' then
-            return server
-        end
-    end, g.cluster.servers):totable()
-
-    for _, server in ipairs(alive_servers) do
-        t.assert_equals(check_lsp_disabled(server), false, server.alias)
-    end
-
-    t.assert_equals(check_lsp_disabled(g.server), false)
+    local code = 'assert(package.loaded["tarantool-lsp"] == nil)'
+    g.cluster:server('storage').net_box:eval(code)
+    g.cluster:server('router').net_box:eval(code)
 end

--- a/webui/cypress/integration/code-lsp.spec.js
+++ b/webui/cypress/integration/code-lsp.spec.js
@@ -1,0 +1,58 @@
+describe('Code page: lsp', () => {
+
+      it('Text color', () => {
+
+            cy.visit(Cypress.config('baseUrl') + "/admin/cluster/code");
+            cy.get('.meta-test__addFileBtn').click();
+            cy.get('.meta-test__enterName').focused().type('test-code.lua{enter}');
+            cy.get('.ScrollbarsCustom-Content').contains('test-code.lua').click();
+            cy.get('.monaco-editor textarea').type("local json = require( 'json');\n");
+            cy.get('.mtk19').should('have.css', 'color', 'rgb(32, 96, 160)');
+            cy.get('.mtk30').should('have.css', 'color', 'rgb(192, 48, 48)');
+      });
+
+      it('Tooltip for selecting an object and Read more/less information', () => {
+            cy.get('.monaco-editor textarea').type('js');
+
+            //open Read more
+            cy.get('.monaco-editor textarea').type('{ctrl} ');
+            cy.get('.type').contains('M<json>');
+            //open Read less
+            cy.get('.monaco-editor textarea').type('{ctrl} ');
+            cy.get('.type').contains('M<json>').should('not.be.visible');
+
+            cy.get('.monaco-highlighted-label').click();
+            cy.get('.monaco-editor textarea').should('have.value', "local json = require( 'json');\njson");
+      });
+
+      it('Method selection', () => {
+            cy.get('.monaco-editor textarea').type(".");
+            cy.get('.monaco-highlighted-label');
+            cy.get('span[class="monaco-highlighted-label"]').contains('cfg()').click();
+            cy.get('.monaco-editor textarea').should('have.value', "local json = require( 'json');\njson.cfg()");
+      });
+
+      it('Description for text in Code', () => {
+            cy.get('.monaco-editor-hover').should('not.be.visible');
+            cy.get('.monaco-editor textarea')
+                  .type("{leftarrow}{leftarrow}{leftarrow}{leftarrow}")
+                  .type("{ctrl}k{ctrl}i");
+            cy.get('.monaco-editor-hover').should('be.visible');
+      });
+
+      it('LSP connection is not interrupted after 2 minutes', () => {
+            cy.get('.monaco-editor textarea').type("{del}{del}{del}{del}");
+            cy.get('.monaco-editor textarea').type("f");
+            cy.get('span[class="monaco-highlighted-label"]').should('be.visible');
+            cy.get('.monaco-editor textarea').type("{backspace}{backspace}{backspace}");
+
+            cy.exec('kill -SIGSTOP $(lsof -sTCP:LISTEN -i :13301 -t)', { failOnNonZeroExit: true });
+            cy.get('.monaco-editor textarea').type(".");
+            cy.get('span[class="monaco-highlighted-label"]').should('not.be.visible');
+
+            cy.exec('kill -SIGCONT $(lsof -sTCP:LISTEN -i :13301 -t)', { failOnNonZeroExit: true });
+            cy.get('.monaco-editor textarea').type("c");
+            cy.get('span[class="monaco-highlighted-label"]').should('be.visible');
+
+      });
+});

--- a/webui/src/components/LSPHoC.js
+++ b/webui/src/components/LSPHoC.js
@@ -1,0 +1,114 @@
+// @flow
+
+import * as React from 'react'
+import { installLSP } from '../misc/installLSP';
+import monaco from '../misc/initMonacoEditor';
+import * as R from 'ramda'
+
+type LSPHoCProps = {
+  lspEndpoints: []
+}
+
+type LSPHocState = {
+  lspStatus: {
+    [string]: {
+      enabled: boolean,
+      dispose?: Function,
+    }
+  }
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default (WrappedComponent: React.ComponentType<any>) => {
+
+  class LSPHoC extends React.Component<LSPHoCProps, LSPHocState> {
+    static defaultProps = {
+      lspEndpoints: []
+    }
+    static displayName = `LSPHoC<${getDisplayName(WrappedComponent)}>`
+
+
+    state = {
+      lspStatus: {}
+    }
+
+
+    componentDidMount(): void {
+      this.props.lspEndpoints.forEach(
+        async ({ endpoint, language }) => {
+
+          const disposeLanguage = await installLSP(monaco.editor, language, endpoint)
+          if (disposeLanguage) {
+            this.setState(({ lspStatus }) => ({
+              lspStatus: {
+                ...lspStatus,
+                [language]: {
+                  enabled: true,
+                  dispose: disposeLanguage
+                }
+              }
+            }))
+          }
+        }
+      )
+    }
+
+    componentDidUpdate(prevProps: LSPHoCProps, prevState: LSPHocState): void {
+
+      const lspEndpoints = this.props.lspEndpoints
+      const prevLspEndpoints = prevProps.lspEndpoints
+
+      const removed = R.differenceWith(R.eqProps('language'), prevLspEndpoints, lspEndpoints)
+      const added = R.differenceWith(R.eqProps('language'), lspEndpoints, prevLspEndpoints)
+
+      const removedLanguages = removed.map(R.prop('language'))
+
+      for (const lang of removedLanguages) {
+        const langStatus = this.state.lspStatus[lang]
+        if (langStatus.enabled && langStatus.dispose) {
+          langStatus.dispose()
+        }
+        this.setState(({ lspStatus }) => ({
+          lspStatus: R.filter(R.equals(R.compose(R.not, langStatus)), lspStatus)
+        }))
+      }
+
+      added.forEach(
+        async ({ endpoint, language }) => {
+          const disposeLanguage = await installLSP(monaco.editor, language, endpoint)
+          if (disposeLanguage) {
+            this.setState(({ lspStatus }) => ({
+              lspStatus: {
+                ...lspStatus,
+                [language]: {
+                  enabled: true,
+                  dispose: disposeLanguage
+                }
+              }
+            }))
+          }
+        }
+      )
+    }
+
+    componentWillUnmount() {
+      for (const lang of Object.keys(this.state.lspStatus)) {
+        const langStatus = this.state.lspStatus[lang]
+        if (langStatus.enabled && langStatus.dispose) {
+          langStatus.dispose()
+        }
+      }
+    }
+
+    render() {
+      const { lspEndpoints, ...props } = this.props
+
+      return <WrappedComponent {...props} />
+    }
+  }
+
+  return LSPHoC
+}

--- a/webui/src/components/MonacoEditor/index.js
+++ b/webui/src/components/MonacoEditor/index.js
@@ -5,11 +5,12 @@ import monaco from '../../misc/initMonacoEditor';
 import { subscribeOnTargetEvent } from '../../misc/eventHandler';
 import { getModelByFile, setModelByFile } from '../../misc/monacoModelStorage';
 import { getYAMLError } from '../../misc/yamlValidation';
+import LSPHoC from '../LSPHoC';
 
 
 const DEF_CURSOR = {}
 
-export default class MonacoEditor extends React.Component {
+class MonacoEditor extends React.Component {
   static propTypes = {
     fileId: PropTypes.string,
     initialValue: PropTypes.string,
@@ -29,7 +30,7 @@ export default class MonacoEditor extends React.Component {
 
   static defaultProps = {
     initialValue: '',
-    language: 'javascript',
+    language: 'lua',
     theme: null,
     options: {},
     overrideServices: {},
@@ -172,7 +173,7 @@ export default class MonacoEditor extends React.Component {
           ...(theme ? { theme } : {})
         },
         overrideServices
-      );
+      )
 
 
       // After initializing monaco editor
@@ -232,3 +233,5 @@ export default class MonacoEditor extends React.Component {
     );
   }
 }
+
+export default LSPHoC(MonacoEditor)

--- a/webui/src/misc/initMonacoEditor.js
+++ b/webui/src/misc/initMonacoEditor.js
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor/esm/vs/editor/edcore.main.js';
+import * as monaco from 'monaco-editor/esm/vs/editor/edcore.main';
 import themeData from 'monaco-themes/themes/Slush and Poppies.json';
 import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution';
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';

--- a/webui/src/misc/installLSP.js
+++ b/webui/src/misc/installLSP.js
@@ -1,0 +1,142 @@
+import {
+  MonacoServices, MonacoLanguageClient,
+  CloseAction, ErrorAction, createConnection
+} from 'monaco-languageclient'
+import { listen } from 'vscode-ws-jsonrpc';
+import RWSocket from 'reconnecting-websocket';
+import rest from 'src/api/rest';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+function createLanguageClient(connection, language) {
+  return new MonacoLanguageClient({
+    name: 'Sample Language Client',
+    clientOptions: {
+      // use a language id as a document selector
+      documentSelector: [language],
+      // disable the default error handler
+      errorHandler: {
+        error: () => ErrorAction.Continue,
+        closed: () => CloseAction.DoNotRestart
+      }
+    },
+    // create a language client connection from the JSON RPC connection on demand
+    connectionProvider: {
+      get: (errorHandler, closeHandler) => {
+        return Promise.resolve(createConnection(connection, errorHandler, closeHandler))
+      }
+    }
+  });
+}
+
+function createWebSocket(url: string): WebSocket {
+  const socketOptions = {
+    maxReconnectionDelay: 10000,
+    minReconnectionDelay: 1000,
+    reconnectionDelayGrowFactor: 1.3,
+    connectionTimeout: 10000,
+    maxRetries: Infinity,
+    debug: false
+  };
+  return new RWSocket(url, [], socketOptions);
+}
+
+const serviceSymbol = '__service_inited__';
+
+const createClient = (endpoint, language) => new Promise((resolve, reject) => {
+  const { protocol, host } = window.location
+  const usedProtocol = protocol === 'https' ? 'wss' : 'ws'
+  const lspEndpoint = `${usedProtocol}://localhost:8081${endpoint}`
+  const socket = createWebSocket(
+    lspEndpoint
+  )
+
+  let timeouted = false
+
+  let timeout = setTimeout(() => {
+    timeouted = true
+    reject('timeout connection to client')
+  }, 10000)
+
+  listen({
+    webSocket: socket,
+    onConnection: connection => {
+      if (timeouted) {
+        return
+      }
+      // create and start the language client
+      const languageClient = createLanguageClient(connection, language);
+      const disposable = languageClient.start();
+      connection.onClose(() => {
+        disposable.dispose()
+      });
+      clearTimeout(timeout)
+      resolve(async () => {
+        await languageClient.stop()
+        await disposable.dispose()
+        socket.close()
+      })
+    },
+    onError: console.error
+  })
+})
+
+const checkEndpoint = async (endpoint, retry = false) => {
+  try {
+    const res = await rest.get(endpoint)
+    return true
+  } catch(e) {
+    if (e && e.response && e.response.status) {
+      switch(e.response.status) {
+        case 401:
+          return false
+        case 501:
+          return false
+        default:
+          return true
+      }
+    }
+    if (retry) {
+      return false
+    }
+    await sleep(5000)
+    return await checkEndpoint(endpoint, true)
+  }
+}
+
+
+export const installLSP = async (editor, language, endpoint) => {
+  if (!editor[serviceSymbol]) {
+    editor[serviceSymbol] = {}
+    MonacoServices.install(editor)
+  }
+
+  const isEndpointAvailable = await checkEndpoint(endpoint)
+
+  if (!isEndpointAvailable) return null
+
+  try {
+    if (!editor[serviceSymbol][language]) {
+      editor[serviceSymbol][language] = {
+        client: await createClient(endpoint, language),
+        counter: 0
+      }
+    }
+
+    editor[serviceSymbol][language].counter++
+
+    return () => {
+      const ln = editor[serviceSymbol][language]
+      console.log(language, ln.counter)
+      ln.counter--
+      if (ln.counter === 0) {
+        console.log('dispose', language)
+        ln.client()
+        editor[serviceSymbol][language] = null
+      }
+    }
+  } catch(e) {
+    console.error(e)
+    return null
+  }
+}

--- a/webui/src/misc/installLSP.js
+++ b/webui/src/misc/installLSP.js
@@ -46,7 +46,7 @@ const serviceSymbol = '__service_inited__';
 const createClient = (endpoint, language) => new Promise((resolve, reject) => {
   const { protocol, host } = window.location
   const usedProtocol = protocol === 'https' ? 'wss' : 'ws'
-  const lspEndpoint = `${usedProtocol}://localhost:8081${endpoint}`
+  const lspEndpoint = `${usedProtocol}://${host}${endpoint}`
   const socket = createWebSocket(
     lspEndpoint
   )

--- a/webui/src/pages/Code.js
+++ b/webui/src/pages/Code.js
@@ -419,6 +419,7 @@ class Code extends React.Component<CodeProps, CodeState> {
                   initialValue={selectedFile ? selectedFile.initialContent : 'Select or add a file'}
                   isContentChanged={selectedFile ? !selectedFile.saved : null}
                   setIsContentChanged={this.handleSetIsContentChanged}
+                  lspEndpoints={[{ endpoint: '/admin/lsp', language: 'lua' }]}
                 />
               </>
               :

--- a/webui/src/store/actionTypes.js
+++ b/webui/src/store/actionTypes.js
@@ -187,3 +187,4 @@ export const RENAME_FOLDER = 'RENAME_FOLDER'
 // export const deleteFolder = types(DELETE_FOLDER)
 // export const renameFile = types(RENAME_FILE)
 // export const renameFolder = types(RENAME_FOLDER)
+

--- a/webui/src/store/reducers/codeEditor.reducer.test.js
+++ b/webui/src/store/reducers/codeEditor.reducer.test.js
@@ -22,7 +22,7 @@ describe('When the selected file gets deleted', () => {
 
   const state: CodeEditorState = {
     editor: {
-      selectedFile: '1'
+      selectedFile: '1',
     },
     files: [
       { ..._fileBlank, fileId: '1', path: 'folder/file.txt' },

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -524,3 +524,4 @@ export const getFilesQuery = gql`
     }
   }
 `;
+

--- a/webui/src/store/saga/editor.saga.js
+++ b/webui/src/store/saga/editor.saga.js
@@ -1,5 +1,8 @@
-import { put, select, takeLatest } from 'redux-saga/effects';
-import { FETCH_CONFIG_FILES_DONE, SELECT_FILE } from 'src/store/actionTypes';
+import { put, select, takeLatest, call } from 'redux-saga/effects';
+import {
+  FETCH_CONFIG_FILES_DONE,
+  SELECT_FILE,
+} from 'src/store/actionTypes';
 import { LS_CODE_EDITOR_OPENED_FILE } from 'src/constants';
 
 let initiallyOpened = false;
@@ -25,7 +28,7 @@ function* openFirstFileSaga() {
 
     if (storedPath !== null) {
       file = files.find(({ type, path }) => type === 'file' && path === storedPath);
-      if (!file) 
+      if (!file)
         file = getFileToOpen(files)
     } else {
       file = getFileToOpen(files)
@@ -34,7 +37,7 @@ function* openFirstFileSaga() {
     yield put({ type: SELECT_FILE, payload: file.fileId });
     initiallyOpened = true;
   }
-};
+}
 
 function* storeOpenedFileSaga() {
   const { codeEditor: { files, editor: { selectedFile } } } = yield select();

--- a/webui/src/store/saga/editor.saga.js
+++ b/webui/src/store/saga/editor.saga.js
@@ -1,7 +1,7 @@
-import { put, select, takeLatest, call } from 'redux-saga/effects';
+import { put, select, takeLatest } from 'redux-saga/effects';
 import {
   FETCH_CONFIG_FILES_DONE,
-  SELECT_FILE,
+  SELECT_FILE
 } from 'src/store/actionTypes';
 import { LS_CODE_EDITOR_OPENED_FILE } from 'src/constants';
 


### PR DESCRIPTION
Add tarantool-lsp dependency and as option to config that's enabled lsp endpoint.

Add LSP integration to our monaco editor component.

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #333 

Add more info about this:

We add new option `lsp_enabled` that's indicate when lsp socket will be accessible.
It provides us with autocomplete in GUI Code Editor on codepage. This autocomplete based on our current documentation and Lua. That supports people without knowledge about Lua and Tarantool built-in modules to write code.