### PR TITLE
Fix leaking sockets in remote control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- Validation of `console_sock` length.
+- Avoid trimming `console_sock` it it's name is too long.
+
+- Fix fd leak during box recovery.
 
 ## [2.1.1] - 2020-04-20
 

--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -2,6 +2,7 @@ local t = require('luatest')
 local g = t.group()
 
 local fio = require('fio')
+local fiber = require('fiber')
 local digest = require('digest')
 local socket = require('socket')
 local pickle = require('pickle')
@@ -191,7 +192,6 @@ function g.test_late_accept()
     t.assert_equals(ok, true)
     local url = 'superuser:3.141592@localhost:13301'
 
-    local fiber = require('fiber')
     local f = fiber.new(netbox.connect, url)
     f:name('netbox_connect')
     f:set_joinable(true)
@@ -833,14 +833,14 @@ function g.test_socket_gc()
         local s = socket.tcp_connect('127.0.0.1', 13301)
         t.assert(s, string.format('socket #%s: %s', i, errno.strerror()))
         s:close()
-        require('fiber').sleep(0)
+        fiber.sleep(0)
     end
 
     -- One socket still remains in CLOSE_WAIT state
     t.assert_equals(fdcnt(), initial_fdcnt+1)
 
     remote_control.accept({username = username, password = password})
-    require('fiber').sleep(0)
+    fiber.sleep(0)
 
     -- It disappears after accept()
     t.assert_equals(fdcnt(), initial_fdcnt)


### PR DESCRIPTION
Consider the case when cartridge instance recovers from snapshot.
It calls `remote_control.bind()` and accepts new connections, but doesn't
reply anything until recovery finishes. It may take some time.

If a client connection times out, the socket remains in CLOSE_WAIT state.
It's not GC'ed until the handler returns and socket is closed from
the server side explicitly.

If a client tries to reconnect afterwards, it results in fd leak, and
after some time the instance will likely get "too many open files" error.
We've met similar problem [here](https://github.com/tarantool/tarantool/issues/4910).

After this patch tcp handler doesn't retain closed sockets forever.

I didn't forget about

- [x] Tests
- [x] Changelog
