### PR TITLE
Fix rpc on uninitialized cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Make GraphQL compatible with `req:read_cached()` call in httpd hooks.
 
+- Avoid "attempt to index nil value" error when using rpc on an
+  uninitialized instance.
+
 ## [2.0.1] - 2020-01-15
 
 ### Added

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -80,8 +80,12 @@ local function get_candidates(role_name, opts)
     })
 
     local topology_cfg = confapplier.get_readonly('topology')
-    local servers = topology_cfg.servers
-    local replicasets = topology_cfg.replicasets
+    if topology_cfg == nil then
+        return {}
+    end
+
+    local servers = assert(topology_cfg.servers)
+    local replicasets = assert(topology_cfg.replicasets)
     local active_leaders
     if opts.leader_only then
         active_leaders = failover.get_active_leaders()

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -176,3 +176,20 @@ function g.test_membership_options()
         100
     )
 end
+
+function g.test_rpc()
+    local candidates = g.server.net_box:call(
+        'package.loaded.cartridge.rpc_get_candidates',
+        {'myrole-permanent'}
+    )
+    t.assert_equals(candidates, {})
+
+    local _, err = g.server.net_box:call(
+        'package.loaded.cartridge.rpc_call',
+        {'myrole-permanent', 'unknown'}
+    )
+    t.assert_covers(err, {
+        class_name = "RemoteCallError",
+        err = 'No remotes with role "myrole-permanent" available',
+    })
+end


### PR DESCRIPTION
Avoid "attempt to index nil value" error when using rpc on an
uninitialized instance.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #560
