### PR TITLE
Update errors dependency to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - auth_params graphql endpoint returns "fullname" (if it was specified)
   instead of "username".
 
+- Update `errors` dependency to 2.1.3.
+
 ### Deprecated
 
 Lua API:

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     'http == 1.1.0-1',
     'checks == 3.0.1-1',
     'lulpeg == 0.1.2-1',
-    'errors == 2.1.2-1',
+    'errors == 2.1.3-1',
     'vshard == 0.1.15-1',
     'membership == 2.2.0-1',
     'frontend-core == 6.4.0-1',

--- a/cartridge/graphql.lua
+++ b/cartridge/graphql.lua
@@ -304,14 +304,7 @@ local function _execute_graphql(req)
     )
 
     if data == nil then
-        -- TODO replace with errors.is_error_object as we upgrade errors
-        if not (type(err) == 'table'
-            and err.err ~= nil
-            and err.str ~= nil
-            and err.line ~= nil
-            and err.file ~= nil
-            and err.class_name ~= nil
-        ) then
+        if not errors.is_error_object(err) then
             err = e_graphql_execute:new(err or "Unknown error")
         end
 

--- a/test/integration/pool_map_call_test.lua
+++ b/test/integration/pool_map_call_test.lua
@@ -92,7 +92,7 @@ function g.test_timeout()
 
     t.assert_equals(retmap, {})
     assert_err_equals(errmap, 'localhost:13301',
-        'Net.box call failed: Timeout exceeded'
+        'NetboxCallError: Timeout exceeded'
     )
 end
 
@@ -185,8 +185,8 @@ function g.test_negative()
 
     t.assert_equals(retmap, {})
     assert_err_equals(errmap, '!@#$%^&*()',      'FormatURIError: Invalid URI "!@#$%^&*()"')
-    assert_err_equals(errmap, 'localhost:13301', 'Net.box call failed: Too long WAL write')
-    assert_err_equals(errmap, 'localhost:13302', 'Net.box call failed: Too long WAL write')
+    assert_err_equals(errmap, 'localhost:13301', 'NetboxCallError: Too long WAL write')
+    assert_err_equals(errmap, 'localhost:13302', 'NetboxCallError: Too long WAL write')
     assert_err_equals(errmap, 'localhost:13309', 'NetboxConnectError: "localhost:13309": Invalid greeting')
     assert_err_equals(errmap, 'localhost:9',
         'NetboxConnectError: "localhost:9": ' .. errno.strerror(errno.ECONNREFUSED),

--- a/test/unit/stateboard_client_test.lua
+++ b/test/unit/stateboard_client_test.lua
@@ -52,7 +52,7 @@ function g.test_session()
     local ok, err = session:get_leaders()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
-        class_name = 'Net.box call failed',
+        class_name = 'NetboxCallError',
         err = 'Peer closed',
     })
     t.assert_is_not(client:get_session(), session)
@@ -80,7 +80,7 @@ function g.test_drop_session()
     local ok, err = session:get_leaders()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
-        class_name = 'Net.box call failed',
+        class_name = 'NetboxCallError',
         err = 'Connection closed',
     })
 


### PR DESCRIPTION
* Make use of errors.is_error_object in graphql.lua
* Fix tests for new netbox error class names

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
