### PR TITLE
Update cluster list layout

### DIFF
--- a/webui/src/components/ReplicasetList/ReplicasetList.js
+++ b/webui/src/components/ReplicasetList/ReplicasetList.js
@@ -25,10 +25,10 @@ const styles = {
     padding-right: 103px;
   `,
   aliasTooltip: css`
-    flex-basis: 463px;
+    flex-basis: 458px;
     flex-grow: 1;
     flex-shrink: 0;
-    margin-right: 24px;
+    margin-right: 16px;
     margin-bottom: 8px;
     overflow: hidden;
   `,
@@ -39,8 +39,9 @@ const styles = {
   `,
   statusGroup: css`
     display: flex;
-    flex-basis: 530px;
+    flex-basis: 592px;
     flex-shrink: 0;
+    margin-right: -55px;
     margin-bottom: 12px;
   `,
   statusWrap: css`
@@ -70,7 +71,9 @@ const styles = {
     font-weight: bold;
   `,
   vshard: css`
-    flex-basis: 306px;
+    position: absolute;
+    right: 76px;
+    width: 343px;
     margin-left: 12px;
     margin-right: 12px;
     color: rgba(0, 0, 0, 0.65);

--- a/webui/src/components/ReplicasetServerListItem.js
+++ b/webui/src/components/ReplicasetServerListItem.js
@@ -33,14 +33,14 @@ const styles = {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
-    padding-right: 40px;
+    padding-right: 31px;
     margin-bottom: -8px;
   `,
   heading: css`
-    flex-basis: 430px;
+    flex-basis: 415px;
     flex-grow: 1;
     flex-shrink: 0;
-    margin-right: 24px;
+    margin-right: 16px;
     margin-bottom: 8px;
     overflow: hidden;
   `,
@@ -67,47 +67,57 @@ const styles = {
     left: 3px;
   `,
   iconMargin: css`
-    margin-right: 8px;
-  `,
-  iconMarginSmall: css`
     margin-right: 4px;
   `,
   statusGroup: css`
     display: flex;
     flex-basis: 576px;
     flex-shrink: 0;
+    flex-grow: 1;
     align-items: flex-start;
     margin-bottom: 8px;
   `,
   memStats: css`
-    width: 229px;
+    flex-shrink: 0;
+    width: 246px;
+  `,
+  memStatsRow: css`
+    display: flex;
+    align-items: center;
+  `,
+  statsText: css`
+    white-space: nowrap;
   `,
   memProgress: css`
     width: auto;
-    margin-left: 24px;
+    margin-left: 20px;
   `,
   configureBtn: css`
     position: absolute;
     top: 12px;
-    right: 16px;
+    right: 12px;
   `,
   status: css`
     flex-basis: 193px;
     flex-shrink: 0;
     margin-top: 1px;
-    margin-right: 24px;
+    margin-right: 16px;
     margin-left: -8px;
   `,
   stats: css`
-    position: relative;
+    position: absolute;
+    right: 46px;
     display: flex;
-    flex-basis: 351px;
     flex-shrink: 0;
     align-items: stretch;
+    margin-left: auto;
+    width: 384px;
   `,
   bucketsCount: css`
     flex-shrink: 0;
-    width: 120px;
+    display: flex;
+    align-items: center;
+    width: 122px;
     margin-right: 16px;
   `,
   tags: css`
@@ -237,8 +247,8 @@ class ReplicasetServerListItem extends React.PureComponent<
                           </React.Fragment>
                         )}
                       >
-                        <IconBucket className={styles.iconMarginSmall} />
-                        <Text variant='h5' tag='span'>
+                        <IconBucket className={styles.iconMargin} />
+                        <Text className={styles.statsText} variant='h5' tag='span'>
                           Buckets: <b>{(statistics && statistics.bucketsCount) || '-'}</b>
                         </Text>
                       </Tooltip>
@@ -247,8 +257,8 @@ class ReplicasetServerListItem extends React.PureComponent<
                   }
                   <div className={styles.memStats}>
                     <div>
-                      <MemoryIcon {...statistics} />
-                      <Text variant='h5' tag='span'>{usageText}</Text>
+                      <MemoryIcon {...statistics} className={styles.iconMargin} />
+                      <Text className={styles.statsText} variant='h5' tag='span'>{usageText}</Text>
                     </div>
                     <ProgressBar
                       className={styles.memProgress}

--- a/webui/src/components/UnconfiguredServerList.js
+++ b/webui/src/components/UnconfiguredServerList.js
@@ -29,16 +29,16 @@ const styles = {
     margin-right: 16px;
   `,
   heading: css`
-    flex-basis: 463px;
+    flex-basis: 458px;
     flex-grow: 1;
     flex-shrink: 0;
-    margin-right: 24px;
+    margin-right: 16px;
     margin-bottom: 8px;
     overflow: hidden;
   `,
   status: css`
     display: flex;
-    flex-basis: 498px;
+    flex-basis: 505px;
     flex-shrink: 0;
     align-items: center;
     margin-bottom: 8px;


### PR DESCRIPTION
Update layout of replicasets list and fix text overload.

Before:
![image](https://user-images.githubusercontent.com/27233703/79402963-2624f680-7f96-11ea-9a1a-dbcd893d9623.png)

After:
![image](https://user-images.githubusercontent.com/27233703/79402972-30df8b80-7f96-11ea-9228-475917289308.png)

Before:
![image](https://user-images.githubusercontent.com/27233703/79402987-3a68f380-7f96-11ea-8b66-8b3cdb545fcf.png)

After:
![image](https://user-images.githubusercontent.com/27233703/79403000-405ed480-7f96-11ea-8a32-0deeb202015b.png)


I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #603 
