### PR TITLE
cleanup cartridge sources

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Tarantool framework for distributed applications development.
 --
 -- Cartridge provides you a simple way

--- a/cartridge/VERSION.lua
+++ b/cartridge/VERSION.lua
@@ -1,3 +1,1 @@
-#!/usr/bin/env tarantool
-
 return "scm-1"

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Gather configuration options.
 --
 -- The module tries to read configuration options from multiple sources

--- a/cartridge/auth-backend.lua
+++ b/cartridge/auth-backend.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local fiber = require('fiber')
 local cartridge = require('cartridge')
 local checks = require('checks')

--- a/cartridge/auth.lua
+++ b/cartridge/auth.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Administrators authentication and authorization.
 --
 -- @module cartridge.auth

--- a/cartridge/cluster-cookie.lua
+++ b/cartridge/cluster-cookie.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local os = require('os')
 local fio = require('fio')
 local errno = require('errno')

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- The abstraction, representing clusterwide configuration.
 --
 -- Clusterwide configuration is more than just a lua table. It's an

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Configuration management primitives.
 --
 -- Implements the internal state machine which helps to manage cluster

--- a/cartridge/ddl-manager.lua
+++ b/cartridge/ddl-manager.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log = require('log')
 local ddl = require('ddl')
 local yaml = require('yaml')

--- a/cartridge/feedback.lua
+++ b/cartridge/feedback.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log   = require('log')
 local json  = require('json')
 local fiber = require('fiber')

--- a/cartridge/graphql.lua
+++ b/cartridge/graphql.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log = require('log')
 local json = require('json')
 local checks = require('checks')

--- a/cartridge/graphql/funcall.lua
+++ b/cartridge/graphql/funcall.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local checks = require('checks')
 local errors = require('errors')
 

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Connection pool.
 --
 -- Reuse tarantool net.box connections with ease.

--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Tarantool remote control server.
 --
 -- Allows to control an instance over TCP by `net.box` `call` and `eval`.

--- a/cartridge/roles.lua
+++ b/cartridge/roles.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Role management (internal module).
 --
 -- The module consolidates all the role management functions:

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log = require('log')
 local vshard = require('vshard')
 local checks = require('checks')

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log = require('log')
 local vshard = require('vshard')
 local checks = require('checks')

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Remote procedure calls between cluster instances.
 --
 -- @module cartridge.rpc

--- a/cartridge/service-registry.lua
+++ b/cartridge/service-registry.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Inter-role interaction.
 --
 -- These functions make

--- a/cartridge/tar.lua
+++ b/cartridge/tar.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Handle basic tar format.
 --
 -- <http://www.gnu.org/software/tar/manual/html_node/Standard.html>

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -1,4 +1,3 @@
-#!/usr/bin/env tarantool
 -- luacheck: ignore _it
 
 --- Topology validation and filtering.

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 --- Clusterwide configuration propagation two-phase algorithm.
 --
 -- (**Added** in v1.2.0-19)

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local fio = require('fio')
 local ffi = require('ffi')
 local errno = require('errno')

--- a/cartridge/vars.lua
+++ b/cartridge/vars.lua
@@ -1,4 +1,3 @@
-#!/usr/bin/env tarantool
 -- luacheck: globals box
 
 local checks = require('checks')

--- a/cartridge/vshard-utils.lua
+++ b/cartridge/vshard-utils.lua
@@ -1,4 +1,3 @@
-#!/usr/bin/env tarantool
 -- luacheck: ignore _it
 
 local fun = require('fun')

--- a/cartridge/webui.lua
+++ b/cartridge/webui.lua
@@ -1,6 +1,3 @@
-#!/usr/bin/env tarantool
-
--- local log = require('log')
 local front = require('frontend-core')
 
 local vars = require('cartridge.vars').new('cartridge.webui')

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local errors = require('errors')
 
 local auth = require('cartridge.auth')

--- a/cartridge/webui/api-config.lua
+++ b/cartridge/webui/api-config.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local log = require('log')
 local json = require('json').new()
 local yaml = require('yaml').new()

--- a/cartridge/webui/api-ddl.lua
+++ b/cartridge/webui/api-ddl.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local yaml = require('yaml')
 local errors = require('errors')
 local netbox = require('net.box')

--- a/cartridge/webui/api-issues.lua
+++ b/cartridge/webui/api-issues.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local _ = require('cartridge.issues')
 local gql_types = require('cartridge.graphql.types')
 

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local roles = require('cartridge.roles')
 local gql_types = require('cartridge.graphql.types')
 local gql_boxinfo_schema = require('cartridge.webui.gql-boxinfo').schema

--- a/cartridge/webui/api-vshard.lua
+++ b/cartridge/webui/api-vshard.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local gql_types = require('cartridge.graphql.types')
 local vshard_utils = require('cartridge.vshard-utils')
 local _ = require('cartridge.lua-api.vshard')

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local gql_types = require('cartridge.graphql.types')
 local lua_api_boxinfo = require('cartridge.lua-api.boxinfo')
 

--- a/cartridge/webui/gql-stat.lua
+++ b/cartridge/webui/gql-stat.lua
@@ -1,5 +1,3 @@
-#!/usr/bin/env tarantool
-
 local pool = require('cartridge.pool')
 local gql_types = require('cartridge.graphql.types')
 local lua_api_stat = require('cartridge.lua-api.stat')


### PR DESCRIPTION
Non-executable files that contain shebang but doesn't countain
executable bit causes following rpmlint error when we try to pack
cartridge application into rpm:
```
This text file contains a shebang or is located in a path dedicated
for executables, but lacks the executable bits and cannot thus be
executed. If the file is meant to be an executable script, add the
executable bits, otherwise remove the shebang or move the file elsewhere.
```

This patch just removes shebangs from files that located in
cartridge directory.

