### PR TITLE
Refactor failover api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - - (Lua) `cartridge.admin_get_failover` - deprecated
 - - (Lua) `cartridge.failover_get_params` - added
 - - (Lua) `cartridge.failover_set_params` - added
+- - (GraphQL) `query {cluster {failover{}}}` - changed
+      (returns composite type instead of boolean)
+- - (GraphQL) `mutation {cluster {failover(){}}}` - changed
+      (returns composite type instead of boolean)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove redundant topology availability checks.
 
+- Failover API changed:
+- - (Lua) `cartridge.admin_enable_failover` - deprecated
+- - (Lua) `cartridge.admin_disable_failover` - deprecated
+- - (Lua) `cartridge.admin_get_failover` - deprecated
+- - (Lua) `cartridge.failover_get_params` - added
+- - (Lua) `cartridge.failover_set_params` - added
+
 ### Fixed
 
 - DDL failure if spaces is `null` in input schema.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -630,22 +630,25 @@ return {
     -- @function admin_disable_servers
     admin_disable_servers = lua_api_topology.disable_servers,
 
+--- Automatic failover management.
+-- @section failover
+
     --- .
-    -- @refer cartridge.lua-api.failover.get_failover_enabled
-    -- @function admin_get_failover
-    admin_get_failover = lua_api_failover.get_failover_enabled,
+    -- @field .
+    -- @refer cartridge.lua-api.failover.FailoverParams
+    -- @table FailoverParams
 
-    --- Enable failover.
-    -- @function admin_enable_failover
-    admin_enable_failover = function()
-        return lua_api_failover.set_failover_enabled(true)
-    end,
+    --- .
+    -- @refer cartridge.lua-api.failover.get_params
+    -- @function failover_get_params
+    failover_get_params = lua_api_failover.get_params,
+    --- .
+    -- @refer cartridge.lua-api.failover.set_params
+    -- @function failover_set_params
+    failover_set_params = lua_api_failover.set_params,
 
-    --- Disable failover.
-    -- @function admin_disable_failover
-    admin_disable_failover = function()
-        return lua_api_failover.set_failover_enabled(false)
-    end,
+    -- TODO: will be implemented later
+    -- failover_switch_leader = lua_api_failover.switch_leader,
 
 --- Managing cluster topology.
 -- @section topology
@@ -757,4 +760,19 @@ return {
     -- @refer cartridge.lua-api.deprecated.expel_server
     -- @function admin_expel_server
     admin_expel_server = lua_api_deprecated.expel_server,
+
+    --- .
+    -- @refer cartridge.lua-api.deprecated.get_failover_enabled
+    -- @function admin_get_failover
+    admin_get_failover = lua_api_failover.get_failover_enabled,
+
+    --- .
+    -- @refer cartridge.lua-api.deprecated.enable_failover
+    -- @function admin_enable_failover
+    admin_enable_failover = lua_api_failover.enable,
+
+    --- .
+    -- @refer cartridge.lua-api.deprecated.disable_failover
+    -- @function admin_disable_failover
+    admin_disable_failover = lua_api_failover.disable,
 }

--- a/cartridge/lua-api/deprecated.lua
+++ b/cartridge/lua-api/deprecated.lua
@@ -10,6 +10,7 @@ local membership = require('membership')
 local pool = require('cartridge.pool')
 local confapplier = require('cartridge.confapplier')
 local lua_api_topology = require('cartridge.lua-api.topology')
+local lua_api_failover = require('cartridge.lua-api.failover')
 
 local EditTopologyError = errors.new_class('Editing cluster topology failed')
 
@@ -228,9 +229,54 @@ local function edit_replicaset(args)
     return true
 end
 
+--- Get current failover state.
+--
+-- (**Deprecated** since v2.0.1-78)
+-- @function get_failover_enabled
+-- @treturn boolean `true`/`false`
+local function get_failover_enabled()
+    return lua_api_failover.get_params().enabled
+end
+
+--- Enable failover.
+--
+-- (**Deprecated** since v2.0.1-78)
+-- @function enable_failover
+-- @treturn[1] boolean New enabled state
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function enable_failover()
+    local ok, err = lua_api_failover.set_params({enabled = true})
+    if ok == nil then
+        return nil, err
+    end
+
+    return get_failover_enabled()
+end
+
+--- Disable failover.
+--
+-- (**Deprecated** since v2.0.1-78)
+-- @function disable_failover
+-- @treturn[1] boolean New enabled state
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function disable_failover()
+    local ok, err = lua_api_failover.set_params({enabled = false})
+    if ok == nil then
+        return nil, err
+    end
+
+    return get_failover_enabled()
+end
+
 return {
-    edit_replicaset = edit_replicaset, -- deprecated
-    edit_server = edit_server, -- deprecated
-    join_server = join_server, -- deprecated
-    expel_server = expel_server, -- deprecated
+    edit_replicaset = edit_replicaset,
+    edit_server = edit_server,
+    join_server = join_server,
+    expel_server = expel_server,
+
+    enable_failover = enable_failover,
+    disable_failover = disable_failover,
+    get_failover_enabled = get_failover_enabled,
 }

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -8,41 +8,78 @@ local errors = require('errors')
 local twophase = require('cartridge.twophase')
 local confapplier = require('cartridge.confapplier')
 
-local EditTopologyError = errors.new_class('Editing cluster topology failed')
+local FailoverSetParamsError = errors.new_class('FailoSetParamsError')
 
---- Get current failover state.
--- @function get_failover_enabled
-local function get_failover_enabled()
+--- Get failover configuration.
+--
+-- (**Added** in v2.0.1-78)
+-- @function get_params
+-- @treturn FailoverParams
+local function get_params()
     local topology_cfg = confapplier.get_readonly('topology')
-    if topology_cfg == nil then
-        return false
+    local failover_cfg = topology_cfg and topology_cfg.failover
+
+    --- Failover parameters.
+    --
+    -- (**Added** in v2.0.1-78)
+    -- @table FailoverParams
+    -- @tfield boolean enabled Wether automatic failover is enabled
+    -- @tfield nil|string coordinator_uri URI of external coordinator
+    if failover_cfg == nil then
+        return {enabled = false}
+    elseif type(failover_cfg) == 'boolean' then
+        return {enabled = failover_cfg}
+    else
+        return failover_cfg
     end
-    return topology_cfg.failover or false
 end
 
---- Enable or disable automatic failover.
--- @function set_failover_enabled
--- @tparam boolean enabled
--- @treturn[1] boolean New failover state
+--- Configure automatic failover.
+--
+-- (**Added** in v2.0.1-78)
+-- @function set_params
+-- @treturn[1] boolean `true` if config applied successfully
 -- @treturn[2] nil
 -- @treturn[2] table Error description
-local function set_failover_enabled(enabled)
-    checks('boolean')
+local function set_params(opts)
+    checks({
+        enabled = '?boolean',
+        coordinator_uri = '?string'
+    })
+
     local topology_cfg = confapplier.get_deepcopy('topology')
     if topology_cfg == nil then
-        return nil, EditTopologyError:new('Not bootstrapped yet')
+        return nil, FailoverSetParamsError:new("Cluster isn't bootstrapped yet")
     end
-    topology_cfg.failover = enabled
+
+    if opts == nil then
+        return true
+    end
+
+    -- backward compatibility with older clusterwide config
+    if topology_cfg.failover == nil then
+        topology_cfg.failover = {enabled = false}
+    elseif type(topology_cfg.failover) == 'boolean' then
+        topology_cfg.failover = {enabled = topology_cfg.failover}
+    end
+
+    if opts.enabled ~= nil then
+        topology_cfg.failover.enabled = opts.enabled
+    end
+
+    if opts.coordinator_uri ~= nil then
+        topology_cfg.failover.coordinator_uri = opts.coordinator_uri
+    end
 
     local ok, err = twophase.patch_clusterwide({topology = topology_cfg})
     if not ok then
         return nil, err
     end
 
-    return topology_cfg.failover
+    return true
 end
 
 return {
-    get_failover_enabled = get_failover_enabled,
-    set_failover_enabled = set_failover_enabled,
+    get_params = get_params,
+    set_params = set_params,
 }

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -22,7 +22,10 @@ vars:new('known_roles', {
 })
 --[[ topology_cfg: {
     auth = false,
-    failover = false,
+    failover = nil | boolean | {
+        -- enabled = boolean,
+        -- coordinator_uri = nil | 'kingdom.com:4401',
+    },
     servers = {
         -- ['instance-uuid-1'] = 'expelled',
         -- ['instance-uuid-2'] = {
@@ -125,9 +128,37 @@ local function validate_schema(field, topology)
     )
 
     e_config:assert(
-        topology.failover == nil or type(topology.failover) == 'boolean',
-        '%s.failover must be boolean, got %s', field, type(topology.failover)
+        topology.failover == nil or
+        type(topology.failover) == 'boolean' or
+        type(topology.failover) == 'table',
+        '%s.failover must be a table, got %s', field, type(topology.failover)
     )
+
+    if type(topology.failover) == 'table' then
+        e_config:assert(
+            type(topology.failover.enabled) == 'boolean',
+            '%s.failover.enabled must be boolean, got %s',
+            field, type(topology.failover.enabled)
+        )
+
+        e_config:assert(
+            topology.failover.coordinator_uri == nil or
+            type(topology.failover.coordinator_uri) == 'string',
+            '%s.failover.coordinator_uri must be a string, got %s',
+            field, type(topology.failover.coordinator_uri)
+        )
+
+        local known_keys = {
+            ['enabled'] = true,
+            ['coordinator_uri'] = true,
+        }
+        for k, _ in pairs(topology.failover) do
+            e_config:assert(
+                known_keys[k],
+                '%s.failover has unknown parameter %q', field, k
+            )
+        end
+    end
 
     e_config:assert(
         type(servers) == 'table',

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -3,17 +3,32 @@ local module_name = 'cartridge.webui.api-failover'
 local gql_types = require('cartridge.graphql.types')
 local lua_api_failover = require('cartridge.lua-api.failover')
 
-local function get_failover_enabled(_, _)
-    return lua_api_failover.get_params().enabled
+local gql_type_userapi = gql_types.object({
+    name = 'FailoverAPI',
+    description = 'Failover parameters managent',
+    fields = {
+        enabled = {
+            kind = gql_types.boolean.nonNull,
+            description = 'Whether automatic failover is enabled.',
+        },
+        coordinator_uri = {
+            kind = gql_types.string,
+            description = 'URI of external coordinator.',
+        },
+    }
+})
+
+local function get_failover_params(_, _)
+    return lua_api_failover.get_params()
 end
 
-local function set_failover_enabled(_, args)
+local function set_failover_params(_, args)
     local ok, err = lua_api_failover.set_params(args)
     if ok == nil then
         return nil, err
     end
 
-    return get_failover_enabled()
+    return get_failover_params()
 end
 
 local function init(graphql)
@@ -21,28 +36,28 @@ local function init(graphql)
     graphql.add_callback({
         prefix = 'cluster',
         name = 'failover',
-        doc = 'Get current failover state.',
+        doc = 'Get automatic failover configuration.',
         args = {},
-        kind = gql_types.boolean.nonNull,
-        callback = module_name .. '.get_failover_enabled',
+        kind = gql_type_userapi.nonNull,
+        callback = module_name .. '.get_failover_params',
     })
 
     graphql.add_mutation({
         prefix = 'cluster',
         name = 'failover',
-        doc = 'Enable or disable automatic failover. '
-            .. 'Returns new state.',
+        doc = 'Configure automatic failover.',
         args = {
-            enabled = gql_types.boolean.nonNull,
+            enabled = gql_types.boolean,
+            coordinator_uri = gql_types.string,
         },
-        kind = gql_types.boolean.nonNull,
-        callback = module_name .. '.set_failover_enabled',
+        kind = gql_type_userapi.nonNull,
+        callback = module_name .. '.set_failover_params',
     })
 
 end
 
 return {
     init = init,
-    get_failover_enabled = get_failover_enabled,
-    set_failover_enabled = set_failover_enabled,
+    get_failover_params = get_failover_params,
+    set_failover_params = set_failover_params,
 }

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -4,11 +4,16 @@ local gql_types = require('cartridge.graphql.types')
 local lua_api_failover = require('cartridge.lua-api.failover')
 
 local function get_failover_enabled(_, _)
-    return lua_api_failover.get_failover_enabled()
+    return lua_api_failover.get_params().enabled
 end
 
 local function set_failover_enabled(_, args)
-    return lua_api_failover.set_failover_enabled(args.enabled)
+    local ok, err = lua_api_failover.set_params(args)
+    if ok == nil then
+        return nil, err
+    end
+
+    return get_failover_enabled()
 end
 
 local function init(graphql)

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Sun Mar 01 2020 23:08:34 GMT+0300 (Moscow Standard Time)
+# timestamp: Tue Mar 03 2020 00:12:06 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -18,8 +18,8 @@ type Apicluster {
   """List authorized users"""
   users(username: String): [User!]
 
-  """Get current failover state."""
-  failover: Boolean!
+  """Get automatic failover configuration."""
+  failover: FailoverAPI!
   auth_params: UserManagementAPI!
 
   """Whether it is reasonble to call bootstrap_vshard mutation"""
@@ -94,6 +94,15 @@ type Error {
   message: String!
 }
 
+"""Failover parameters managent"""
+type FailoverAPI {
+  """URI of external coordinator."""
+  coordinator_uri: String
+
+  """Whether automatic failover is enabled."""
+  enabled: Boolean!
+}
+
 type Issue {
   level: String!
   replicaset_uuid: String
@@ -150,8 +159,8 @@ type MutationApicluster {
   """Applies DDL schema on cluster"""
   schema(as_yaml: String!): DDLSchema!
 
-  """Enable or disable automatic failover. Returns new state."""
-  failover(enabled: Boolean!): Boolean!
+  """Configure automatic failover."""
+  failover(coordinator_uri: String, enabled: Boolean): FailoverAPI!
 
   """Checks that schema can be applied on cluster"""
   check_schema(as_yaml: String!): DDLCheckResult!

--- a/frontend-test.sh
+++ b/frontend-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 npm run graphqlgen --prefix=webui
 npm run flow --prefix=webui
 npm run test_once --prefix=webui

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -x
 
 # lint
 .rocks/bin/luacheck .

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -97,11 +97,11 @@ function g.test_uninitialized()
 
     local resp = g.server:graphql({
         query = [[{
-            cluster { failover }
+            cluster { failover {enabled} }
         }]]
     })
 
-    t.assert_equals(resp['data']['cluster']['failover'], false)
+    t.assert_equals(resp.data.cluster.failover.enabled, false)
 
     t.assert_error_msg_contains(
         "Cluster isn't bootstrapped yet",
@@ -109,7 +109,7 @@ function g.test_uninitialized()
             return g.server:graphql({
                 query = [[
                     mutation {
-                        cluster { failover(enabled: false) }
+                        cluster { failover(enabled: false) {} }
                     }
                 ]]
             })

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -104,7 +104,7 @@ function g.test_uninitialized()
     t.assert_equals(resp['data']['cluster']['failover'], false)
 
     t.assert_error_msg_contains(
-        'Not bootstrapped yet',
+        "Cluster isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[

--- a/test/integration/failover_test.lua
+++ b/test/integration/failover_test.lua
@@ -115,21 +115,21 @@ end
 local function get_failover()
     return cluster.main_server:graphql({query = [[
         {
-            cluster { failover }
+            cluster { failover {enabled}}
         }
-    ]]}).data.cluster.failover
+    ]]}).data.cluster.failover.enabled
 end
 
 local function set_failover(enabled)
     local response = cluster.main_server:graphql({
         query = [[
             mutation($enabled: Boolean!) {
-                cluster { failover(enabled: $enabled) }
+                cluster { failover(enabled: $enabled) {enabled} }
             }
         ]],
         variables = {enabled = enabled}
     })
-    return response.data.cluster.failover
+    return response.data.cluster.failover.enabled
 end
 
 local function check_active_master(expected_uuid)

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -129,9 +129,35 @@ local function test_all()
 auth:
 ...]])
 
-    check_config('topology_new.failover must be boolean, got string',
+    check_config('topology_new.failover must be a table, got string',
 [[---
 failover:
+...]])
+
+    check_config('topology_new.failover.enabled must be boolean, got number',
+[[---
+failover:
+  enabled: 7
+...]])
+
+    check_config('topology_new.failover.enabled must be boolean, got nil',
+[[---
+failover:
+  coordinator_uri: kingdom.com
+...]])
+
+    check_config('topology_new.failover.coordinator_uri must be a string, got boolean',
+[[---
+failover:
+  enabled: true
+  coordinator_uri: false
+...]])
+
+    check_config('topology_new.failover has unknown parameter "unknown"',
+[[---
+failover:
+  enabled: true
+  unknown: yes
 ...]])
 
     check_config('topology_new has unknown parameter "unknown"',
@@ -647,7 +673,8 @@ replicasets:
     check_config(true,
 [[---
 auth: false
-failover: false
+failover:
+  enabled: false
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001
@@ -663,6 +690,9 @@ replicasets:
     check_config(true,
 [[---
 auth: true
+failover:
+  enabled: true
+  coordinator_uri: kingdom.com
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001

--- a/webui/cypress/integration/failover.spec.js
+++ b/webui/cypress/integration/failover.spec.js
@@ -1,21 +1,28 @@
 //Steps:
 //1.Failover
-//      Open probe dialog
 //      Failover turn on
 //      Failover turn off
 
 describe('Failover', () => {
   it('Failover turn on', () => {
-    cy.visit(Cypress.config('baseUrl'));
-    cy.get('.meta-test__FailoverSwitcherBtn').contains('Failover').click();//component:ClusterButtonsPanel
-    cy.get('.meta-test__FailoverControlBtn').click();//component: FailoverButton
-    cy.get('#root').contains('Failover change is OK...');//add to frontend-core classname for notification
+    cy.visit(Cypress.config('baseUrl') + '/admin/cluster/dashboard');
+    cy.get('.meta-test__FailoverButton').should('be.visible');
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('not.be.checked');
+    cy.get('.meta-test__FailoverButton').click();
+    cy.get('.meta-test__FailoverModal').contains('Failover disabled').should('exist');
+    cy.get('.meta-test__SubmitButton').contains('Enable').click();
+    cy.get('#root').contains('Failover change is OK...').click();
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('be.checked');
   })
 
   it('Failover turn off', () => {
-    cy.get('.meta-test__FailoverSwitcherBtn').contains('Failover').click();//component:ClusterButtonsPanel
-    cy.get('.meta-test__FailoverControlBtn').click();//component: FailoverButton
-    cy.get('#root').contains('Failover change is OK...');//add to frontend-core classname for notification
+    cy.visit(Cypress.config('baseUrl') + '/admin/cluster/dashboard');
+    cy.get('.meta-test__FailoverButton').should('be.visible');
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('be.checked');
+    cy.get('.meta-test__FailoverButton').click();
+    cy.get('.meta-test__FailoverModal').contains('Failover enabled').should('exist');
+    cy.get('.meta-test__SubmitButton').contains('Disable').click();
+    cy.get('#root').contains('Failover change is OK...').click();
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('not.be.checked');
   })
-
 });

--- a/webui/src/components/ClusterButtonsPanel.js
+++ b/webui/src/components/ClusterButtonsPanel.js
@@ -24,7 +24,7 @@ const ClusterButtonsPanel = (
   }: ClusterButtonsPanelProps) => {
   return (
     <PageSection
-      className='meta-test__FailoverSwitcherBtn'
+      className='meta-test__ButtonsPanel'
       topRightControls={[
         <ProbeServerModal />,
         showToggleAuth && <AuthToggleButton />,

--- a/webui/src/components/FailoverButton.js
+++ b/webui/src/components/FailoverButton.js
@@ -11,7 +11,7 @@ import {
 } from '@tarantool.io/ui-kit';
 import { SwitcherIconContainer, ModalInfoContainer, SwitcherInfoLine } from './styled'
 
-const description = `When enabled, every storage starts monitoring instance statuses.  
+const description = `When enabled, every storage starts monitoring instance statuses.
 If a user-specified master goes down, a replica with the lowest UUID takes its place.
 When the user-specified master comes back online, both roles are restored.`
 
@@ -27,32 +27,37 @@ const FailoverButton = ({
   return (
     <React.Fragment>
       <Switcher
+        className='meta-test__FailoverButton'
         onChange={() => dispatch(setVisibleFailoverModal(true))}
-        checked={failover}
+        checked={failover.enabled}
       >
         Failover
       </Switcher>
       <Modal
-        className='meta-test__FailoverControl'
+        className='meta-test__FailoverModal'
         title="Failover control"
         visible={showFailoverModal}
         onClose={() => dispatch(setVisibleFailoverModal(false))}
         footerControls={[
-          <Button onClick={() => dispatch(setVisibleFailoverModal(false))}>Close</Button>,
           <Button
-            className='meta-test__FailoverControlBtn'
-            intent='primary'
-            onClick={() => dispatch(changeFailover({ enabled: !failover }))}
+            onClick={() => dispatch(setVisibleFailoverModal(false))}
           >
-            {failover ? 'Disable' : 'Enable'}
+            Close
+          </Button>,
+          <Button
+            className='meta-test__SubmitButton'
+            intent='primary'
+            onClick={() => dispatch(changeFailover({ enabled: !failover.enabled }))}
+          >
+            {failover.enabled ? 'Disable' : 'Enable'}
           </Button>
         ]}
       >
         <ModalInfoContainer>
           <SwitcherInfoLine>
             <Text variant={'basic'}>
-              <SwitcherIconContainer>{failover ? <IconOk/> : <IconCancel/>}</SwitcherIconContainer>
-              Failover <b>{failover ? 'enabled' : 'disabled'}</b>
+              <SwitcherIconContainer>{failover.enabled ? <IconOk/> : <IconCancel/>}</SwitcherIconContainer>
+              Failover <b>{failover.enabled ? 'enabled' : 'disabled'}</b>
             </Text>
           </SwitcherInfoLine>
           <SwitcherInfoLine>

--- a/webui/src/pages/Cluster/index.js
+++ b/webui/src/pages/Cluster/index.js
@@ -63,7 +63,7 @@ const styles = {
 
 export type ClusterProps = {
   clusterSelf: $PropertyType<AppState, 'clusterSelf'>,
-  failover: boolean,
+  failover: {enabled: boolean},
   pageMount: boolean,
   pageDataRequestStatus: RequestStatusType,
   replicasetCounts: ReplicasetCounts,

--- a/webui/src/store/request/clusterPage.requests.js
+++ b/webui/src/store/request/clusterPage.requests.js
@@ -171,7 +171,7 @@ export async function changeFailover(params: ChangeFailoverArgs) {
   const clusterSelfResponse = await getClusterSelf();
   return {
     changeFailoverResponse: {
-      changeFailover: changeFailoverResponse,
+      changeFailover: changeFailoverResponse.enabled,
       clusterSelf: clusterSelfResponse
     }
   };

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -31,7 +31,7 @@ export const getClusterQuery = gql`
         uuid: uuid
         demo_uri
       }
-      failover
+      failover { enabled }
       knownRoles: known_roles {
         name
         dependencies
@@ -58,7 +58,7 @@ export const getClusterQuery = gql`
 `;
 
 export const boxInfoQuery = gql`
-  query boxInfo ($uuid: String){ 
+  query boxInfo ($uuid: String){
     servers(uuid: $uuid) {
       alias
       status
@@ -218,7 +218,7 @@ export const instanceDataQuery = gql`
         }
       }
     }
-    
+
     descriptionCartridge: __type(name: "ServerInfoCartridge") {
       fields {
         name
@@ -402,7 +402,9 @@ mutation changeFailover (
   cluster {
     failover(
       enabled: $enabled
-    )
+    ) {
+      enabled
+    }
   }
 }
 `;
@@ -510,7 +512,7 @@ export const setFilesMutation = gql`
         filename
         content
       }
-    }  
+    }
   }
 `;
 


### PR DESCRIPTION
This patch is necessary in context of #148 for upcoming failover changes.

### Failover configuration

 Clusterwide config schema is extended (preserving backward compatibility):

```yaml
# topology.yml
failover: true # old
failover:      # new
  enabled: true
  coordinator_uri: "localhost:3310"
```

### Lua API:
- `cartridge.admin_enable/disable_failover` - deprecated in favor of `failover_set_params`.
- `cartridge.admin_get_failover` - deprecated in favor of `failover_get_params`.
- `cartridge.failover_get_params` - returns `{enabled = ..., coordinator_uri = ...}`
- `cartridge.failover_set_params({enabled = ..., coordinator_uri = ...})`

### GraphQL API
- `query {cluster {failover {enabled coordinator_uri} }}` - changed (returns composite type instead of boolean)
- `mutation {cluster {failover(enabled: ... coordinator_uri: ...) {enabled coordinator_uri} }}` - changed (returns composite type instead of boolean)

### P.S.

I've changed frontend code and cypress tests to conform the new API. @rgbabaev, please check its correctness.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

