### PR TITLE
Fix failover vocabulary in WebUI dialogs

### DIFF
--- a/webui/cypress/integration/failover.spec.js
+++ b/webui/cypress/integration/failover.spec.js
@@ -12,8 +12,8 @@ describe('Failover', () => {
 
     cy.get('.meta-test__disableRadioBtn').click();
 
-    cy.get('.meta-test__statefulStorageURI input').should('be.disabled');
-    cy.get('.meta-test__storagePassword input').should('be.disabled');
+    cy.get('.meta-test__stateboardURI input').should('be.disabled');
+    cy.get('.meta-test__stateboardPassword input').should('be.disabled');
 
 
     cy.get('.meta-test__SubmitButton').click();
@@ -27,8 +27,8 @@ describe('Failover', () => {
 
     cy.get('.meta-test__eventualRadioBtn').click();
 
-    cy.get('.meta-test__statefulStorageURI input').should('be.disabled');
-    cy.get('.meta-test__storagePassword input').should('be.disabled');
+    cy.get('.meta-test__stateboardURI input').should('be.disabled');
+    cy.get('.meta-test__stateboardPassword input').should('be.disabled');
 
     cy.get('.meta-test__SubmitButton').click();
     cy.get('span:contains(Failover mode) + * + span:contains(eventual)').click();
@@ -40,8 +40,8 @@ describe('Failover', () => {
     cy.get('.meta-test__FailoverButton').click();
 
     cy.get('.meta-test__statefulRadioBtn').click();
-    cy.get('.meta-test__statefulStorageURI input').type('{selectall}{backspace}');
-    cy.get('.meta-test__storagePassword input').type('{selectall}{backspace}');
+    cy.get('.meta-test__stateboardURI input').type('{selectall}{backspace}');
+    cy.get('.meta-test__stateboardPassword input').type('{selectall}{backspace}');
 
     cy.get('.meta-test__SubmitButton').click();
     cy.get('.meta-test__FailoverModal')
@@ -56,10 +56,10 @@ describe('Failover', () => {
 
     cy.get('.meta-test__statefulRadioBtn').click().click();
 
-    cy.get('.meta-test__statefulStorageURI input').should('be.enabled');
-    cy.get('.meta-test__storagePassword input').should('be.enabled');
+    cy.get('.meta-test__stateboardURI input').should('be.enabled');
+    cy.get('.meta-test__stateboardPassword input').should('be.enabled');
 
-    cy.get('.meta-test__statefulStorageURI input').type('{selectall}{backspace}localhost:13303');
+    cy.get('.meta-test__stateboardURI input').type('{selectall}{backspace}localhost:13303');
 
     cy.get('.meta-test__SubmitButton').click();
     cy.get('span:contains(Failover mode) + * + span:contains(stateful)').click();

--- a/webui/src/components/FailoverModal.js
+++ b/webui/src/components/FailoverModal.js
@@ -175,24 +175,24 @@ class FailoverModal extends React.Component<FailoverModalProps, FailoverModalSta
             <div>
               <Text className={styles.radioLabel}>Stateful</Text>
               <Text className={styles.radioDescription} tag='p'>
-                Leader appointments are polled from the external storage.
+                Leader appointments are polled from the external state provider.
                 Decisions are taken by one of the instances with the failover-coordinator role enabled.
               </Text>
             </div>
           </RadioButton>
         </FormField>
         <div className={styles.inputs}>
-          <LabeledInput className={styles.inputField} label='Stateful storage URI'>
+          <LabeledInput className={styles.inputField} label='State provider URI'>
             <Input
-              className='meta-test__statefulStorageURI'
+              className='meta-test__stateboardURI'
               value={uri}
               disabled={mode !== 'stateful'}
               onChange={this.handleURIChange}
             />
           </LabeledInput>
-          <LabeledInput className={styles.inputField} label='Storage password'>
+          <LabeledInput className={styles.inputField} label='Password'>
             <InputPassword
-              className='meta-test__storagePassword'
+              className='meta-test__stateboardPassword'
               value={password}
               disabled={mode !== 'stateful'}
               onChange={this.handlePasswordChange}


### PR DESCRIPTION
Change terminology according to our spoken language

I didn't forget about

- [x] Tests

