### PR TITLE
Revise CI settings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ stages:
   - test
   - publish
 
+########################################################################
 ###
 ### Prebuilt base docker image
 ### only if Dockerfile or test requirements changed
@@ -24,7 +25,6 @@ stages:
     changes:
       - Dockerfile.base-ee
       - Dockerfile.base-ce
-      - .gitlab-ci.yml
       - test/integration/requirements.txt
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
@@ -68,8 +68,9 @@ docker-build-ce-2.2:
       --build-arg TARANTOOL_BRANCH=2_2
     DOCKER_FILE: Dockerfile.base-ce
 
+########################################################################
 ###
-### Test
+### Run backend tests
 ###
 .test-template: &test-template
   image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${IMAGE_TAG}
@@ -78,19 +79,16 @@ docker-build-ce-2.2:
     - docker
   before_script:
     - ls -al # to see if caching works
+    - export CMAKE_DUMMY_WEBUI=YES
     - tarantoolctl rocks make
     - tarantoolctl rocks list
   after_script:
     # avoid caching cartridge rock
     - tarantoolctl rocks remove cartridge
   cache:
-    key: ${IMAGE_NAME}
+    key: ${IMAGE_NAME}-fake-ui
     paths:
       - build.luarocks/
-      - webui/node_modules
-      - webui/build/bundle.lua
-      - .npm
-      - .cache/Cypress
       - .rocks/
 
 integration-ee:
@@ -120,37 +118,10 @@ compatibility:
   variables:
     IMAGE_NAME: *IMAGE_NAME_EE
     CARTRIDGE_OLDER_PATH: /tmp/cartridge-1.2.0
-  before_script:
-    - tarantoolctl rocks make
+  script:
     - mkdir -p $CARTRIDGE_OLDER_PATH
     - (cd $CARTRIDGE_OLDER_PATH; tarantoolctl rocks install cartridge 1.2.0-1)
-  script:
     - luatest -v -p compatibility.upgrade
-
-.cypress: &cypress
-  <<: *test-template
-  script:
-    - luatest -v -p cypress.*
-  artifacts:
-    name: "${CI_COMMIT_REF_NAME}.cypress"
-    when: always
-    expire_in: 1 week
-    paths:
-      - webui/cypress/screenshots/
-      - webui/cypress/videos/
-  variables:
-    IMAGE_NAME: *IMAGE_NAME_EE
-
-cypress-auto:
-  <<: *cypress
-  only:
-    changes:
-      - webui/**/*
-      - test/cypress/**/*
-
-cypress-manual:
-  <<: *cypress
-  when: manual
 
 misc:
   <<: *test-template
@@ -158,22 +129,67 @@ misc:
     - luacheck .
     - ./taptest.lua
     - ./fetch-schema.sh
-    - ./check-flow-graphql.sh
-    - ./frontend-test.sh
-    - ./release.sh
   artifacts:
     name: "${CI_COMMIT_REF_NAME}.misc"
     when: on_success
     expire_in: 1 week
     paths:
       - doc/
-      - release/
-      - release-doc/
-      - luacov.report.out
   variables:
     IMAGE_NAME: *IMAGE_NAME_EE
+    CMAKE_LDOC_FIND_REQUIRED: "YES"
 
+########################################################################
 ###
+### Run frontend tests
+###
+.cypress: &cypress-template
+  image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${IMAGE_TAG}
+  stage: test
+  tags:
+    - docker
+  variables:
+    IMAGE_NAME: *IMAGE_NAME_EE
+  before_script:
+    - ls -al # to see if caching works
+    - tarantoolctl rocks make
+    - tarantoolctl rocks list
+  script:
+    - luatest -v -p cypress.*
+    - ./frontend-test.sh
+  after_script:
+    # avoid caching cartridge rock
+    - tarantoolctl rocks remove cartridge
+  cache:
+    key: ${IMAGE_NAME}-real-ui
+    paths:
+      - build.luarocks/
+      - webui/build/bundle.lua
+      - .npm
+      - .cache/Cypress
+      - .rocks/
+
+  artifacts:
+    name: "${CI_COMMIT_REF_NAME}.cypress"
+    when: always
+    expire_in: 1 week
+    paths:
+      - webui/cypress/screenshots/
+      - webui/cypress/videos/
+
+cypress-auto:
+  <<: *cypress-template
+  only:
+    changes:
+      - webui/**/*
+      - test/cypress/**/*
+
+cypress-manual:
+  <<: *cypress-template
+  when: manual
+
+
+########################################################################
 ### Publish rocks
 ###
 publish-scm-1:
@@ -192,13 +208,22 @@ publish-release:
   stage: publish
   tags:
     - docker
-  image: centos:7
+  image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${IMAGE_TAG}
+  variables:
+    IMAGE_NAME: *IMAGE_NAME_EE
   only:
     - tags
   script:
+    - ./release.sh
     - cd release/
     - curl --fail -X PUT -F "rockspec=@${ROCK_NAME}-${CI_COMMIT_TAG}-1.rockspec"
       https://${ROCKS_USERNAME}:${ROCKS_PASSWORD}@rocks.tarantool.org
     - curl --fail -X PUT -F "rockspec=@${ROCK_NAME}-${CI_COMMIT_TAG}-1.all.rock"
       https://${ROCKS_USERNAME}:${ROCKS_PASSWORD}@rocks.tarantool.org
-  dependencies: ["misc"]
+  artifacts:
+    name: "${CI_COMMIT_REF_NAME}.release"
+    when: on_success
+    expire_in: 1 week
+    paths:
+      - release/
+      - release-doc/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,10 @@ configure_file (
 
 ## Webui ######################################################################
 ###############################################################################
-
 add_custom_command(
   OUTPUT ${WEB_ROOT}/node_modules
   COMMAND NODE_ENV=production npm ci --prefix "${WEB_ROOT}"
-  DEPENDS "${WEB_ROOT}/package.json"
+  DEPENDS "${WEB_ROOT}/package-lock.json"
   COMMENT "Installing node_modules"
 )
 
@@ -62,23 +61,46 @@ add_custom_command(
   COMMENT "Building web archive"
 )
 
-add_custom_target(front-bundle ALL
-  DEPENDS ${WEB_ROOT}/build/bundle.lua
-)
+if(DEFINED ENV{CMAKE_DUMMY_WEBUI})
+  set(DUMMY_WEBUI "$ENV{CMAKE_DUMMY_WEBUI}")
+endif()
+
+if(DUMMY_WEBUI)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/front-bundle.fake.lua"
+    "return {__data = function() return {} end}\n"
+  )
+  add_custom_target(front-bundle ALL
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/front-bundle.fake.lua"
+      "${CMAKE_CURRENT_BINARY_DIR}/front-bundle.lua"
+    COMMENT "Generating fake front-bundle.lua"
+    VERBATIM
+  )
+else()
+  add_custom_target(front-bundle ALL
+    DEPENDS "${WEB_ROOT}/build/bundle.lua"
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${WEB_ROOT}/build/bundle.lua"
+      "${CMAKE_CURRENT_BINARY_DIR}/front-bundle.lua"
+    COMMENT "Copying real front-bundle.lua"
+    VERBATIM
+  )
+endif()
+
 
 ## API doc ####################################################################
 ###############################################################################
 
 set(DOC_OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/doc/index.html)
 
-if(BUILD_DOC)
-  set(LDOC_FIND_REQUIRED ON)
+if(DEFINED ENV{CMAKE_LDOC_FIND_REQUIRED})
+  set(LDOC_FIND_REQUIRED "$ENV{CMAKE_LDOC_FIND_REQUIRED}")
 endif()
 find_package(Ldoc)
 
 add_custom_command(
   OUTPUT DOC_OUTPUT
-  COMMAND ${LDOC} -t "${PROJECT_NAME}-${version}" -p "${PROJECT_NAME} (${version})" --all .
+  COMMAND ${LDOC} --all .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${LUA_FILES}
   COMMENT "Building API documentation"
@@ -144,12 +166,8 @@ install(
 )
 
 install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/VERSION.lua
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/VERSION.lua
+    ${CMAKE_CURRENT_BINARY_DIR}/front-bundle.lua
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/
-)
-
-install(
-  FILES ${WEB_ROOT}/build/bundle.lua
-  DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}
-  RENAME front-bundle.lua
 )

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -26,7 +26,6 @@ build = {
     type = 'cmake',
     variables = {
         version = 'scm-1',
-        BUILD_DOC = '$(BUILD_DOC)',
         TARANTOOL_DIR = '$(TARANTOOL_DIR)',
         TARANTOOL_INSTALL_LIBDIR = '$(LIBDIR)',
         TARANTOOL_INSTALL_LUADIR = '$(LUADIR)',

--- a/check-flow-graphql.sh
+++ b/check-flow-graphql.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-npm run graphqlgen --prefix=webui
-npm run flow --prefix=webui

--- a/frontend-test.sh
+++ b/frontend-test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+npm run graphqlgen --prefix=webui
+npm run flow --prefix=webui
 npm run test_once --prefix=webui

--- a/release.sh
+++ b/release.sh
@@ -19,7 +19,6 @@ echo "Preparing release \"$TAG\""
 mkdir -p release
 sed -e "s/branch = '.\+'/tag = '$TAG'/g" \
     -e "s/version = '.\+'/version = '$TAG-1'/g" \
-    -e "s/BUILD_DOC = '.\+'/BUILD_DOC = 'YES'/g" \
     cartridge-scm-1.rockspec > release/cartridge-$TAG-1.rockspec
 
 tarantoolctl rocks make release/cartridge-$TAG-1.rockspec


### PR DESCRIPTION
* Introduce new option `CMAKE_DUMMY_WEBUI=YES tarantoolctl rocks make`
  which skips WebUI building (which is slow)

* Split CI frontend and backend tests. Backend tests are run with dummy
  webui option enabled.

* Replace BUILD_DOC option with more clear CMAKE_LDOC_FIND_REQUIRED.
  Doc is always built if there is ldoc installed. But with this new
  option it's forced to require ldoc.

