### PR TITLE
Enhance failover params compatibility with v2.0.2

### DIFF
--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -35,6 +35,7 @@ local BoxError = errors.new_class('BoxError')
 local InitError = errors.new_class('InitError')
 local BootError = errors.new_class('BootError')
 local StateError = errors.new_class('StateError')
+local OperationError = errors.new_class('OperationError')
 
 vars:new('state', '')
 vars:new('error')
@@ -226,9 +227,15 @@ local function apply_config(clusterwide_config)
         ),
     })
 
-    failover.cfg(clusterwide_config)
+    local ok, err = OperationError:pcall(failover.cfg,
+        clusterwide_config
+    )
+    if not ok then
+        set_state('OperationError', err)
+        return nil, err
+    end
 
-    local ok, err = ddl_manager.apply_config(
+    local ok, err = OperationError:pcall(ddl_manager.apply_config,
         clusterwide_config:get_readonly(),
         {is_master = failover.is_leader()}
     )

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -304,7 +304,9 @@ local function cfg(clusterwide_config)
         })
         vars.failover_fiber:name('cartridge.eventual-failover')
 
-    elseif failover_cfg.mode == 'stateful' and failover_cfg.state_provider == 'tarantool' then
+    elseif failover_cfg.mode == 'stateful'
+    and failover_cfg.state_provider == 'tarantool'
+    then
         local params = assert(failover_cfg.tarantool_params)
         vars.client = stateboard_client.new({
             uri = assert(params.uri),
@@ -337,8 +339,16 @@ local function cfg(clusterwide_config)
             end,
         })
         vars.failover_fiber:name('cartridge.stateful-failover')
+    elseif failover_cfg.mode == 'stateful' then
+        return nil, ApplyConfigError:new(
+            'Unknown failover state provider %q',
+            failover_cfg.state_provider
+        )
     else
-        error('Unknown failover mode')
+        return nil, ApplyConfigError:new(
+            'Unknown failover mode %q',
+            failover_cfg.mode
+        )
     end
 
     accept_appointments(first_appointments)

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -136,114 +136,6 @@ local function validate_schema(field, topology)
         '%s.failover must be a table, got %s', field, type(topology.failover)
     )
 
-    if type(topology.failover) == 'table' then
-        e_config:assert(
-            topology.failover.mode == nil or
-            type(topology.failover.mode) == 'string',
-            '%s.failover.mode must be string, got %s',
-            field, type(topology.failover.mode)
-        )
-        e_config:assert(
-            topology.failover.mode == nil or
-            topology.failover.mode == 'disabled' or
-            topology.failover.mode == 'eventual' or
-            topology.failover.mode == 'stateful',
-            '%s.failover unknown mode %q',
-            field, topology.failover.mode
-        )
-
-        if topology.failover.mode == 'stateful' then
-            e_config:assert(
-                topology.failover.state_provider ~= nil,
-                '%s.failover missing state_provider for mode "stateful"',
-                field
-            )
-        end
-
-        if topology.failover.state_provider ~= nil then
-            e_config:assert(
-                type(topology.failover.state_provider) == 'string',
-                '%s.failover.state_provider must be a string, got %s',
-                field, type(topology.failover.state_provider)
-            )
-        end
-
-        if topology.failover.state_provider == 'tarantool' then
-            e_config:assert(
-                topology.failover.tarantool_params ~= nil,
-                '%s.failover missing tarantool_params',
-                field
-            )
-        elseif topology.failover.state_provider ~= nil then
-            e_config:assert(false,
-                '%s.failover unknown state_provider %q',
-                field, topology.failover.state_provider
-            )
-        end
-
-        if topology.failover.tarantool_params ~= nil then
-            local params = topology.failover.tarantool_params
-            local field = field .. '.failover.tarantool_params'
-            e_config:assert(
-                type(params) == 'table',
-                '%s must be a table, got %s',
-                field, type(params)
-            )
-
-            e_config:assert(
-                type(params.uri) == 'string',
-                '%s.uri must be a string, got %s',
-                field, type(params.uri)
-            )
-
-            local parts = uri.parse(params.uri)
-            e_config:assert(
-                type(parts) == 'table',
-                '%s.uri invalid URI %q',
-                field, params.uri
-            )
-
-            e_config:assert(
-                parts.service ~= nil,
-                '%s.uri invalid URI %q (missing port)',
-                field, params.uri
-            )
-
-            e_config:assert(
-                type(params.password) == 'string',
-                '%s.password must be a string, got %s',
-                field, type(params.params)
-            )
-
-            local known_keys = {
-                ['uri'] = true,
-                ['password'] = true,
-            }
-            for k, _ in pairs(params) do
-                e_config:assert(
-                    known_keys[k],
-                    '%s has unknown parameter %q', field, k
-                )
-            end
-        end
-
-        local known_keys = {
-            ['mode'] = true,
-            ['state_provider'] = true,
-            ['tarantool_params'] = true,
-            -- For the sake of backward compatibility with v2.0.1-78
-            -- See bug https://github.com/tarantool/cartridge/issues/754
-            ['enabled'] = true,
-            ['coordinator_uri'] = true,
-        }
-        for k, _ in pairs(topology.failover) do
-            e_config:assert(
-                known_keys[k],
-                '%s.failover has unknown parameter %q', field, k
-            )
-        end
-    end
-
     e_config:assert(
         type(servers) == 'table',
         '%s.servers must be a table, got %s', field, type(servers)
@@ -415,6 +307,117 @@ local function validate_schema(field, topology)
     end
 end
 
+local function validate_failover_schema(field, topology)
+
+    if type(topology.failover) == 'table' then
+        e_config:assert(
+            topology.failover.mode == nil or
+            type(topology.failover.mode) == 'string',
+            '%s.failover.mode must be string, got %s',
+            field, type(topology.failover.mode)
+        )
+        e_config:assert(
+            topology.failover.mode == nil or
+            topology.failover.mode == 'disabled' or
+            topology.failover.mode == 'eventual' or
+            topology.failover.mode == 'stateful',
+            '%s.failover unknown mode %q',
+            field, topology.failover.mode
+        )
+
+        if topology.failover.mode == 'stateful' then
+            e_config:assert(
+                topology.failover.state_provider ~= nil,
+                '%s.failover missing state_provider for mode "stateful"',
+                field
+            )
+        end
+
+        if topology.failover.state_provider ~= nil then
+            e_config:assert(
+                type(topology.failover.state_provider) == 'string',
+                '%s.failover.state_provider must be a string, got %s',
+                field, type(topology.failover.state_provider)
+            )
+        end
+
+        if topology.failover.state_provider == 'tarantool' then
+            e_config:assert(
+                topology.failover.tarantool_params ~= nil,
+                '%s.failover missing tarantool_params',
+                field
+            )
+        elseif topology.failover.state_provider ~= nil then
+            e_config:assert(false,
+                '%s.failover unknown state_provider %q',
+                field, topology.failover.state_provider
+            )
+        end
+
+        if topology.failover.tarantool_params ~= nil then
+            local params = topology.failover.tarantool_params
+            local field = field .. '.failover.tarantool_params'
+            e_config:assert(
+                type(params) == 'table',
+                '%s must be a table, got %s',
+                field, type(params)
+            )
+
+            e_config:assert(
+                type(params.uri) == 'string',
+                '%s.uri must be a string, got %s',
+                field, type(params.uri)
+            )
+
+            local parts = uri.parse(params.uri)
+            e_config:assert(
+                type(parts) == 'table',
+                '%s.uri invalid URI %q',
+                field, params.uri
+            )
+
+            e_config:assert(
+                parts.service ~= nil,
+                '%s.uri invalid URI %q (missing port)',
+                field, params.uri
+            )
+
+            e_config:assert(
+                type(params.password) == 'string',
+                '%s.password must be a string, got %s',
+                field, type(params.params)
+            )
+
+            local known_keys = {
+                ['uri'] = true,
+                ['password'] = true,
+            }
+            for k, _ in pairs(params) do
+                e_config:assert(
+                    known_keys[k],
+                    '%s has unknown parameter %q', field, k
+                )
+            end
+        end
+
+        local known_keys = {
+            ['mode'] = true,
+            ['state_provider'] = true,
+            ['tarantool_params'] = true,
+            -- For the sake of backward compatibility with v2.0.1-78
+            -- See bug https://github.com/tarantool/cartridge/issues/754
+            ['enabled'] = true,
+            ['coordinator_uri'] = true,
+        }
+        for k, _ in pairs(topology.failover) do
+            e_config:assert(
+                known_keys[k],
+                '%s.failover has unknown parameter %q', field, k
+            )
+        end
+    end
+end
+
 local function validate_consistency(topology)
     checks('table')
     local servers = topology.servers or {}
@@ -558,6 +561,7 @@ local function validate(topology_new, topology_old)
 
     validate_schema('topology_old', topology_old)
     validate_schema('topology_new', topology_new)
+    validate_failover_schema('topology_new', topology_new)
     validate_consistency(topology_new)
     validate_availability(topology_new)
     validate_upgrade(topology_new, topology_old)
@@ -584,11 +588,30 @@ local function get_failover_params(topology_cfg)
             mode = topology_cfg.failover and 'eventual' or 'disabled'
         }
     elseif type(topology_cfg.failover) == 'table' then
-        return {
-            mode = topology_cfg.failover.mode or 'disabled',
+        local ret = {
+            mode = topology_cfg.failover.mode,
             state_provider = topology_cfg.failover.state_provider,
             tarantool_params = topology_cfg.failover.tarantool_params,
         }
+
+        if ret.mode == nil
+        and type(topology_cfg.failover.enabled) == 'boolean'
+        then
+            -- backward compatibility with 2.0.1-78
+            -- see https://github.com/tarantool/cartridge/pull/617
+            ret.mode = topology_cfg.failover.enabled and 'eventual' or 'disabled'
+        end
+
+        if ret.mode == 'stateful'
+        and ret.state_provider == nil
+        then
+            -- backward compatibility with 2.0.1-95
+            -- see https://github.com/tarantool/cartridge/pull/651
+            ret.mode = 'disabled'
+            -- because stateful failover itself wasn't implemented yet
+        end
+
+        return ret
     else
         local err = string.format(
             'assertion failed! topology.failover = %s (%s)',

--- a/test/compatibility/config_test.lua
+++ b/test/compatibility/config_test.lua
@@ -23,8 +23,14 @@ g.after_each(function()
     fio.rmtree(g.tempdir)
 end)
 
-function g.test_failover_params()
-    -- Test the issue https://github.com/tarantool/cartridge/issues/754d
+function g.test_failover_2_0_1_78()
+    -- Test the issue https://github.com/tarantool/cartridge/issues/754
+    -- 2.0.1-78 (#617)
+    -- failover = nil | boolean | {
+    --     enabled = boolean, -- this is the main problem
+    --     coordinator_uri = nil | 'kingdom.com:4401',
+    -- }
+
     local instance_uuid = helpers.uuid('a', 'a', 1)
     local replicaset_uuid = helpers.uuid('a')
     utils.file_write(g.tempdir .. '/config.yml', yaml.encode({
@@ -43,6 +49,67 @@ function g.test_failover_params()
             },
             failover = {
                 enabled = true,
+            },
+        },
+        vshard_groups = {
+            default = {
+                bucket_count = 3000,
+                bootstrapped = false,
+            }
+        }
+    }))
+
+    g.server:start()
+    helpers.retrying({}, function()
+        g.server.net_box:eval([[
+            local cartridge = package.loaded['cartridge']
+            return assert(cartridge) and assert(cartridge.is_healthy())
+        ]])
+    end)
+
+    local failover_params = g.server:graphql({query = [[mutation{
+        cluster { failover_params(mode: "eventual") {
+            mode
+            state_provider
+            tarantool_params {}
+        }}
+    }]]}).data.cluster.failover_params
+
+    t.assert_equals(failover_params, {
+        mode = 'eventual',
+        state_provider = box.NULL,
+        tarantool_params = box.NULL,
+    })
+end
+
+
+function g.test_failover_2_0_1_95()
+    -- Test the issue https://github.com/tarantool/cartridge/issues/754
+    -- 2.0.1-95 (#653 + #651)
+    -- failover = nil | boolean | {
+    --     mode = 'disabled'|'eventual'|'stateful',
+    --     coordinator_uri = nil | 'kingdom.com:4401',
+    -- }
+
+    local instance_uuid = helpers.uuid('a', 'a', 1)
+    local replicaset_uuid = helpers.uuid('a')
+    utils.file_write(g.tempdir .. '/config.yml', yaml.encode({
+        topology = {
+            servers = {
+                [instance_uuid] = {
+                    uri = 'localhost:13301',
+                    replicaset_uuid = replicaset_uuid,
+                },
+            },
+            replicasets = {
+                [replicaset_uuid] = {
+                    roles = {},
+                    master = instance_uuid,
+                },
+            },
+            failover = {
+                mode = 'stateful',
+                coordinator_uri = 'client:qwerty@localhost:4401',
             },
         },
         vshard_groups = {


### PR DESCRIPTION
Follow-up for #755
In context of #754

1. Don't check failover params schema for old config. It's useless and
   may be even harmful.
2. Protect apply_config with pcalls. Otherwise the instance could stuck
   in ConfiguringRoles state during boot forever.
3. Enhance compatibility with v2.0.2

I didn't forget about

- [x] Tests