### PR TITLE
Fix flaky CI tests by engaging tmpfs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ variables:
   ROCK_NAME: cartridge
   BUNDLE_VERSION: "1.10.4-8-g3f2b35b"
   IMAGE_TAG: latest
+  TMPDIR: /dev/shm
   # Enable caching frontend stuff
   npm_config_cache: "$CI_PROJECT_DIR/.npm"
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,7 +1,22 @@
 local fio = require('fio')
+local digest = require('digest')
 local helpers = table.copy(require('cartridge.test-helpers'))
 
 helpers.project_root = fio.dirname(debug.sourcedir())
+
+local __fio_tempdir = fio.tempdir
+fio.tempdir = function()
+    local base = os.getenv('TMPDIR')
+    if base == nil or base == '/tmp' then
+        return __fio_tempdir()
+    else
+        local random = digest.urandom(9)
+        local suffix = digest.base64_encode(random, {urlsafe = true})
+        local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)
+        fio.mktree(path)
+        return path
+    end
+end
 
 function helpers.entrypoint(name)
     local path = fio.pathjoin(


### PR DESCRIPTION
As investigation [shows](https://github.com/tarantool/cartridge/issues/612),
the root of timeouts is in slow IO on out Gitlab CI runner.

This patch engages tmpfs (`/dev/shm`) for saving snapshots in tests.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Close #612