### PR TITLE
Fix add_user on uninitialized instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ GraphQL API:
 
 - Fix quering failure `cluster {issues {...} }` on uninitialized instance
 
+- Fix `add_user` on uninitialized instance
+
 ## [2.0.2] - 2020-03-17
 
 ### Added

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -245,6 +245,11 @@ local function _clusterwide(patch)
 
     local topology_old = clusterwide_config_old:get_readonly('topology')
     local topology_new = clusterwide_config_new:get_readonly('topology')
+    if topology_new == nil then
+        return nil, PatchClusterwideError:new(
+            "Topology not specified, seems that cluster isn't bootstrapped"
+        )
+    end
 
     topology.probe_missing_members(topology_new.servers)
 

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -475,6 +475,17 @@ function g.test_uninitialized()
     local lsid = resp.cookies['lsid'][1]
     check_401(g.server, {headers = {cookie = 'lsid='}})
     check_200(g.server, {headers = {cookie = 'lsid=' .. lsid}})
+
+    t.assert_error_msg_contains(
+        "PatchClusterwideError: Topology not specified, " ..
+        "seems that cluster isn't bootstrapped",
+        _add_user, g.server, 'new_admin', 'password'
+    )
+
+    t.assert_error_msg_contains(
+        "edit_user() can't change integrated superuser 'admin'",
+        _edit_user, g.server, g.server_user, 'password11'
+    )
 end
 
 function g.test_keepalive()


### PR DESCRIPTION
* Add check that new topology not empty at twophase.lua

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #723
