### PR TITLE
Enhance failover tests

### DIFF
--- a/frontend-test.sh
+++ b/frontend-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 npm run graphqlgen --prefix=webui
 npm run flow --prefix=webui
 npm run test_once --prefix=webui

--- a/test/integration/failover_test.lua
+++ b/test/integration/failover_test.lua
@@ -201,10 +201,26 @@ g.test_api_master = function()
 end
 
 g.test_api_failover = function()
-    t.assert_equals(false, set_failover(false))
-    t.assert_equals(false, get_failover())
-    t.assert_equals(true, set_failover(true))
-    t.assert_equals(true, get_failover())
+    local function _call(name, ...)
+        return cluster.main_server.net_box:call(
+            'package.loaded.cartridge.' .. name, {...}
+        )
+    end
+    t.assert_equals(set_failover(false), false)
+    t.assert_equals(get_failover(), false)
+    t.assert_equals(_call('admin_get_failover'), false)
+
+    t.assert_equals(set_failover(true), true)
+    t.assert_equals(get_failover(), true)
+    t.assert_equals(_call('admin_get_failover'), true)
+
+    t.assert_equals(_call('admin_disable_failover'), false)
+    t.assert_equals(_call('admin_get_failover'), false)
+    t.assert_equals(get_failover(), false)
+
+    t.assert_equals(_call('admin_enable_failover'), true)
+    t.assert_equals(_call('admin_get_failover'), true)
+    t.assert_equals(get_failover(), true)
 end
 
 g.test_switchover = function()

--- a/webui/cypress/integration/failover.spec.js
+++ b/webui/cypress/integration/failover.spec.js
@@ -1,21 +1,28 @@
 //Steps:
 //1.Failover
-//      Open probe dialog
 //      Failover turn on
 //      Failover turn off
 
 describe('Failover', () => {
   it('Failover turn on', () => {
-    cy.visit(Cypress.config('baseUrl'));
-    cy.get('.meta-test__FailoverSwitcherBtn').contains('Failover').click();//component:ClusterButtonsPanel
-    cy.get('.meta-test__FailoverControlBtn').click();//component: FailoverButton
-    cy.get('#root').contains('Failover change is OK...');//add to frontend-core classname for notification
+    cy.visit(Cypress.config('baseUrl') + '/admin/cluster/dashboard');
+    cy.get('.meta-test__FailoverButton').should('be.visible');
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('not.be.checked');
+    cy.get('.meta-test__FailoverButton').click();
+    cy.get('.meta-test__FailoverModal').contains('Failover disabled').should('exist');
+    cy.get('.meta-test__SubmitButton').contains('Enable').click();
+    cy.get('#root').contains('Failover change is OK...').click();
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('be.checked');
   })
 
   it('Failover turn off', () => {
-    cy.get('.meta-test__FailoverSwitcherBtn').contains('Failover').click();//component:ClusterButtonsPanel
-    cy.get('.meta-test__FailoverControlBtn').click();//component: FailoverButton
-    cy.get('#root').contains('Failover change is OK...');//add to frontend-core classname for notification
+    cy.visit(Cypress.config('baseUrl') + '/admin/cluster/dashboard');
+    cy.get('.meta-test__FailoverButton').should('be.visible');
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('be.checked');
+    cy.get('.meta-test__FailoverButton').click();
+    cy.get('.meta-test__FailoverModal').contains('Failover enabled').should('exist');
+    cy.get('.meta-test__SubmitButton').contains('Disable').click();
+    cy.get('#root').contains('Failover change is OK...').click();
+    cy.get('.meta-test__FailoverButton').get(':checkbox').should('not.be.checked');
   })
-
 });

--- a/webui/cypress/integration/server-details-dead-server.spec.js
+++ b/webui/cypress/integration/server-details-dead-server.spec.js
@@ -1,7 +1,7 @@
 describe('Server details - dead server', () => {
   it('Server details - dead server', () => {
-    cy.visit(Cypress.config('baseUrl'));
     cy.exec('kill -SIGSTOP $(lsof -sTCP:LISTEN -i :8082 -t)', { failOnNonZeroExit: true });
+    cy.visit(Cypress.config('baseUrl'));
     cy.get('.ServerLabelsHighlightingArea').contains(':13302').closest('li')
       .should('contain', 'Server status is "dead"')
       .find('.meta-test__ReplicasetServerListItem__dropdownBtn').eq(0).click();

--- a/webui/src/components/ClusterButtonsPanel.js
+++ b/webui/src/components/ClusterButtonsPanel.js
@@ -24,7 +24,7 @@ const ClusterButtonsPanel = (
   }: ClusterButtonsPanelProps) => {
   return (
     <PageSection
-      className='meta-test__FailoverSwitcherBtn'
+      className='meta-test__ButtonsPanel'
       topRightControls={[
         <ProbeServerModal />,
         showToggleAuth && <AuthToggleButton />,

--- a/webui/src/components/FailoverButton.js
+++ b/webui/src/components/FailoverButton.js
@@ -11,7 +11,7 @@ import {
 } from '@tarantool.io/ui-kit';
 import { SwitcherIconContainer, ModalInfoContainer, SwitcherInfoLine } from './styled'
 
-const description = `When enabled, every storage starts monitoring instance statuses.  
+const description = `When enabled, every storage starts monitoring instance statuses.
 If a user-specified master goes down, a replica with the lowest UUID takes its place.
 When the user-specified master comes back online, both roles are restored.`
 
@@ -27,20 +27,26 @@ const FailoverButton = ({
   return (
     <React.Fragment>
       <Switcher
+        className='meta-test__FailoverButton'
         onChange={() => dispatch(setVisibleFailoverModal(true))}
         checked={failover}
       >
         Failover
       </Switcher>
       <Modal
-        className='meta-test__FailoverControl'
+        className='meta-test__FailoverModal'
         title="Failover control"
         visible={showFailoverModal}
         onClose={() => dispatch(setVisibleFailoverModal(false))}
         footerControls={[
-          <Button onClick={() => dispatch(setVisibleFailoverModal(false))}>Close</Button>,
           <Button
-            className='meta-test__FailoverControlBtn'
+            className='meta-test__CancelButton'
+            onClick={() => dispatch(setVisibleFailoverModal(false))}
+          >
+            Close
+          </Button>,
+          <Button
+            className='meta-test__SubmitButton'
             intent='primary'
             onClick={() => dispatch(changeFailover({ enabled: !failover }))}
           >


### PR DESCRIPTION
We're going to refactor failover API (in #651) and want to be sure it
doesn't break anything. This patch enhances failover testing - both Lua
and GraphQL API, as well as WebUI cypress tests.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
