### PR TITLE
vshard: bump version to 0.1.15

### DIFF
--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'checks == 3.0.1-1',
     'lulpeg == 0.1.2-1',
     'errors == 2.1.2-1',
-    'vshard == 0.1.14-1',
+    'vshard == 0.1.15-1',
     'membership == 2.2.0-1',
     'frontend-core == 6.3.0-1',
 }


### PR DESCRIPTION
Contains following changes:
  - Added if_not_bootstrapped option to router.bootstrap();
  - Fixed assertion in failover;
  - Discovery reports warnings instead of errors;
  - Fixed duplication of active bucket.