### PR TITLE
Fix dead server details error

### DIFF
--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -162,3 +162,7 @@ end
 function g.test_offline_splash()
     cypress_run('network-error-splash.spec.js')
 end
+
+function g.test_dead_server()
+    cypress_run('server-details-dead-server.spec.js')
+end

--- a/test/cypress/basic_test.lua
+++ b/test/cypress/basic_test.lua
@@ -128,6 +128,7 @@ function g.test_users()
         ',cypress/integration/edit-user.spec.js' ..
         ',cypress/integration/remove-user.spec.js' ..
         ',cypress/integration/server-details.spec.js' ..
+        ',cypress/integration/server-details-dead-server.spec.js' ..
         ',cypress/integration/login-and-logout.spec.js'..
         ',cypress/integration/auth-switcher-not-moved.spec.js'
     )
@@ -161,8 +162,4 @@ end
 
 function g.test_offline_splash()
     cypress_run('network-error-splash.spec.js')
-end
-
-function g.test_dead_server()
-    cypress_run('server-details-dead-server.spec.js')
 end

--- a/webui/cypress/integration/server-details-dead-server.spec.js
+++ b/webui/cypress/integration/server-details-dead-server.spec.js
@@ -2,11 +2,22 @@ describe('Server details - dead server', () => {
   it('Server details - dead server', () => {
     cy.visit(Cypress.config('baseUrl'));
     cy.exec('kill -SIGSTOP $(lsof -sTCP:LISTEN -i :8082 -t)', { failOnNonZeroExit: true });
-    cy.get('li').contains('storage1-do-not-use-me').closest('li').find('.meta-test__ReplicasetServerListItem__dropdownBtn').eq(0).click();
-    cy.get('.meta-test__ReplicasetServerListItem__dropdownBtn').contains('Server details').click(); 
+    cy.get('.ServerLabelsHighlightingArea').contains(':13302').closest('li')
+      .find('.meta-test__ReplicasetServerListItem__dropdownBtn').eq(0).click();
+    cy.get('.meta-test__ReplicasetServerListItem__dropdownBtn').contains('Server details').click();
     cy.get('.meta-test__ServerInfoModal').contains('Server status is "suspect"');
-    cy.get('.meta-test__ServerInfoModal').find('button').contains('Cartridge').click();
-    cy.get('.meta-test__ServerInfoModal button[type="button"]').contains('Close').click();
+    cy.get('.meta-test__ServerInfoModal button').contains('Cartridge').click();
+    cy.get('.meta-test__ServerInfoModal button').contains('Replication').click();
+    cy.get('.meta-test__ServerInfoModal button').contains('Storage').click();
+    cy.get('.meta-test__ServerInfoModal button').contains('Network').click();
+    cy.get('.meta-test__ServerInfoModal button').contains('General').click();
     cy.exec('kill -SIGCONT $(lsof -sTCP:LISTEN -i :8082 -t)', { failOnNonZeroExit: true });
+    // FIXME panel with status isn't updated
+    // cy.get('.meta-test__ServerInfoModal').contains('healthy');
+    cy.get('.meta-test__ServerInfoModal').contains('instance_uuid');
+    cy.get('.meta-test__ServerInfoModal').contains('bbbbbbbb-bbbb-0000-0000-000000000001');
+    cy.get('.meta-test__ServerInfoModal button').contains('Close').click();
+    cy.get('.ServerLabelsHighlightingArea').contains(':13302').closest('li')
+      .contains('healthy');
   })
 });

--- a/webui/cypress/integration/server-details-dead-server.spec.js
+++ b/webui/cypress/integration/server-details-dead-server.spec.js
@@ -1,0 +1,12 @@
+describe('Server details - dead server', () => {
+  it('Server details - dead server', () => {
+    cy.visit(Cypress.config('baseUrl'));
+    cy.exec('kill -SIGSTOP $(lsof -sTCP:LISTEN -i :8082 -t)', { failOnNonZeroExit: true });
+    cy.get('li').contains('storage1-do-not-use-me').closest('li').find('.meta-test__ReplicasetServerListItem__dropdownBtn').eq(0).click();
+    cy.get('.meta-test__ReplicasetServerListItem__dropdownBtn').contains('Server details').click(); 
+    cy.get('.meta-test__ServerInfoModal').contains('Server status is "suspect"');
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('Cartridge').click();
+    cy.get('.meta-test__ServerInfoModal button[type="button"]').contains('Close').click();
+    cy.exec('kill -SIGCONT $(lsof -sTCP:LISTEN -i :8082 -t)', { failOnNonZeroExit: true });
+  })
+});

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -10,9 +10,11 @@ describe('Detail server', () => {
   it('Detail server', () => {
     cy.visit(Cypress.config('baseUrl'));
     cy.get('li').contains('storage1-do-not-use-me').closest('li').find('.meta-test__ReplicasetServerListItem__dropdownBtn').eq(0).click();
-    cy.get('.meta-test__ReplicasetServerListItem__dropdownBtn').contains('Server details').click(); //need to change conteins later
-    cy.get('.meta-test__ServerInfoModal').find('button').contains('General').click(); //need to change conteins later
-    cy.get('.meta-test__ServerInfoModal').find('button').contains('Replication').click(); //need to change conteins later
-    cy.get('.meta-test__ServerInfoModal').find('button').contains('Storage').click(); //need to change conteins later
+    cy.get('.meta-test__ReplicasetServerListItem__dropdownBtn').contains('Server details').click();
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('Cartridge').click();
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('Replication').click();
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('Storage').click();
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('Network').click();
+    cy.get('.meta-test__ServerInfoModal').find('button').contains('General').click();
   })
 });

--- a/webui/src/components/ClusterInstanceSection.js
+++ b/webui/src/components/ClusterInstanceSection.js
@@ -94,7 +94,7 @@ const mapStateToProps = (
   },
   { sectionName }
 ) => {
-  const section = boxinfo[sectionName];
+  const section = boxinfo && boxinfo[sectionName] || {};
 
   return {
     descriptions: descriptions[sectionName],

--- a/webui/src/components/ServerInfoModal.js
+++ b/webui/src/components/ServerInfoModal.js
@@ -74,8 +74,7 @@ class ServerInfoModal extends React.Component<ServerInfoModalProps, ServerInfoMo
       status,
       uri
     } = this.props
-    console.log(ServerInfoModal.tabsOrder);
-    
+
     return (
       <Modal
         className='meta-test__ServerInfoModal'

--- a/webui/src/store/reducers/app.reducer.js
+++ b/webui/src/store/reducers/app.reducer.js
@@ -66,7 +66,7 @@ const initialState: AppState = {
   connectionAlive: true,
   failover: null,
   messages: [],
-  authParams: {},
+  authParams: {}
 };
 
 const appMountReducer = getReducer(APP_DID_MOUNT, { appMount: true });


### PR DESCRIPTION
Fix WebUI crash when opening details for a dead server.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Close #620
