### PR TITLE
Take care of cancelled fibers

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -217,12 +217,12 @@ local function failover_loop(args)
 
     while pcall(fiber.testcancel) do
         local appointments, err = FailoverError:pcall(args.get_appointments)
+        fiber.testcancel()
+
         if appointments == nil then
             log.warn('%s', err.err)
             goto start_over
-        end
-
-        if not accept_appointments(appointments) then
+        elseif not accept_appointments(appointments) then
             -- nothing changed
             goto start_over
         end


### PR DESCRIPTION
In coordinator:

- Closing connection implicitly yields and should be pcalled
- Cancelling another fiber raises an error if parent was cancelled too
- Pcall fiber.status just in case

See also: https://github.com/tarantool/tarantool/commit/d41cda32a94ccdebe2566deef9c27ff4a33a991b

In failover_loop:

- Avoid logging errors if fiber was cancelled intentionally

What has been done? Why? What problem is being solved?

I didn't forget about

- [x] Tests
- [x] Changelog (not needed)
- [x] Documentation (not needed)
