### PR TITLE
Refactor failover API for the third time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Deprecated
+
+Lua API:
+
+- `cartridge.admin_get_failover` -> `cartridge.failover_get_params`
+- `cartridge.admin_enable/disable_failover` -> `cartridge.failover_set_params`
+
+GraphQL API:
+
+- `query {cluster {failover} }` -> `query {cluster {failover_params {...} } }`
+- `mutation {cluster {failover()} }` -> `mutation {cluster {failover_params() {...} } }`
+
 ## [2.0.2] - 2020-03-17
 
 ### Added
@@ -57,18 +69,6 @@ Test helpers:
   `reconnect_after` are deprecated and ignored, they never worked as
   intended and will never do. Option `connect_timeout` is deprecated,
   but for backward compatibility treated as `wait_connected`.
-
-### Deprecated
-
-Lua API:
-
-- `cartridge.admin_get_failover` -> `cartridge.failover_get_params`
-- `cartridge.admin_enable/disable_failover` -> `cartridge.failover_set_params`
-
-GraphQL API:
-
-- `query {cluster {failover} }` -> `query {cluster {failover_params {...} } }`
-- `mutation {cluster {failover()} }` -> `mutation {cluster {failover_params() {...} } }`
 
 ### Fixed
 

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -13,13 +13,13 @@ local FailoverSetParamsError = errors.new_class('FailoverSetParamsError')
 
 --- Get failover configuration.
 --
--- (**Added** in v2.0.2-??)
+-- (**Added** in v2.0.2-2)
 -- @function get_params
 -- @treturn FailoverParams
 local function get_params()
     --- Failover parameters.
     --
-    -- (**Added** in v2.0.2-??)
+    -- (**Added** in v2.0.2-2)
     -- @table FailoverParams
     -- @tfield string mode
     --   Supported modes are "disabled", "eventual" and "stateful"
@@ -34,7 +34,7 @@ end
 
 --- Configure automatic failover.
 --
--- (**Added** in v2.0.2-??)
+-- (**Added** in v2.0.2-2)
 -- @function set_params
 -- @tparam table opts
 -- @tparam ?string opts.mode
@@ -89,7 +89,7 @@ end
 
 --- Get current failover state.
 --
--- (**Deprecated** since v2.0.2-??)
+-- (**Deprecated** since v2.0.2-2)
 -- @function get_failover_enabled
 local function get_failover_enabled()
     return get_params().mode ~= 'disabled'
@@ -97,7 +97,7 @@ end
 
 --- Enable or disable automatic failover.
 --
--- (**Deprecated** since v2.0.2-??)
+-- (**Deprecated** since v2.0.2-2)
 -- @function set_failover_enabled
 -- @tparam boolean enabled
 -- @treturn[1] boolean New failover state

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -13,17 +13,20 @@ local FailoverSetParamsError = errors.new_class('FailoverSetParamsError')
 
 --- Get failover configuration.
 --
--- (**Added** in v2.0.1-95)
+-- (**Added** in v2.0.2-??)
 -- @function get_params
 -- @treturn FailoverParams
 local function get_params()
     --- Failover parameters.
     --
-    -- (**Added** in v2.0.1-95)
+    -- (**Added** in v2.0.2-??)
     -- @table FailoverParams
-    -- @tfield string mode Supported modes are "disabled", "eventual"
-    --   and "stateful"
-    -- @tfield nil|string coordinator_uri URI of external coordinator
+    -- @tfield string mode
+    --   Supported modes are "disabled", "eventual" and "stateful"
+    -- @tfield nil|string state_provider
+    --   Only "tarantool" is supported now
+    -- @tfield nil|table tarantool_params
+    --   `{uri = 'string', password = 'string'}`
     return topology.get_failover_params(
         confapplier.get_readonly('topology')
     )
@@ -31,18 +34,20 @@ end
 
 --- Configure automatic failover.
 --
--- (**Added** in v2.0.1-95)
+-- (**Added** in v2.0.2-??)
 -- @function set_params
 -- @tparam table opts
 -- @tparam ?string opts.mode
--- @tparam ?string opts.coordinator_uri
+-- @tparam ?string opts.state_provider
+-- @tparam ?table opts.tarantool_params
 -- @treturn[1] boolean `true` if config applied successfully
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function set_params(opts)
     checks({
         mode = '?string',
-        coordinator_uri = '?string'
+        state_provider = '?string',
+        tarantool_params = '?table',
     })
 
     local topology_cfg = confapplier.get_deepcopy('topology')
@@ -67,8 +72,11 @@ local function set_params(opts)
         topology_cfg.failover.mode = opts.mode
     end
 
-    if opts.coordinator_uri ~= nil then
-        topology_cfg.failover.coordinator_uri = opts.coordinator_uri
+    if opts.state_provider ~= nil then
+        topology_cfg.failover.state_provider = opts.state_provider
+    end
+    if opts.tarantool_params ~= nil then
+        topology_cfg.failover.tarantool_params = opts.tarantool_params
     end
 
     local ok, err = twophase.patch_clusterwide({topology = topology_cfg})
@@ -81,7 +89,7 @@ end
 
 --- Get current failover state.
 --
--- (**Deprecated** since v2.0.1-95)
+-- (**Deprecated** since v2.0.2-??)
 -- @function get_failover_enabled
 local function get_failover_enabled()
     return get_params().mode ~= 'disabled'
@@ -89,7 +97,7 @@ end
 
 --- Enable or disable automatic failover.
 --
--- (**Deprecated** since v2.0.1-95)
+-- (**Deprecated** since v2.0.2-??)
 -- @function set_failover_enabled
 -- @tparam boolean enabled
 -- @treturn[1] boolean New failover state

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -36,7 +36,7 @@ local gql_type_userapi = gql_types.object({
             description = 'Type of external storage for the mode' ..
                 ' "stateful". Only "tarantool" is supported now.',
         },
-        tarantool_params = gql_type_tarantool_cfg.nonNull,
+        tarantool_params = gql_type_tarantool_cfg,
     }
 })
 
@@ -67,7 +67,7 @@ local function init(graphql)
         prefix = 'cluster',
         name = 'failover',
         doc = 'Get current failover state.'
-            .. ' (Deprecated since v2.0.2-??)',
+            .. ' (Deprecated since v2.0.2-2)',
         args = {},
         kind = gql_types.boolean.nonNull,
         callback = module_name .. '.get_failover_enabled',
@@ -78,7 +78,7 @@ local function init(graphql)
         name = 'failover',
         doc = 'Enable or disable automatic failover. '
             .. 'Returns new state.'
-            .. ' (Deprecated since v2.0.2-??)',
+            .. ' (Deprecated since v2.0.2-2)',
         args = {
             enabled = gql_types.boolean.nonNull,
         },

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -4,6 +4,24 @@ local gql_types = require('cartridge.graphql.types')
 local lua_api_failover = require('cartridge.lua-api.failover')
 
 
+local gql_type_tarantool_cfg = gql_types.object {
+    name = 'FailoverStateProviderCfgTarantool',
+    description = 'State provider configuration (Tarantool)',
+    fields = {
+        uri = gql_types.string.nonNull,
+        password = gql_types.string.nonNull,
+    }
+}
+
+local gql_type_tarantool_cfg_input = gql_types.inputObject {
+    name = 'FailoverStateProviderCfgInputTarantool',
+    description = 'State provider configuration (Tarantool)',
+    fields = {
+        uri = gql_types.string.nonNull,
+        password = gql_types.string.nonNull,
+    }
+}
+
 local gql_type_userapi = gql_types.object({
     name = 'FailoverAPI',
     description = 'Failover parameters managent',
@@ -13,10 +31,12 @@ local gql_type_userapi = gql_types.object({
             description = 'Supported modes are "disabled",' ..
                 ' "eventual" and "stateful".',
         },
-        coordinator_uri = {
+        state_provider = {
             kind = gql_types.string,
-            description = 'URI of external coordinator.',
+            description = 'Type of external storage for the mode' ..
+                ' "stateful". Only "tarantool" is supported now.',
         },
+        tarantool_params = gql_type_tarantool_cfg.nonNull,
     }
 })
 
@@ -47,7 +67,7 @@ local function init(graphql)
         prefix = 'cluster',
         name = 'failover',
         doc = 'Get current failover state.'
-            .. ' (Deprecated since v2.0.1-95)',
+            .. ' (Deprecated since v2.0.2-??)',
         args = {},
         kind = gql_types.boolean.nonNull,
         callback = module_name .. '.get_failover_enabled',
@@ -58,7 +78,7 @@ local function init(graphql)
         name = 'failover',
         doc = 'Enable or disable automatic failover. '
             .. 'Returns new state.'
-            .. ' (Deprecated since v2.0.1-95)',
+            .. ' (Deprecated since v2.0.2-??)',
         args = {
             enabled = gql_types.boolean.nonNull,
         },
@@ -81,7 +101,8 @@ local function init(graphql)
         doc = 'Configure automatic failover.',
         args = {
             mode = gql_types.string,
-            coordinator_uri = gql_types.string,
+            state_provider = gql_types.string,
+            tarantool_params = gql_type_tarantool_cfg_input,
         },
         kind = gql_type_userapi.nonNull,
         callback = module_name .. '.set_failover_params',

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Thu Mar 12 2020 18:09:10 GMT+0300 (Moscow Standard Time)
+# timestamp: Fri Mar 20 2020 17:22:05 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -9,7 +9,7 @@ type Apicluster {
   """Clusterwide DDL schema"""
   schema: DDLSchema!
 
-  """Get current failover state. (Deprecated since v2.0.1-95)"""
+  """Get current failover state. (Deprecated since v2.0.2-2)"""
   failover: Boolean!
 
   """Get automatic failover configuration."""
@@ -99,11 +99,27 @@ type Error {
 
 """Failover parameters managent"""
 type FailoverAPI {
+  tarantool_params: FailoverStateProviderCfgTarantool
+
   """Supported modes are "disabled", "eventual" and "stateful"."""
   mode: String!
 
-  """URI of external coordinator."""
-  coordinator_uri: String
+  """
+  Type of external storage for the mode "stateful". Only "tarantool" is supported now.
+  """
+  state_provider: String
+}
+
+"""State provider configuration (Tarantool)"""
+input FailoverStateProviderCfgInputTarantool {
+  uri: String!
+  password: String!
+}
+
+"""State provider configuration (Tarantool)"""
+type FailoverStateProviderCfgTarantool {
+  uri: String!
+  password: String!
 }
 
 type Issue {
@@ -163,12 +179,12 @@ type MutationApicluster {
   schema(as_yaml: String!): DDLSchema!
 
   """
-  Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.1-95)
+  Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.2-2)
   """
   failover(enabled: Boolean!): Boolean!
 
   """Configure automatic failover."""
-  failover_params(mode: String, coordinator_uri: String): FailoverAPI!
+  failover_params(tarantool_params: FailoverStateProviderCfgInputTarantool, mode: String, state_provider: String): FailoverAPI!
 
   """Checks that schema can be applied on cluster"""
   check_schema(as_yaml: String!): DDLCheckResult!

--- a/test/integration/failover_test.lua
+++ b/test/integration/failover_test.lua
@@ -307,7 +307,7 @@ g.test_api_failover = function()
         set_failover_params, {tarantool_params = {uri = '!@#$'}}
     )
     t.assert_error_msg_equals(
-        'topology_new.failover.tarantool_params.password must be string, got nil',
+        'topology_new.failover.tarantool_params.password must be a string, got nil',
         set_failover_params, {tarantool_params = {uri = 'localhost:9'}}
     )
 

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -145,38 +145,60 @@ failover:
   mode: 7
 ...]])
 
-    check_config('topology_new.failover.mode "one" is unknown',
+    check_config('topology_new.failover unknown mode "one"',
 [[---
 failover:
   mode: one
 ...]])
 
-    check_config('topology_new.failover missing coordinator_uri for mode "stateful"',
+    check_config('topology_new.failover missing state_provider for mode "stateful"',
 [[---
 failover:
   mode: stateful
-  coordinator_uri: null
+  state_provider: null
 ...]])
 
-    check_config('topology_new.failover.coordinator_uri must be a string, got boolean',
+    check_config('topology_new.failover.state_provider must be a string, got boolean',
 [[---
 failover:
   mode: disabled
-  coordinator_uri: false
+  state_provider: false
 ...]])
 
-    check_config('topology_new.failover.coordinator_uri invalid URI ":-0"',
+    check_config('topology_new.failover unknown state_provider "joe"',
+[[---
+failover:
+  mode: disabled
+  state_provider: joe
+...]])
+
+
+    check_config('topology_new.failover.tarantool_params.uri invalid URI ":-0"',
+[[---
+failover:
+  mode: eventual
+  tarantool_params: {uri: ":-0"}
+...]])
+
+    check_config('topology_new.failover missing tarantool_params',
 [[---
 failover:
   mode: stateful
-  coordinator_uri: ":-0"
+  state_provider: tarantool
 ...]])
 
-    check_config('topology_new.failover.coordinator_uri invalid URI "localhost" (missing port)',
+    check_config('topology_new.failover.tarantool_params.uri invalid URI "localhost" (missing port)',
 [[---
 failover:
-  mode: stateful
-  coordinator_uri: "localhost"
+  mode: eventual
+  tarantool_params: {uri: "localhost"}
+...]])
+
+    check_config('topology_new.failover.tarantool_params.password must be a string, got nil',
+[[---
+failover:
+  mode: eventual
+  tarantool_params: {uri: "localhost:9"}
 ...]])
 
     check_config('topology_new.failover has unknown parameter "enabled"',
@@ -725,7 +747,10 @@ replicasets:
 auth: true
 failover:
   mode: stateful
-  coordinator_uri: kingdom.com:4401
+  state_provider: tarantool
+  tarantool_params:
+    uri: kingdom.com:4401
+    password: ''
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001


### PR DESCRIPTION
Follow-up for #651 and #617. Refactoring failover API once more.

Now config looks as following:

```yaml
topology:
  mode: stateful
  state_provider: tarantool
  tarantool_params:
    uri: localhost:4401
    password: qwerty
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
