### PR TITLE
Fix flaky stateboard test

### DIFF
--- a/test/integration/stateboard_test.lua
+++ b/test/integration/stateboard_test.lua
@@ -79,7 +79,7 @@ function g.test_locks()
 
     local kid = uuid.str()
     helpers.retrying({}, function()
-        t.assert_equals(c1:get_coordinator(), nil)
+        t.assert_equals({c2:get_coordinator()}, {nil})
     end)
 
     t.assert_equals(


### PR DESCRIPTION
The test checks acquiring the lock in another session after dropping the
first one.

Stateboard didn't notice the connection was closed by the second attempt
to acquire lock, so the test failed.

And retrying was useless since it performed network call on a closed
connection which always used to return nil (and and error) immediately.

https://gitlab.com/tarantool/cartridge/-/jobs/504365744
