### PR TITLE
Show fullname instead of username in UI auth title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   non-nullable arguments in variable list is forbidden. Your code **may
   be affected** if it doesn't conform GraphQL specification.
 
+- auth_params graphql endpoint returns "fullname" (if it was specified)
+  instead of "username".
+
 ### Deprecated
 
 Lua API:

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -75,8 +75,21 @@ end
 local function get_auth_params()
     local callbacks = auth.get_callbacks()
     local params = auth.get_params()
+
+    local user, username
+    local session_username = auth.get_session_username()
+    if session_username ~= nil then
+        user = auth.get_user(session_username)
+    end
+
+    if user ~= nil and user.fullname ~= nil then
+        username = user.fullname
+    else
+        username = session_username
+    end
+
     return {
-        username = auth.get_session_username(),
+        username = username,
 
         enabled = params.enabled,
         cookie_max_age = params.cookie_max_age,

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -76,18 +76,11 @@ local function get_auth_params()
     local callbacks = auth.get_callbacks()
     local params = auth.get_params()
 
-    local user, username
-    local session_username = auth.get_session_username()
-    if session_username ~= nil then
-        user = auth.get_user(session_username)
-    end
-
+    local username = auth.get_session_username()
+    local user = username and auth.get_user(username)
     if user ~= nil and user.fullname ~= nil then
         username = user.fullname
-    else
-        username = session_username
     end
-
     return {
         username = username,
 

--- a/test/integration/admin_test.lua
+++ b/test/integration/admin_test.lua
@@ -6,6 +6,7 @@ local helpers = require('test.helper')
 local digest = require('digest')
 
 local ADMIN_USERNAME = 'admin'
+local ADMIN_FULLNAME = 'Cartridge Administrator'
 local ADMIN_PASSWORD = '12345'
 
 local function bauth(username, password)
@@ -60,7 +61,7 @@ function g.test_api()
 
     local auth_params = resp['data']['cluster']['auth_params']
     t.assert_equals(auth_params['enabled'], true)
-    t.assert_equals(auth_params['username'], ADMIN_USERNAME)
+    t.assert_equals(auth_params['username'], ADMIN_FULLNAME)
 
     local add_user = function(username, password)
         return g.server:graphql({


### PR DESCRIPTION
Since "username" is a part of account credentials it's secure
information and should be hidden from public view.
This patch simply changes "username" to "fullname" (if it was
specified) in user's auth params graphql endpoint and auth title
in UI.

Closes #726

- [x] Tests
- [x] Changelog
