### PR TITLE
Handle missed "workdir" argument properly

### DIFF
--- a/stateboard.lua
+++ b/stateboard.lua
@@ -14,6 +14,10 @@ local opts = argparse.get_opts({
     lock_delay = 'number',
 })
 
+if opts.workdir == nil then
+    error('"workdir" must be specified', 0)
+end
+
 local ok, err = fio.mktree(opts.workdir)
 if not ok then error(err, 0) end
 


### PR DESCRIPTION
Before this patch if user simply run "./stateboard.lua" it got:
```
LuajitError: builtin/fio.lua:354: Usage: fio.mktree(path[, mode])
fatal error, exiting the event loop
```

This message could confuse user because it doesn't contain any
useful insformation. This patch adds additional check for case
when "workdir" is omitted.

New error message:
```
LuajitError: "workdir" must be specified
fatal error, exiting the event loop
```

Closes #708
