### PR TITLE
build: port fetch-schema to OS X

### DIFF
--- a/fetch-schema.sh
+++ b/fetch-schema.sh
@@ -3,8 +3,8 @@
 TARANTOOL_WORKDIR=dev/gql-schema test/entrypoint/srv_basic.lua &
 PID=$!
 
-TMP=$(mktemp --suffix .graphql)
-graphql get-schema -o $TMP
+TMP=$(uuidgen).graphql
+npx graphql get-schema -o $TMP
 
 OUTPUT="doc/schema.graphql"
 diff \


### PR DESCRIPTION
"mktemp" on Linux and OS X has different implementations. So, some
features of Linux "mktemp" is unsupported on OS X/FreeBSD. However
such function was used only as random name generator. It was
replaced with "uuidgen" that should be supported on all platforms.

Also this patch runs "graphql-cli" with npx. Sometimes we could
get "graphql: command is not found".

Closes #683
