### PR TITLE
Forbid reacquiring kingdom lock if it was stolen

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -218,9 +218,10 @@ local function failover_loop(args)
 
     while pcall(fiber.testcancel) do
         local appointments, err = FailoverError:pcall(args.get_appointments)
-        fiber.testcancel()
-
         if appointments == nil then
+            -- don't log an error in case the fiber was cancelled
+            fiber.testcancel()
+
             log.warn('%s', err.err)
             vars.failover_err = FailoverError:new(
                 "Error fetching appointments: %s", err.err

--- a/test/integration/kingdom_test.lua
+++ b/test/integration/kingdom_test.lua
@@ -169,7 +169,7 @@ function g.test_outage()
         {true}
     )
     t.assert_equals(
-        -- C1 can renew expired lock if it wasn't stolen yen
+        -- C1 can renew expired lock if it wasn't stolen yet
         {c1:call('acquire_lock', payload)},
         {true}
     )
@@ -182,7 +182,7 @@ function g.test_outage()
     c2:close()
 
     t.assert_equals(
-        -- C1 can't renew lock after if was stolen by C2
+        -- C1 can't renew lock after it was stolen by C2
         {c1:call('acquire_lock', payload)},
         {box.NULL, 'The lock was stolen'}
     )


### PR DESCRIPTION
Here is the case:

1. Coordinator C1 acquires a lock and freezes (but his session remains active);
2. Lock delay expires and kingdom allows C2 to acquire it again;
3. C2 writes some decisions and releases a lock;
4. C1 comes back and tries to renew the lock;

*The goal*: C1 must be informed on his outage.

I didn't forget about

- [x] Tests

Follow-up for #604 
