### PR TITLE
Make use of stateboard client in failover

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -45,8 +45,8 @@ local StateProviderError = errors.new_class('StateProviderError')
 vars:new('membership_notification', membership.subscribe())
 vars:new('clusterwide_config')
 vars:new('failover_fiber')
-vars:new('stateboard_client')
 vars:new('failover_err')
+vars:new('client')
 vars:new('cache', {
     active_leaders = {--[[ [replicaset_uuid] = leader_uuid ]]},
     is_leader = false,
@@ -120,13 +120,9 @@ end
 -- Used in 'stateful' failover mode.
 -- @function _get_appointments_stateful_mode
 -- @local
-local function _get_appointments_stateful_mode(session, timeout)
-    local appointments, err = session:longpoll(timeout)
-    if appointments == nil then
-        return nil, err
-    end
-
-    return appointments
+local function _get_appointments_stateful_mode(client, timeout)
+    checks('stateboard_client', 'number')
+    return client:longpoll(timeout)
 end
 
 --- Accept new appointments.
@@ -273,9 +269,9 @@ end
 local function cfg(clusterwide_config)
     checks('ClusterwideConfig')
 
-    if vars.stateboard_client then
-        vars.stateboard_client:drop_session()
-        vars.stateboard_client = nil
+    if vars.client then
+        vars.client:drop_session()
+        vars.client = nil
     end
 
     if vars.failover_fiber ~= nil then
@@ -310,28 +306,19 @@ local function cfg(clusterwide_config)
 
     elseif failover_cfg.mode == 'stateful' and failover_cfg.state_provider == 'tarantool' then
         local params = assert(failover_cfg.tarantool_params)
-        local client, err = stateboard_client.new({
+        vars.client = stateboard_client.new({
             uri = assert(params.uri),
             password = params.password,
-            reconnect_after = 1.0,
             call_timeout = vars.options.NETBOX_CALL_TIMEOUT,
         })
 
-        if client == nil then
-            log.warn('Stateful failover not enabled: %s', err)
-            return nil, err
-        else
-            log.info(
-                'Stateful failover enabled with external storage at %s',
-                params.uri
-            )
-        end
-
-        vars.stateboard_client = client
-        local session = client:get_session()
+        log.info(
+            'Stateful failover enabled with external storage at %s',
+            params.uri
+        )
 
         -- WARNING: network yields
-        local appointments, err = _get_appointments_stateful_mode(session, 0)
+        local appointments, err = _get_appointments_stateful_mode(vars.client, 0)
         if appointments == nil then
             log.warn('Failed to get first appointments: %s', err)
             vars.failover_err = FailoverError:new(
@@ -344,7 +331,7 @@ local function cfg(clusterwide_config)
 
         vars.failover_fiber = fiber.new(failover_loop, {
             get_appointments = function()
-                return _get_appointments_stateful_mode(session,
+                return _get_appointments_stateful_mode(vars.client,
                     vars.options.LONGPOLL_TIMEOUT
                 )
             end,
@@ -391,9 +378,12 @@ end
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function get_coordinator()
-    local session = vars.stateboard_client:get_session()
-    if not session:is_connected()
-    then
+    if vars.client == nil then
+        return nil, StateProviderError:new("No state provider configured")
+    end
+
+    local session = vars.client.session
+    if session == nil or not session:is_alive() then
         return nil, StateProviderError:new('State provider unavailable')
     end
 

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -485,7 +485,7 @@ function g.test_issues()
     -- kill failover fiber on storage
     eval('storage-3', [[
         local vars = require('cartridge.vars').new('cartridge.failover')
-        vars.stateboard_conn:close()
+        vars.stateboard_client:drop_session()
         vars.failover_fiber:cancel()
     ]])
 

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -485,7 +485,7 @@ function g.test_issues()
     -- kill failover fiber on storage
     eval('storage-3', [[
         local vars = require('cartridge.vars').new('cartridge.failover')
-        vars.stateboard_client:drop_session()
+        vars.client:drop_session()
         vars.failover_fiber:cancel()
     ]])
 


### PR DESCRIPTION
Since "stateboard-client" was introduced we should use it instead
of raw netbox connections.

Follow-up for #720
Close #736
