### PR TITLE
Cleanup cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ add_test(
 ## Install ####################################################################
 ###############################################################################
 
+file(
+    WRITE ${CMAKE_CURRENT_BINARY_DIR}/stateboard
+    "#!/usr/bin/env tarantool\n\nrequire('cartridge.stateboard').cfg()\n"
+)
+
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}
@@ -165,9 +170,9 @@ install(
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}
 )
 
-file(
-    WRITE ${TARANTOOL_INSTALL_BINDIR}/stateboard
-    "#!/usr/bin/env tarantool\n\nrequire('cartridge.stateboard').cfg()\n"
+install(
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/stateboard
+  DESTINATION ${TARANTOOL_INSTALL_BINDIR}
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,19 +136,7 @@ enable_testing()
 
 add_test(
   NAME lint
-  COMMAND luacheck cartridge-scm-1.rockspec
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-add_test(
-  NAME test_unit
-  COMMAND ${TARANTOOL} ${CMAKE_CURRENT_SOURCE_DIR}/taptest.lua
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-add_test(
-  NAME test_integration
-  COMMAND pytest -v
+  COMMAND luacheck .
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/cmake/FindTarantool.cmake
+++ b/cmake/FindTarantool.cmake
@@ -34,12 +34,19 @@ if(TARANTOOL_FOUND)
         CACHE PATH "Directory for storing Lua modules written in Lua")
     set(TARANTOOL_INSTALL_LUADIR "${CMAKE_INSTALL_DATADIR}/tarantool"
         CACHE PATH "Directory for storing Lua modules written in C")
+    set(TARANTOOL_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}"
+        CACHE PATH "Directory for storing Lua scripts")
 
     if (NOT TARANTOOL_FIND_QUIETLY AND NOT FIND_TARANTOOL_DETAILS)
         set(FIND_TARANTOOL_DETAILS ON CACHE INTERNAL "Details about TARANTOOL")
         message(STATUS "Tarantool LUADIR is ${TARANTOOL_INSTALL_LUADIR}")
         message(STATUS "Tarantool LIBDIR is ${TARANTOOL_INSTALL_LIBDIR}")
+        message(STATUS "Tarantool BINDIR is ${TARANTOOL_INSTALL_BINDIR}")
     endif ()
 endif()
-mark_as_advanced(TARANTOOL_INCLUDE_DIRS TARANTOOL_INSTALL_LIBDIR
-    TARANTOOL_INSTALL_LUADIR)
+mark_as_advanced(
+    TARANTOOL_INCLUDE_DIRS
+    TARANTOOL_INSTALL_LIBDIR
+    TARANTOOL_INSTALL_LUADIR
+    TARANTOOL_INSTALL_BINDIR
+)


### PR DESCRIPTION
1. Fix launching `cmake` without tarantoolctl rocks
1. Remove obsolete tests from CTest section
