### PR TITLE
Gh 587 describe tarantool migration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,10 +118,13 @@ compatibility:
   variables:
     IMAGE_NAME: *IMAGE_NAME_EE
     CARTRIDGE_OLDER_PATH: /tmp/cartridge-1.2.0
+    TARANTOOL_OLDER_PATH: ${PWD}/tarantool-enterprise/tarantool
+    TARANTOOL_NEWER_PATH: /usr/bin/tarantool
   script:
     - mkdir -p $CARTRIDGE_OLDER_PATH
     - (cd $CARTRIDGE_OLDER_PATH; tarantoolctl rocks install cartridge 1.2.0-1)
-    - luatest -v -p compatibility.upgrade
+    - curl -L https://tarantool.io/installer.sh | VER=2.2 bash
+    - luatest -v -p compatibility
 
 misc:
   <<: *test-template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add option for clusterwide env in test helpers.
 
+- New option in `cartridge.cfg({auto_upgrade_schema=...}, ...)`
+  to perform auto upgrade schema to actual tarantool version
+  (only for leader). It also has bean added for `argparse`.
+
 ### Changed
 
 - Network error shows with fixed splash panel instead of notification.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -186,6 +186,13 @@ end
 --   List of pages to be hidden in WebUI.
 --   (**Added** in v2.0.1-54, default: `{}`)
 --
+-- @tparam ?boolean opts.auto_upgrade_schema
+--   Auto schema upgrade.
+--   (**Added** in v2.0.1-54,
+--   default: `false`, overridden by
+--   env `TARANTOOL_AUTO_UPGRADE_SCHEMA`
+--   args `--auto-upgrade-schema`)
+--
 -- @tparam ?table box_opts
 --   tarantool extra box.cfg options (e.g. memtx_memory),
 --   that may require additional tuning
@@ -208,6 +215,7 @@ local function cfg(opts, box_opts)
         vshard_groups = '?table',
         console_sock = '?string',
         webui_blacklist = '?table',
+        auto_upgrade_schema = '?boolean',
     }, '?table')
 
     if opts.webui_blacklist ~= nil then
@@ -509,6 +517,7 @@ local function cfg(opts, box_opts)
         box_opts = box_opts,
         binary_port = advertise.service,
         advertise_uri = advertise_uri,
+        auto_upgrade_schema = opts.auto_upgrade_schema,
     })
     if not ok then
         return nil, err

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -91,6 +91,7 @@ local cluster_opts = {
     console_sock = 'string', -- **string**
     auth_enabled = 'boolean', -- **boolean**
     bucket_count = 'number', -- **number**
+    auto_upgrade_schema = 'boolean', -- **boolean**
 }
 
 --- Common [box.cfg](https://www.tarantool.io/en/doc/latest/reference/configuration/) tuning options.

--- a/test/compatibility/upgrade_schema_test.lua
+++ b/test/compatibility/upgrade_schema_test.lua
@@ -1,0 +1,88 @@
+local fio = require('fio')
+
+local helpers = require('test.helper')
+local t = require('luatest')
+local g = t.group()
+
+function g.before_all()
+    g.tempdir = fio.tempdir()
+    g.srv_basic = helpers.entrypoint('srv_basic')
+    g.cluster = helpers.Cluster:new({
+        datadir = g.tempdir,
+        use_vshard = true,
+        cookie = 'test-cluster-cookie',
+        server_command = g.srv_basic,
+        args = nil,
+        replicasets = {{
+            uuid = helpers.uuid('a'),
+            roles = {'vshard-router', 'vshard-storage'},
+            servers = {{
+                alias = 'leader',
+                instance_uuid = helpers.uuid('a', 'a', 1),
+                advertise_port = 13301,
+                http_port = 8081,
+                env = {
+                    TARANTOOL_AUTO_UPGRADE_SCHEMA = 'true',
+                },
+            }, {
+                alias = 'replica',
+                instance_uuid = helpers.uuid('a', 'a', 2),
+                advertise_port = 13302,
+                http_port = 8082,
+            }},
+        }},
+    })
+end
+
+function g.after_all()
+    fio.rmtree(g.tempdir)
+end
+
+local function start_cartridge(server_command, ...)
+    g.cluster.server_command = server_command
+    g.cluster.args = {...}
+    for _, server in ipairs(g.cluster.servers) do
+        server.command = server_command
+        server.args = {...}
+    end
+    g.cluster:start()
+end
+
+function g.test_upgrade()
+    local tarantool_older_path = os.getenv('TARANTOOL_OLDER_PATH')
+    local tarantool_newer_path = os.getenv('TARANTOOL_NEWER_PATH')
+    t.skip_if(
+        tarantool_older_path == nil or tarantool_newer_path == nil,
+        'No older or newer version provided. Skipping'
+    )
+
+    start_cartridge(tarantool_older_path, g.srv_basic)
+    g.cluster.main_server.net_box:eval([[
+box.schema.create_space('test', {
+    format = {
+        id = 'unsigned',
+        name = 'string'
+    }
+})
+]])
+    local old_tarantool_version = string.split(
+        g.cluster.main_server.net_box:eval('return _TARANTOOL'), '.'
+    )
+    local old_schema_version = g.cluster.main_server.net_box.space._schema:get{'version'}
+    t.assert_equals(old_schema_version[2], tonumber(old_tarantool_version[1]))
+    t.assert_equals(old_schema_version[3], tonumber(old_tarantool_version[2]))
+    local old_space = g.cluster.main_server.net_box:eval('return box.space')
+    g.cluster:stop()
+
+    start_cartridge(tarantool_newer_path, g.srv_basic)
+    local new_tarantool_version = string.split(
+        g.cluster.main_server.net_box:eval('return _TARANTOOL'), '.'
+    )
+    local new_schema_version = g.cluster.main_server.net_box.space._schema:get{'version'}
+    t.assert_equals(new_schema_version[2], tonumber(new_tarantool_version[1]))
+    t.assert_equals(new_schema_version[3], tonumber(new_tarantool_version[2]))
+
+    local new_space = g.cluster.main_server.net_box:eval('return box.space')
+    t.assert_equals(old_space, new_space)
+    g.cluster:stop()
+end


### PR DESCRIPTION
Add new option `auto_upgrade_schema` (boolen) for `cartridge.cfg` which pass in `boot_instance`. It is used for upgrade schema to actual tarantool version (only for leader). The option has bean added for `argparse`.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #587 
