### PR TITLE
Refactor failover API once again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,13 +65,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Lua API:
 
 - `cartridge.admin_get_failover` -> `cartridge.failover_get_params`
-- `cartridge.admin_enable_failover` -> `cartridge.failover_set_params`
-- `cartridge.admin_disable_failover`
+- `cartridge.admin_enable/disable_failover` -> `cartridge.failover_set_params`
 
 GraphQL API:
 
-- `query {cluster {failover} }` -> `query {cluster {failover_params} }`
-- `mutation {cluster {failover()} }` -> `mutation {cluster {failover_params()} }`
+- `query {cluster {failover} }` -> `query {cluster {failover_params {...} } }`
+- `mutation {cluster {failover()} }` -> `mutation {cluster {failover_params() {...} } }`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   such fails result in staying in `ConnectingFullmesh` state until it
   succeeds.
 
+### Deprecated
+
+Lua API:
+
+- `cartridge.admin_get_failover` -> `cartridge.failover_get_params`
+- `cartridge.admin_enable_failover` -> `cartridge.failover_set_params`
+- `cartridge.admin_disable_failover`
+
+GraphQL API:
+
+- `query {cluster {failover} }` -> `query {cluster {failover_params} }`
+- `mutation {cluster {failover()} }` -> `mutation {cluster {failover_params()} }`
+
 ### Fixed
 
 - DDL failure if spaces is `null` in input schema.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -636,18 +636,43 @@ return {
     -- @function admin_bootstrap_vshard
     admin_bootstrap_vshard = lua_api_vshard.bootstrap_vshard,
 
+
+--- Automatic failover management.
+-- @section failover
+
+    --- .
+    -- @field .
+    -- @refer cartridge.lua-api.failover.FailoverParams
+    -- @table FailoverParams
+
+    --- .
+    -- @refer cartridge.lua-api.failover.get_params
+    -- @function failover_get_params
+    failover_get_params = lua_api_failover.get_params,
+    --- .
+    -- @refer cartridge.lua-api.failover.set_params
+    -- @function failover_set_params
+    failover_set_params = lua_api_failover.set_params,
+
+    -- TODO: will be implemented later
+    -- failover_switch_leader = lua_api_failover.switch_leader,
+
     --- .
     -- @refer cartridge.lua-api.failover.get_failover_enabled
     -- @function admin_get_failover
     admin_get_failover = lua_api_failover.get_failover_enabled,
 
     --- Enable failover.
+    -- (**Deprecated** since v2.0.1-?? in favor of
+    -- `cartridge.failover_set_params`)
     -- @function admin_enable_failover
     admin_enable_failover = function()
         return lua_api_failover.set_failover_enabled(true)
     end,
 
     --- Disable failover.
+    -- (**Deprecated** since v2.0.1-?? in favor of
+    -- `cartridge.failover_set_params`)
     -- @function admin_disable_failover
     admin_disable_failover = function()
         return lua_api_failover.set_failover_enabled(false)

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -663,7 +663,7 @@ return {
     admin_get_failover = lua_api_failover.get_failover_enabled,
 
     --- Enable failover.
-    -- (**Deprecated** since v2.0.1-?? in favor of
+    -- (**Deprecated** since v2.0.1-95 in favor of
     -- `cartridge.failover_set_params`)
     -- @function admin_enable_failover
     admin_enable_failover = function()
@@ -671,7 +671,7 @@ return {
     end,
 
     --- Disable failover.
-    -- (**Deprecated** since v2.0.1-?? in favor of
+    -- (**Deprecated** since v2.0.1-95 in favor of
     -- `cartridge.failover_set_params`)
     -- @function admin_disable_failover
     admin_disable_failover = function()

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -205,7 +205,8 @@ local function cfg(clusterwide_config)
     local topology_cfg = clusterwide_config:get_readonly('topology')
     assert(topology_cfg ~= nil)
 
-    local new_mode = topology_cfg.failover and 'eventual' or 'disabled'
+    local failover_cfg = topology.get_failover_params(topology_cfg)
+    local new_mode = failover_cfg.mode
     if vars.mode ~= new_mode then
         vars.notification:signal()
         log.info('Failover mode set to %q', new_mode)

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -13,13 +13,13 @@ local FailoverSetParamsError = errors.new_class('FailoverSetParamsError')
 
 --- Get failover configuration.
 --
--- (**Added** in v2.0.1-??)
+-- (**Added** in v2.0.1-95)
 -- @function get_params
 -- @treturn FailoverParams
 local function get_params()
     --- Failover parameters.
     --
-    -- (**Added** in v2.0.1-??)
+    -- (**Added** in v2.0.1-95)
     -- @table FailoverParams
     -- @tfield string mode Supported modes are "disabled", "eventual"
     --   and "stateful"
@@ -31,7 +31,7 @@ end
 
 --- Configure automatic failover.
 --
--- (**Added** in v2.0.1-??)
+-- (**Added** in v2.0.1-95)
 -- @function set_params
 -- @tparam table opts
 -- @tparam ?string opts.mode
@@ -81,7 +81,7 @@ end
 
 --- Get current failover state.
 --
--- (**Deprecated** since v2.0.1-??)
+-- (**Deprecated** since v2.0.1-95)
 -- @function get_failover_enabled
 local function get_failover_enabled()
     return get_params().mode ~= 'disabled'
@@ -89,7 +89,7 @@ end
 
 --- Enable or disable automatic failover.
 --
--- (**Deprecated** since v2.0.1-??)
+-- (**Deprecated** since v2.0.1-95)
 -- @function set_failover_enabled
 -- @tparam boolean enabled
 -- @treturn[1] boolean New failover state

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -6,21 +6,90 @@ local checks = require('checks')
 local errors = require('errors')
 
 local twophase = require('cartridge.twophase')
+local topology = require('cartridge.topology')
 local confapplier = require('cartridge.confapplier')
 
-local EditTopologyError = errors.new_class('Editing cluster topology failed')
+local FailoverSetParamsError = errors.new_class('FailoverSetParamsError')
+
+--- Get failover configuration.
+--
+-- (**Added** in v2.0.1-??)
+-- @function get_params
+-- @treturn FailoverParams
+local function get_params()
+    --- Failover parameters.
+    --
+    -- (**Added** in v2.0.1-??)
+    -- @table FailoverParams
+    -- @tfield string mode Supported modes are "disabled", "eventual"
+    --   and "stateful"
+    -- @tfield nil|string coordinator_uri URI of external coordinator
+    return topology.get_failover_params(
+        confapplier.get_readonly('topology')
+    )
+end
+
+--- Configure automatic failover.
+--
+-- (**Added** in v2.0.1-??)
+-- @function set_params
+-- @tparam table opts
+-- @tparam ?string opts.mode
+-- @tparam ?string opts.coordinator_uri
+-- @treturn[1] boolean `true` if config applied successfully
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function set_params(opts)
+    checks({
+        mode = '?string',
+        coordinator_uri = '?string'
+    })
+
+    local topology_cfg = confapplier.get_deepcopy('topology')
+    if topology_cfg == nil then
+        return nil, FailoverSetParamsError:new("Cluster isn't bootstrapped yet")
+    end
+
+    if opts == nil then
+        return true
+    end
+
+    -- backward compatibility with older clusterwide config
+    if topology_cfg.failover == nil then
+        topology_cfg.failover = {mode = 'disabled'}
+    elseif type(topology_cfg.failover) == 'boolean' then
+        topology_cfg.failover = {
+            mode = topology_cfg.failover and 'eventual' or 'disabled',
+        }
+    end
+
+    if opts.mode ~= nil then
+        topology_cfg.failover.mode = opts.mode
+    end
+
+    if opts.coordinator_uri ~= nil then
+        topology_cfg.failover.coordinator_uri = opts.coordinator_uri
+    end
+
+    local ok, err = twophase.patch_clusterwide({topology = topology_cfg})
+    if not ok then
+        return nil, err
+    end
+
+    return true
+end
 
 --- Get current failover state.
+--
+-- (**Deprecated** since v2.0.1-??)
 -- @function get_failover_enabled
 local function get_failover_enabled()
-    local topology_cfg = confapplier.get_readonly('topology')
-    if topology_cfg == nil then
-        return false
-    end
-    return topology_cfg.failover or false
+    return get_params().mode ~= 'disabled'
 end
 
 --- Enable or disable automatic failover.
+--
+-- (**Deprecated** since v2.0.1-??)
 -- @function set_failover_enabled
 -- @tparam boolean enabled
 -- @treturn[1] boolean New failover state
@@ -28,21 +97,19 @@ end
 -- @treturn[2] table Error description
 local function set_failover_enabled(enabled)
     checks('boolean')
-    local topology_cfg = confapplier.get_deepcopy('topology')
-    if topology_cfg == nil then
-        return nil, EditTopologyError:new('Not bootstrapped yet')
-    end
-    topology_cfg.failover = enabled
-
-    local ok, err = twophase.patch_clusterwide({topology = topology_cfg})
-    if not ok then
+    local ok, err = set_params({
+        mode = enabled and 'eventual' or 'disabled'
+    })
+    if ok == nil then
         return nil, err
     end
 
-    return topology_cfg.failover
+    return get_failover_enabled()
 end
 
 return {
-    get_failover_enabled = get_failover_enabled,
-    set_failover_enabled = set_failover_enabled,
+    get_params = get_params,
+    set_params = set_params,
+    get_failover_enabled = get_failover_enabled, -- deprecated
+    set_failover_enabled = set_failover_enabled, -- deprecated
 }

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -7,6 +7,7 @@
 
 local fun = require('fun')
 -- local log = require('log')
+local uri = require('uri')
 local checks = require('checks')
 local errors = require('errors')
 local membership = require('membership')
@@ -22,7 +23,10 @@ vars:new('known_roles', {
 })
 --[[ topology_cfg: {
     auth = false,
-    failover = false,
+    failover = nil | boolean | {
+        -- mode = 'disabled'|'eventual'|'stateful',
+        -- coordinator_uri = nil | 'kingdom.com:4401',
+    },
     servers = {
         -- ['instance-uuid-1'] = 'expelled',
         -- ['instance-uuid-2'] = {
@@ -125,9 +129,66 @@ local function validate_schema(field, topology)
     )
 
     e_config:assert(
-        topology.failover == nil or type(topology.failover) == 'boolean',
-        '%s.failover must be boolean, got %s', field, type(topology.failover)
+        topology.failover == nil or
+        type(topology.failover) == 'boolean' or
+        type(topology.failover) == 'table',
+        '%s.failover must be a table, got %s', field, type(topology.failover)
     )
+
+    if type(topology.failover) == 'table' then
+        e_config:assert(
+            type(topology.failover.mode) == 'string',
+            '%s.failover.mode must be string, got %s',
+            field, type(topology.failover.mode)
+        )
+        e_config:assert(
+            topology.failover.mode == 'disabled' or
+            topology.failover.mode == 'eventual' or
+            topology.failover.mode == 'stateful',
+            '%s.failover.mode %q is unknown',
+            field, topology.failover.mode
+        )
+
+        if topology.failover.mode == 'stateful' then
+            e_config:assert(
+                topology.failover.coordinator_uri ~= nil,
+                '%s.failover missing coordinator_uri for mode "stateful"',
+                field
+            )
+        end
+
+        if topology.failover.coordinator_uri ~= nil then
+            e_config:assert(
+                type(topology.failover.coordinator_uri) == 'string',
+                '%s.failover.coordinator_uri must be a string, got %s',
+                field, type(topology.failover.coordinator_uri)
+            )
+
+            local parts = uri.parse(topology.failover.coordinator_uri)
+            e_config:assert(
+                type(parts) == 'table',
+                '%s.failover.coordinator_uri invalid URI %q',
+                field, topology.failover.coordinator_uri
+            )
+
+            e_config:assert(
+                parts.service ~= nil,
+                '%s.failover.coordinator_uri invalid URI %q (missing port)',
+                field, topology.failover.coordinator_uri
+            )
+        end
+
+        local known_keys = {
+            ['mode'] = true,
+            ['coordinator_uri'] = true,
+        }
+        for k, _ in pairs(topology.failover) do
+            e_config:assert(
+                known_keys[k],
+                '%s.failover has unknown parameter %q', field, k
+            )
+        end
+    end
 
     e_config:assert(
         type(servers) == 'table',
@@ -450,6 +511,26 @@ local function validate(topology_new, topology_old)
     return true
 end
 
+local function get_failover_params(topology_cfg)
+    checks('?table')
+    if topology_cfg == nil then
+        return {
+            mode = 'disabled',
+        }
+    elseif topology_cfg.__type == 'ClusterwideConfig' then
+        local err = "Bad argument #1 to get_failover_params" ..
+            " (table expected, got ClusterwideConfig)"
+        error(err, 2)
+    elseif type(topology_cfg.failover) == 'boolean' then
+        return {
+            mode = topology_cfg.failover and 'eventual' or 'disabled'
+        }
+    else
+        assert(type(topology_cfg.failover) == 'table')
+        return topology_cfg.failover
+    end
+end
+
 --- Find the server in topology config.
 --
 -- (**Added** in v1.2.0-17)
@@ -590,6 +671,7 @@ return {
     not_expelled = not_expelled,
     not_disabled = not_disabled,
 
+    get_failover_params = get_failover_params,
     get_leaders_order = get_leaders_order,
     cluster_is_healthy = cluster_is_healthy,
     probe_missing_members = probe_missing_members,

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -521,13 +521,22 @@ local function get_failover_params(topology_cfg)
         local err = "Bad argument #1 to get_failover_params" ..
             " (table expected, got ClusterwideConfig)"
         error(err, 2)
+    elseif topology_cfg.failover == nil then
+        return {
+            mode = 'disabled',
+        }
     elseif type(topology_cfg.failover) == 'boolean' then
         return {
             mode = topology_cfg.failover and 'eventual' or 'disabled'
         }
-    else
-        assert(type(topology_cfg.failover) == 'table')
+    elseif type(topology_cfg.failover) == 'table' then
         return topology_cfg.failover
+    else
+        local err = string.format(
+            'assertion failed! topology.failover = %s (%s)',
+            topology_cfg.failover, type(topology_cfg.failover)
+        )
+        error(err)
     end
 end
 

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -3,6 +3,36 @@ local module_name = 'cartridge.webui.api-failover'
 local gql_types = require('cartridge.graphql.types')
 local lua_api_failover = require('cartridge.lua-api.failover')
 
+
+local gql_type_userapi = gql_types.object({
+    name = 'FailoverAPI',
+    description = 'Failover parameters managent',
+    fields = {
+        mode = {
+            kind = gql_types.string.nonNull,
+            description = 'Supported modes are "disabled",' ..
+                ' "eventual" and "stateful".',
+        },
+        coordinator_uri = {
+            kind = gql_types.string,
+            description = 'URI of external coordinator.',
+        },
+    }
+})
+
+local function get_failover_params(_, _)
+    return lua_api_failover.get_params()
+end
+
+local function set_failover_params(_, args)
+    local ok, err = lua_api_failover.set_params(args)
+    if ok == nil then
+        return nil, err
+    end
+
+    return get_failover_params()
+end
+
 local function get_failover_enabled(_, _)
     return lua_api_failover.get_failover_enabled()
 end
@@ -16,7 +46,8 @@ local function init(graphql)
     graphql.add_callback({
         prefix = 'cluster',
         name = 'failover',
-        doc = 'Get current failover state.',
+        doc = 'Get current failover state.'
+            .. ' (Deprecated since v2.0.1-??)',
         args = {},
         kind = gql_types.boolean.nonNull,
         callback = module_name .. '.get_failover_enabled',
@@ -26,7 +57,8 @@ local function init(graphql)
         prefix = 'cluster',
         name = 'failover',
         doc = 'Enable or disable automatic failover. '
-            .. 'Returns new state.',
+            .. 'Returns new state.'
+            .. ' (Deprecated since v2.0.1-??)',
         args = {
             enabled = gql_types.boolean.nonNull,
         },
@@ -34,10 +66,32 @@ local function init(graphql)
         callback = module_name .. '.set_failover_enabled',
     })
 
+    graphql.add_callback({
+        prefix = 'cluster',
+        name = 'failover_params',
+        doc = 'Get automatic failover configuration.',
+        args = {},
+        kind = gql_type_userapi.nonNull,
+        callback = module_name .. '.get_failover_params',
+    })
+
+    graphql.add_mutation({
+        prefix = 'cluster',
+        name = 'failover_params',
+        doc = 'Configure automatic failover.',
+        args = {
+            mode = gql_types.string,
+            coordinator_uri = gql_types.string,
+        },
+        kind = gql_type_userapi.nonNull,
+        callback = module_name .. '.set_failover_params',
+    })
 end
 
 return {
     init = init,
     get_failover_enabled = get_failover_enabled,
     set_failover_enabled = set_failover_enabled,
+    get_failover_params = get_failover_params,
+    set_failover_params = set_failover_params,
 }

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -47,7 +47,7 @@ local function init(graphql)
         prefix = 'cluster',
         name = 'failover',
         doc = 'Get current failover state.'
-            .. ' (Deprecated since v2.0.1-??)',
+            .. ' (Deprecated since v2.0.1-95)',
         args = {},
         kind = gql_types.boolean.nonNull,
         callback = module_name .. '.get_failover_enabled',
@@ -58,7 +58,7 @@ local function init(graphql)
         name = 'failover',
         doc = 'Enable or disable automatic failover. '
             .. 'Returns new state.'
-            .. ' (Deprecated since v2.0.1-??)',
+            .. ' (Deprecated since v2.0.1-95)',
         args = {
             enabled = gql_types.boolean.nonNull,
         },

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -9,7 +9,7 @@ type Apicluster {
   """Clusterwide DDL schema"""
   schema: DDLSchema!
 
-  """Get current failover state. (Deprecated since v2.0.1-??)"""
+  """Get current failover state. (Deprecated since v2.0.1-95)"""
   failover: Boolean!
 
   """Get automatic failover configuration."""
@@ -163,7 +163,7 @@ type MutationApicluster {
   schema(as_yaml: String!): DDLSchema!
 
   """
-  Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.1-??)
+  Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.1-95)
   """
   failover(enabled: Boolean!): Boolean!
 

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Thu Mar 12 2020 15:50:58 GMT+0300 (Moscow Standard Time)
+# timestamp: Thu Mar 12 2020 18:09:10 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -9,8 +9,11 @@ type Apicluster {
   """Clusterwide DDL schema"""
   schema: DDLSchema!
 
-  """List issues in cluster"""
-  issues: [Issue!]
+  """Get current failover state. (Deprecated since v2.0.1-??)"""
+  failover: Boolean!
+
+  """Get automatic failover configuration."""
+  failover_params: FailoverAPI!
 
   """Virtual buckets count in cluster"""
   vshard_bucket_count: Int!
@@ -18,22 +21,22 @@ type Apicluster {
   """List authorized users"""
   users(username: String): [User!]
 
-  """Get current failover state."""
-  failover: Boolean!
+  """List issues in cluster"""
+  issues: [Issue!]
   auth_params: UserManagementAPI!
 
-  """Whether it is reasonble to call bootstrap_vshard mutation"""
-  can_bootstrap_vshard: Boolean!
+  """Get list of all registered roles and their dependencies."""
+  known_roles: [Role!]!
 
   """List of pages to be hidden in WebUI"""
   webui_blacklist: [String!]
   vshard_groups: [VshardGroup!]!
 
-  """Get list of all registered roles and their dependencies."""
-  known_roles: [Role!]!
-
   """Get list of known vshard storage groups."""
   vshard_known_groups: [String!]!
+
+  """Whether it is reasonble to call bootstrap_vshard mutation"""
+  can_bootstrap_vshard: Boolean!
 
   """Get cluster config sections"""
   config(sections: [String!]): [ConfigSection]!
@@ -94,6 +97,15 @@ type Error {
   message: String!
 }
 
+"""Failover parameters managent"""
+type FailoverAPI {
+  """Supported modes are "disabled", "eventual" and "stateful"."""
+  mode: String!
+
+  """URI of external coordinator."""
+  coordinator_uri: String
+}
+
 type Issue {
   level: String!
   replicaset_uuid: String
@@ -150,31 +162,36 @@ type MutationApicluster {
   """Applies DDL schema on cluster"""
   schema(as_yaml: String!): DDLSchema!
 
-  """Enable or disable automatic failover. Returns new state."""
+  """
+  Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.1-??)
+  """
   failover(enabled: Boolean!): Boolean!
+
+  """Configure automatic failover."""
+  failover_params(mode: String, coordinator_uri: String): FailoverAPI!
 
   """Checks that schema can be applied on cluster"""
   check_schema(as_yaml: String!): DDLCheckResult!
 
-  """Applies updated config on cluster"""
-  config(sections: [ConfigSectionInput]): [ConfigSection]!
+  """Disable listed servers by uuid"""
+  disable_servers(uuids: [String!]): [Server]
   auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
-  edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
-
-  """Create a new user"""
-  add_user(password: String!, username: String!, fullname: String, email: String): User
-
-  """Edit cluster topology"""
-  edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
-
-  """Remove user"""
-  remove_user(username: String!): User
 
   """Edit an existing user"""
   edit_user(password: String, username: String!, fullname: String, email: String): User
 
-  """Disable listed servers by uuid"""
-  disable_servers(uuids: [String!]): [Server]
+  """Create a new user"""
+  add_user(password: String!, username: String!, fullname: String, email: String): User
+  edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
+
+  """Remove user"""
+  remove_user(username: String!): User
+
+  """Edit cluster topology"""
+  edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
+
+  """Applies updated config on cluster"""
+  config(sections: [ConfigSectionInput]): [ConfigSection]!
 }
 
 type Query {

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -104,7 +104,7 @@ function g.test_uninitialized()
     t.assert_equals(resp['data']['cluster']['failover'], false)
 
     t.assert_error_msg_contains(
-        'Not bootstrapped yet',
+        "Cluster isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -129,9 +129,68 @@ local function test_all()
 auth:
 ...]])
 
-    check_config('topology_new.failover must be boolean, got string',
+    check_config('topology_new.failover must be a table, got string',
 [[---
 failover:
+...]])
+
+    check_config('topology_new.failover.mode must be string, got nil',
+[[---
+failover: {}
+...]])
+
+    check_config('topology_new.failover.mode must be string, got number',
+[[---
+failover:
+  mode: 7
+...]])
+
+    check_config('topology_new.failover.mode "one" is unknown',
+[[---
+failover:
+  mode: one
+...]])
+
+    check_config('topology_new.failover missing coordinator_uri for mode "stateful"',
+[[---
+failover:
+  mode: stateful
+  coordinator_uri: null
+...]])
+
+    check_config('topology_new.failover.coordinator_uri must be a string, got boolean',
+[[---
+failover:
+  mode: disabled
+  coordinator_uri: false
+...]])
+
+    check_config('topology_new.failover.coordinator_uri invalid URI ":-0"',
+[[---
+failover:
+  mode: stateful
+  coordinator_uri: ":-0"
+...]])
+
+    check_config('topology_new.failover.coordinator_uri invalid URI "localhost" (missing port)',
+[[---
+failover:
+  mode: stateful
+  coordinator_uri: "localhost"
+...]])
+
+    check_config('topology_new.failover has unknown parameter "enabled"',
+[[---
+failover:
+  mode: eventual
+  enabled: true
+...]])
+
+    check_config('topology_new.failover has unknown parameter "unknown"',
+[[---
+failover:
+  mode: eventual
+  unknown: yes
 ...]])
 
     check_config('topology_new has unknown parameter "unknown"',
@@ -647,7 +706,8 @@ replicasets:
     check_config(true,
 [[---
 auth: false
-failover: false
+failover:
+  mode: eventual
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001
@@ -663,6 +723,9 @@ replicasets:
     check_config(true,
 [[---
 auth: true
+failover:
+  mode: stateful
+  coordinator_uri: kingdom.com:4401
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001


### PR DESCRIPTION
This patch is necessary in context of #148 for upcoming failover changes.

### Failover configuration

 Clusterwide config schema is extended (preserving backward compatibility):

```yaml
# topology.yml
failover: true # old
failover:      # new
  mode: disabled | eventual | stateful
  coordinator_uri: "kingdom.com:4401"
```

Older setting `enabled = true` corresponds to the eventual failover mode as it used to.

### Lua API:
- `cartridge.admin_enable/disable_failover` - **deprecated**, unchanged;
- `cartridge.admin_get_failover` - **deprecated**, unchanged;
- `cartridge.failover_get_params` - added, returns `{mode = ..., coordinator_uri = ...}`;
- `cartridge.failover_set_params({mode = ..., coordinator_uri = ...})` - **added**, returns `true`;

### GraphQL API
- `query {cluster {failover} }` - **deprecated**, unchanged;
- `mutation {cluster {failover(enabled: true/false)} }` - **deprecated**, unchanged;
- `query {cluster {failover_params {mode coordinator_uri} } }` - added;
- `mutation {cluster {failover_params(mode: ..., coordinator_uri: ...) {mode coordinator_uri} } }` - added;

I didn't forget about

- [x] Tests
- [x] Changelog (already OK)
- [x] Documentation 

Close #650 
