### PR TITLE
Fix flaky tar test

### DIFF
--- a/test/unit/tar_test.lua
+++ b/test/unit/tar_test.lua
@@ -68,7 +68,7 @@ local function tar_execute(opts, tar, filename)
     local cmd = string.format('tar %s %s %s 2>&1', opts, tar, (filename or ''))
     log.info('> %s', cmd)
     local f = io.popen(cmd)
-    return f:read('*all'):strip()
+    return f:read('*all')
 end
 
 local function file_write(path, content)
@@ -94,7 +94,7 @@ function g.test_fixtures_pack()
         file_write(path, packed)
 
         t.assert_items_equals(
-            string.split(tar_execute('tf', path), '\n'),
+            string.split(tar_execute('tf', path):strip(), '\n'),
             table_keys(files),
             string.format('Unexpected listing for %q', tarname)
         )


### PR DESCRIPTION
Function `tar_execute` is used for unpacking files with `tar -xOf` and
strips the resulting string. One of fixtures ("8.tar") is generated
using `digest.urandom()`, and when it occurs to end with a newline or a
whitespace, `t.assert_equals` fails.

This patch removes implicit string stripping from `tar_execute`.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
