### PR TITLE
Fix flaky rejoin.test_rebootstrap

### DIFF
--- a/test/integration/rejoin_test.lua
+++ b/test/integration/rejoin_test.lua
@@ -55,8 +55,8 @@ function g.test_rebootstrap()
 
     local err = t.assert_error(function() g.cluster:join_server(g.server) end)
 
-    -- Retrying was added because of process can be alive (exists in process table)
-    -- for a little time with Zombie state due to asynchroniuos libev child process waiting
+    -- Retrying was added because of process can be a Zombie
+    -- for a little time due to libev child reaping
     t.helpers.retrying({}, function()
         t.assert_not(g.server.process:is_alive())
     end)

--- a/test/integration/rejoin_test.lua
+++ b/test/integration/rejoin_test.lua
@@ -23,7 +23,6 @@ g.setup = function()
         }},
     })
 
-
     g.cluster:start()
 end
 
@@ -54,13 +53,13 @@ function g.test_rebootstrap()
         g.server:graphql({query = '{}'})
     end)
 
-    local ok, err = pcall(
-        helpers.Cluster.join_server,
-        g.cluster, g.server
-    )
-    t.assert(err)
-    t.assert_not(ok)
-    t.assert_not(g.server.process:is_alive())
+    local err = t.assert_error(function() g.cluster:join_server(g.server) end)
+
+    -- Retrying was added because of process can be alive (exists in process table)
+    -- for a little time with Zombie state due to asynchroniuos libev child process waiting
+    t.helpers.retrying({}, function()
+        t.assert_not(g.server.process:is_alive())
+    end)
 
     t.assert_equals(g.server.net_box:ping(), false)
     t.assert_equals(g.server.net_box.state, 'error')


### PR DESCRIPTION
Fixed flaky test_rebootsrap by adding retrying for test assert

I didn't forget about

- [X] Tests
- [X] Changelog
- [X] Documentation
