### PR TITLE
Move list_cluster_issues from tests to test.helpers

### DIFF
--- a/cartridge/test-helpers/server.lua
+++ b/cartridge/test-helpers/server.lua
@@ -271,4 +271,19 @@ function Server:download_config()
     return yaml.decode(self:http_request('get', '/admin/config').body)
 end
 
+--- List issues on a cluster
+function Server:list_cluster_issues()
+    return self:graphql({query = [[{
+        cluster {
+            issues {
+                level
+                message
+                replicaset_uuid
+                instance_uuid
+                topic
+            }
+        }
+    }]]}).data.cluster.issues
+end
+
 return Server

--- a/cartridge/test-helpers/server.lua
+++ b/cartridge/test-helpers/server.lua
@@ -271,19 +271,4 @@ function Server:download_config()
     return yaml.decode(self:http_request('get', '/admin/config').body)
 end
 
---- List issues on a cluster
-function Server:list_cluster_issues()
-    return self:graphql({query = [[{
-        cluster {
-            issues {
-                level
-                message
-                replicaset_uuid
-                instance_uuid
-                topic
-            }
-        }
-    }]]}).data.cluster.issues
-end
-
 return Server

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -38,4 +38,18 @@ function helpers.table_find_by_attr(tbl, key, value)
     end
 end
 
+function helpers.list_cluster_issues(server)
+    return server:graphql({query = [[{
+        cluster {
+            issues {
+                level
+                message
+                replicaset_uuid
+                instance_uuid
+                topic
+            }
+        }
+    }]]}).data.cluster.issues
+end
+
 return helpers

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -195,11 +195,5 @@ function g.test_rpc()
 end
 
 function g.test_issues()
-    t.assert_equals(
-        g.server:graphql({query = [[{
-            cluster {
-                issues {}
-            }
-        }]]}).data.cluster.issues, {}
-    )
+    t.assert_equals(g.server:list_cluster_issues(), {})
 end

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -195,5 +195,5 @@ function g.test_rpc()
 end
 
 function g.test_issues()
-    t.assert_equals(g.server:list_cluster_issues(), {})
+    t.assert_equals(helpers.list_cluster_issues(g.server), {})
 end

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -183,20 +183,6 @@ local function check_active_master(expected_uuid)
     t.assert_equals(response, expected_uuid)
 end
 
-local function list_issues(server)
-    return server:graphql({query = [[{
-        cluster {
-            issues {
-                level
-                message
-                replicaset_uuid
-                instance_uuid
-                topic
-            }
-        }
-    }]]}).data.cluster.issues
-end
-
 g.test_api_master = function()
     set_master(replicaset_uuid, storage_2_uuid)
     t.assert_equals(get_master(replicaset_uuid), {storage_2_uuid, storage_2_uuid})
@@ -445,7 +431,7 @@ g.test_sigstop = function()
     -- Here we use retrying due to this tarantool bug
     -- See: https://github.com/tarantool/tarantool/issues/4668
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(cluster.main_server), {})
+        t.assert_equals(cluster.main_server:list_cluster_issues(), {})
     end)
 
     set_failover(true)
@@ -476,7 +462,7 @@ g.test_sigstop = function()
         {uri = cluster:server('router-1').advertise_uri, statistics={}}
     })
 
-    t.assert_items_equals(list_issues(cluster.main_server), {{
+    t.assert_items_equals(cluster.main_server:list_cluster_issues(), {{
         level = 'warning',
         replicaset_uuid = replicaset_uuid,
         instance_uuid = storage_2_uuid,
@@ -513,6 +499,6 @@ g.test_sigstop = function()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(cluster.main_server), {})
+        t.assert_equals(cluster.main_server:list_cluster_issues(), {})
     end)
 end

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -431,7 +431,7 @@ g.test_sigstop = function()
     -- Here we use retrying due to this tarantool bug
     -- See: https://github.com/tarantool/tarantool/issues/4668
     t.helpers.retrying({}, function()
-        t.assert_equals(cluster.main_server:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(cluster.main_server), {})
     end)
 
     set_failover(true)
@@ -462,7 +462,7 @@ g.test_sigstop = function()
         {uri = cluster:server('router-1').advertise_uri, statistics={}}
     })
 
-    t.assert_items_equals(cluster.main_server:list_cluster_issues(), {{
+    t.assert_items_equals(helpers.list_cluster_issues(cluster.main_server), {{
         level = 'warning',
         replicaset_uuid = replicaset_uuid,
         instance_uuid = storage_2_uuid,
@@ -499,6 +499,6 @@ g.test_sigstop = function()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(cluster.main_server:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(cluster.main_server), {})
     end)
 end

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -122,7 +122,7 @@ function g.test_kingdom_restart()
             err = 'State provider unavailable'
         })
 
-        t.assert_items_include(g.cluster:server('router'):list_cluster_issues(), {{
+        t.assert_items_include(helpers.list_cluster_issues(g.cluster:server('router')), {{
             level = 'warning',
             topic = 'failover',
             message = "Can't obtain failover coordinator:" ..
@@ -148,7 +148,7 @@ function g.test_kingdom_restart()
                 uuid = 'aaaaaaaa-aaaa-0000-0000-000000000001'
             }
         )
-        t.assert_equals(g.cluster:server('router'):list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.cluster:server('router')), {})
     end)
 
     helpers.retrying({}, function()
@@ -463,7 +463,7 @@ function g.test_leaderless()
     t.assert_equals(eval('storage-2', q_readonliness), true)
     t.assert_equals(eval('storage-3', q_readonliness), true)
     t.helpers.retrying({}, function()
-        t.assert_equals(g.cluster:server('router'):list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.cluster:server('router')), {})
     end)
 end
 
@@ -482,7 +482,7 @@ function g.test_issues()
     ]])
 
     helpers.retrying({}, function()
-        t.assert_items_equals(g.cluster:server('router'):list_cluster_issues(), {{
+        t.assert_items_equals(helpers.list_cluster_issues(g.cluster:server('router')), {{
             level = 'warning',
             topic = 'failover',
             message = "There is no active failover coordinator",
@@ -505,6 +505,6 @@ function g.test_issues()
     ]]})
 
     helpers.retrying({}, function()
-        t.assert_equals(g.cluster:server('storage-1'):list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.cluster:server('storage-1')), {})
     end)
 end

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -108,20 +108,6 @@ local function eval(alias, ...)
     return g.cluster:server(alias).net_box:eval(...)
 end
 
-local function list_warnings(name)
-    return g.cluster:server(name):graphql({query = [[{
-        cluster {
-            issues {
-                level
-                replicaset_uuid
-                message
-                instance_uuid
-                topic
-            }
-        }
-    }]]}).data.cluster.issues
-end
-
 function g.test_kingdom_restart()
     fio.rmtree(g.kingdom.workdir)
     g.kingdom:stop()
@@ -136,7 +122,7 @@ function g.test_kingdom_restart()
             err = 'State provider unavailable'
         })
 
-        t.assert_items_include(list_warnings('router'), {{
+        t.assert_items_include(g.cluster:server('router'):list_cluster_issues(), {{
             level = 'warning',
             topic = 'failover',
             message = "Can't obtain failover coordinator:" ..
@@ -162,7 +148,7 @@ function g.test_kingdom_restart()
                 uuid = 'aaaaaaaa-aaaa-0000-0000-000000000001'
             }
         )
-        t.assert_equals(list_warnings('router'), {})
+        t.assert_equals(g.cluster:server('router'):list_cluster_issues(), {})
     end)
 
     helpers.retrying({}, function()
@@ -477,7 +463,7 @@ function g.test_leaderless()
     t.assert_equals(eval('storage-2', q_readonliness), true)
     t.assert_equals(eval('storage-3', q_readonliness), true)
     t.helpers.retrying({}, function()
-        t.assert_equals(list_warnings('router'), {})
+        t.assert_equals(g.cluster:server('router'):list_cluster_issues(), {})
     end)
 end
 
@@ -496,7 +482,7 @@ function g.test_issues()
     ]])
 
     helpers.retrying({}, function()
-        t.assert_items_equals(list_warnings('router'), {{
+        t.assert_items_equals(g.cluster:server('router'):list_cluster_issues(), {{
             level = 'warning',
             topic = 'failover',
             message = "There is no active failover coordinator",
@@ -519,6 +505,6 @@ function g.test_issues()
     ]]})
 
     helpers.retrying({}, function()
-        t.assert_equals(list_warnings('storage-1'), {})
+        t.assert_equals(g.cluster:server('storage-1'):list_cluster_issues(), {})
     end)
 end

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -55,22 +55,14 @@ function g.test_broken_replica()
 
 
     t.helpers.retrying({}, function()
-        local issues = master:graphql({query = [[{
-            cluster {
-                issues {
-                    level
-                    replicaset_uuid
-                    message
-                    instance_uuid
-                }
-            }
-        }]]}).data.cluster.issues
+        local issues = master:list_cluster_issues()
 
         t.assert_equals(
             helpers.table_find_by_attr(
                 issues, 'instance_uuid', helpers.uuid('a', 'a', 2)
             ), {
                 level = 'warning',
+                topic = 'replication',
                 replicaset_uuid = helpers.uuid('a'),
                 instance_uuid = helpers.uuid('a', 'a', 2),
                 message = "Replication from localhost:13301" ..
@@ -84,6 +76,7 @@ function g.test_broken_replica()
                 issues, 'instance_uuid', helpers.uuid('a', 'a', 3)
             ), {
                 level = 'warning',
+                topic = 'replication',
                 replicaset_uuid = helpers.uuid('a'),
                 instance_uuid = helpers.uuid('a', 'a', 3),
                 message = "Replication from localhost:13301" ..

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -55,7 +55,7 @@ function g.test_broken_replica()
 
 
     t.helpers.retrying({}, function()
-        local issues = master:list_cluster_issues()
+        local issues = helpers.list_cluster_issues(master)
 
         t.assert_equals(
             helpers.table_find_by_attr(

--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -103,20 +103,6 @@ local function wish_state(srv, desired_state)
     end)
 end
 
-local function list_issues(server)
-    return server:graphql({query = [[{
-        cluster {
-            issues {
-                level
-                message
-                replicaset_uuid
-                instance_uuid
-                topic
-            }
-        }
-    }]]}).data.cluster.issues
-end
-
 function g.test_failover()
     local function _ro_map()
         local resp = g.cluster:server('slave'):graphql({query = [[{
@@ -143,7 +129,7 @@ function g.test_failover()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(g.master), {})
+        t.assert_equals(g.master:list_cluster_issues(), {})
     end)
 
     --------------------------------------------------------------------
@@ -157,7 +143,7 @@ function g.test_failover()
         slave = false,
     })
     t.helpers.retrying({}, function()
-        local issues = list_issues(g.slave)
+        local issues = g.slave:list_cluster_issues()
         t.assert_covers(issues[1], {
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
@@ -186,7 +172,7 @@ function g.test_failover()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(g.master), {})
+        t.assert_equals(g.master:list_cluster_issues(), {})
     end)
 end
 
@@ -403,7 +389,7 @@ function g.test_orphan_connect_timeout()
     wish_state(g.master, 'ConnectingFullmesh')
 
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(g.master), {{
+        t.assert_equals(g.master:list_cluster_issues(), {{
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
             instance_uuid = helpers.uuid('a', 'a', 1),
@@ -434,7 +420,7 @@ function g.test_orphan_connect_timeout()
     t.assert_equals(is_master(g.master), true)
 
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(g.slave), {})
+        t.assert_equals(g.slave:list_cluster_issues(), {})
     end)
 end
 
@@ -462,7 +448,7 @@ function g.test_orphan_sync_timeout()
     )
 
     t.helpers.retrying({}, function()
-        local issues = list_issues(g.master)
+        local issues = g.master:list_cluster_issues()
         t.assert_covers(issues[1], {
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
@@ -557,6 +543,6 @@ function g.test_restart_both()
 
     g.cluster:wait_until_healthy()
     t.helpers.retrying({}, function()
-        t.assert_equals(list_issues(g.master), {})
+        t.assert_equals(g.master:list_cluster_issues(), {})
     end)
 end

--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -129,7 +129,7 @@ function g.test_failover()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(g.master:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.master), {})
     end)
 
     --------------------------------------------------------------------
@@ -143,7 +143,7 @@ function g.test_failover()
         slave = false,
     })
     t.helpers.retrying({}, function()
-        local issues = g.slave:list_cluster_issues()
+        local issues = helpers.list_cluster_issues(g.slave)
         t.assert_covers(issues[1], {
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
@@ -172,7 +172,7 @@ function g.test_failover()
     })
 
     t.helpers.retrying({}, function()
-        t.assert_equals(g.master:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.master), {})
     end)
 end
 
@@ -389,7 +389,7 @@ function g.test_orphan_connect_timeout()
     wish_state(g.master, 'ConnectingFullmesh')
 
     t.helpers.retrying({}, function()
-        t.assert_equals(g.master:list_cluster_issues(), {{
+        t.assert_equals(helpers.list_cluster_issues(g.master), {{
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
             instance_uuid = helpers.uuid('a', 'a', 1),
@@ -420,7 +420,7 @@ function g.test_orphan_connect_timeout()
     t.assert_equals(is_master(g.master), true)
 
     t.helpers.retrying({}, function()
-        t.assert_equals(g.slave:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.slave), {})
     end)
 end
 
@@ -448,7 +448,7 @@ function g.test_orphan_sync_timeout()
     )
 
     t.helpers.retrying({}, function()
-        local issues = g.master:list_cluster_issues()
+        local issues = helpers.list_cluster_issues(g.master)
         t.assert_covers(issues[1], {
             level = 'warning',
             replicaset_uuid = helpers.uuid('a'),
@@ -543,6 +543,6 @@ function g.test_restart_both()
 
     g.cluster:wait_until_healthy()
     t.helpers.retrying({}, function()
-        t.assert_equals(g.master:list_cluster_issues(), {})
+        t.assert_equals(helpers.list_cluster_issues(g.master), {})
     end)
 end


### PR DESCRIPTION
* Function list_issues was duplicated at some tests and now moved to
   helpers.lua as list_cluster_issues  

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
