### PR TITLE
Enhance error messages

### DIFF
--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -354,7 +354,8 @@ local function bind(host, port)
 
     if not server then
         local err = errors.new('RemoteControlError',
-            "Can't start server: %s", errno.strerror()
+            "Can't start server on %s:%s: %s",
+            host, port, errno.strerror()
         )
         return nil, err
     end

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -153,7 +153,9 @@ local function take_control(uri)
     if conn == nil then
         return nil, err
     elseif not conn:is_connected() then
-        return nil, NetboxConnectError:new('%q: %s', uri, conn.error)
+        return nil, NetboxConnectError:new('"%s:%s": %s',
+            conn.host, conn.port, conn.error
+        )
     end
 
     local lock_delay, err = errors.netbox_call(conn, 'get_lock_delay',

--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -112,7 +112,7 @@ function g.test_start()
     t.assert_not(ok)
     t.assert_equals(err.class_name, "RemoteControlError")
     t.assert_equals(err.err,
-        "Can't start server: " .. errno.strerror(errno.EADDRINUSE)
+        "Can't start server on 127.0.0.1:13301: " .. errno.strerror(errno.EADDRINUSE)
     )
 
     remote_control.stop()
@@ -123,29 +123,29 @@ function g.test_start()
     t.assert_equals(err.class_name, "RemoteControlError")
     -- MacOS and Linux returns different errno
     assertStrOneOf(err.err, {
-        "Can't start server: " .. errno.strerror(errno.EIO),
-        "Can't start server: " .. errno.strerror(errno.EAFNOSUPPORT),
+        "Can't start server on 0.0.0.0:-1: " .. errno.strerror(errno.EIO),
+        "Can't start server on 0.0.0.0:-1: " .. errno.strerror(errno.EAFNOSUPPORT),
     })
 
     local ok, err = remote_control.bind('255.255.255.255', 13301)
     t.assert_not(ok)
     t.assert_equals(err.class_name, "RemoteControlError")
     t.assert_equals(err.err,
-        "Can't start server: " .. errno.strerror(errno.EINVAL)
+        "Can't start server on 255.255.255.255:13301: " .. errno.strerror(errno.EINVAL)
     )
 
     local ok, err = remote_control.bind('google.com', 13301)
     t.assert_not(ok)
     t.assert_equals(err.class_name, "RemoteControlError")
     t.assert_equals(err.err,
-        "Can't start server: " .. errno.strerror(errno.EADDRNOTAVAIL)
+        "Can't start server on google.com:13301: " .. errno.strerror(errno.EADDRNOTAVAIL)
     )
 
     local ok, err = remote_control.bind('8.8.8.8', 13301)
     t.assert_not(ok)
     t.assert_equals(err.class_name, "RemoteControlError")
     t.assert_equals(err.err,
-        "Can't start server: " .. errno.strerror(errno.EADDRNOTAVAIL)
+        "Can't start server on 8.8.8.8:13301: " .. errno.strerror(errno.EADDRNOTAVAIL)
     )
 
     local ok, err = remote_control.bind('localhost', 13301)


### PR DESCRIPTION
1. Remote control: "Can't start server on HOST:PORT"
2. Failover coordinator: don't reveal password in logs

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

