### PR TITLE
Fullmesh state recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - - (GraphQL) `mutation {cluster {failover(){}}}` - changed
       (returns composite type instead of boolean)
 
+- Transition from instance state `ConnectingFullmesh` to `OperationError` is
+  deprecated, now if error occured on instance during `ConnectingFullmesh`
+  state then instance returns an error, but stays at `ConnectingFullmesh`
+  state and tries to reconnect in separate fiber
+
 ### Fixed
 
 - DDL failure if spaces is `null` in input schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - - (GraphQL) `mutation {cluster {failover(){}}}` - changed
       (returns composite type instead of boolean)
 
-- Transition from instance state `ConnectingFullmesh` to `OperationError` is
-  deprecated, now if error occured on instance during `ConnectingFullmesh`
-  state then instance returns an error, but stays at `ConnectingFullmesh`
-  state and tries to reconnect in separate fiber
+- Prevent instance state transition from `ConnectingFullmesh` to
+  `OperationError` if replication fails to connect or to sync. Since now
+  such fails result in staying in `ConnectingFullmesh` state until it
+  succeeds.
 
 ### Fixed
 

--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -377,7 +377,7 @@ end
 function g.test_orphan_connect_timeout()
     -- If the master can't connect to the slave in
     -- <TARANTOOL_REPLICATION_CONNECT_TIMEOUT> seconds
-    -- it stays in ConnectingFullmesh state until reconnects
+    -- it stays in ConnectingFullmesh state until it reconnects
 
     g.master:stop()
     g.slave:stop()
@@ -414,6 +414,7 @@ function g.test_orphan_connect_timeout()
     g.slave:start()
     wish_state(g.slave, 'RolesConfigured')
     wish_state(g.master, 'RolesConfigured')
+    g.cluster:wait_until_healthy(g.slave)
 
     t.assert_equals(
         get_upstream_info(g.slave),
@@ -471,6 +472,11 @@ function g.test_orphan_sync_timeout()
         )
         t.assert_equals(issues[2], nil)
     end)
+
+    g.master.net_box:eval('box.cfg({replication_sync_lag = 30})')
+    wish_state(g.master, 'RolesConfigured')
+    g.cluster:wait_until_healthy(g.master)
+    g.cluster:wait_until_healthy(g.slave)
 end
 
 function g.test_quorum_one()


### PR DESCRIPTION
Removed transition from ConnectingFullmesh state to OperationError if error occurred, instead  instance stays in ConnectingFullmesh state until reconnects.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

References to #566 
