### PR TITLE
Name binary units properly: KiB instead of Kb

### DIFF
--- a/webui/src/components/ReplicasetServerListItem.js
+++ b/webui/src/components/ReplicasetServerListItem.js
@@ -111,7 +111,7 @@ const styles = {
   `
 };
 
-const byteUnits = ['Kb', 'Mb', 'Gb', 'Tb', 'Pb'];
+const byteUnits = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
 
 const getReadableBytes = size => {
   let bytes = size;


### PR DESCRIPTION
See [wipipedia](https://en.wikipedia.org/wiki/Kibibyte)
