### PR TITLE
Make WebUI errors prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Enhanced in WebUI
+
+- Prettier errors displaying.
+
 ## [2.1.2] - 2020-04-24
 
 ### Fixed

--- a/webui/src/api/index.js
+++ b/webui/src/api/index.js
@@ -9,6 +9,8 @@ export const getErrorMessage = error => {
       return getRestErrorMessage(error);
     case isAxiosError(error):
       return getAxiosErrorMessage(error);
+    case isNetworkError(error):
+      return getNetworkErrorMessage(error);
     default:
       return error.message || error.toString();
   }
@@ -17,6 +19,14 @@ export const getErrorMessage = error => {
 export const isDeadServerError = error => {
   return isRestErrorResponse(error)
     && (error.responseText === '' || /^Proxy error:.+ECONNREFUSED/.test(error.response));
+};
+
+export const isNetworkError = error => {
+  return !!error.networkError;
+};
+
+export const getNetworkErrorMessage = error => {
+  return error.networkError.bodyText || error.networkError.message;
 };
 
 export const SERVER_NOT_REACHABLE_ERROR_TYPE = 'SERVER_NOT_REACHABLE_ERROR_TYPE';

--- a/webui/src/app/index.js
+++ b/webui/src/app/index.js
@@ -9,7 +9,7 @@ const mapStateToProps = state => {
     app: {
       appMount,
       appDataRequestStatus,
-      appDataRequestErrorMessage,
+      appDataRequestError,
       clusterSelf,
       messages,
       authParams: {
@@ -25,7 +25,7 @@ const mapStateToProps = state => {
   return {
     appMount,
     appDataRequestStatus,
-    appDataRequestErrorMessage,
+    appDataRequestError,
     clusterSelf,
     authorizationRequired: implements_check_password && authorizationEnabled && !authorized,
     messages

--- a/webui/src/components/PageDataErrorMessage/PageDataErrorMessage.js
+++ b/webui/src/components/PageDataErrorMessage/PageDataErrorMessage.js
@@ -1,22 +1,35 @@
 import React from 'react';
 import { css } from 'emotion';
-import { isGraphqlErrorResponse, getGraphqlErrorMessage } from 'src/api/graphql';
+import { getErrorMessage, isNetworkError } from 'src/api';
+import {
+  SplashErrorNetwork,
+  SplashErrorFatal,
+} from '@tarantool.io/ui-kit';
 
-const styles = {
-  outer: css`
-    padding-bottom: 50px;
-  `
-};
+const style = css`
+  display: flex;
+  justify-content: center;
+  height: calc(100vh - 145px);
+`;
 
 class PageDataErrorMessage extends React.PureComponent {
   render() {
     const { error } = this.props;
+    const errorMessage = getErrorMessage(error);
 
     return (
-      <div className={styles.outer}>
-        {isGraphqlErrorResponse(error)
-          ? getGraphqlErrorMessage(error)
-          : 'Server error: ' + JSON.stringify(error)}
+      <div className={style}>
+        {isNetworkError(error)
+          ?
+          <SplashErrorNetwork
+            description={errorMessage}
+          />
+          :
+          <SplashErrorFatal
+            title={errorMessage}
+            description=''
+          />
+        }
       </div>
     );
   }

--- a/webui/src/components/SectionLoadError.js
+++ b/webui/src/components/SectionLoadError.js
@@ -3,23 +3,39 @@ import * as React from 'react';
 import { css, cx } from 'emotion';
 import {
   Button,
-  IconCancel,
-  NonIdealStateAction
+  NonIdealStateAction,
+  splashGenericErrorSvg
 } from '@tarantool.io/ui-kit';
 
-const style = css`
-  height: calc(100% - 69px);
-`;
+const styles = {
+  block: css`
+    height: calc(100% - 69px);
+  `,
+  icon: css`
+    width: 80px;
+    height: 80px;
+    margin-bottom: 24px;
+  `,
+};
 
 type SectionLoadErrorProps = {
   className?: string,
   onClick: () => void
 };
 
+const IconGenericError = () => (
+  <svg
+    viewBox={splashGenericErrorSvg.viewBox}
+    className={styles.icon}
+  >
+    <use xlinkHref={`#${splashGenericErrorSvg.id}`}/>
+  </svg>
+);
+
 export const SectionLoadError = ({ className, onClick }: SectionLoadErrorProps) => (
   <NonIdealStateAction
-    className={cx(style, className)}
-    icon={IconCancel}
+    className={cx(styles.block, className)}
+    icon={IconGenericError}
     title='Error loading component'
     actionText='Retry'
     onActionClick={onClick}

--- a/webui/src/pages/Code.js
+++ b/webui/src/pages/Code.js
@@ -11,7 +11,9 @@ import {
   IconRefresh,
   PopupBody,
   Text,
-  Scrollbar
+  Scrollbar,
+  NonIdealState,
+  splashSelectFileSvg
 } from '@tarantool.io/ui-kit';
 import { InputModal } from 'src/components/InputModal';
 import MonacoEditor from 'src/components/MonacoEditor';
@@ -33,7 +35,6 @@ import { getLanguageByFileName, getFileIdForMonaco } from 'src/misc/monacoModelS
 import type { TreeFileItem } from 'src/store/selectors/filesSelectors';
 import type { FileItem } from 'src/store/reducers/files.reducer';
 import { type State } from 'src/store/rootReducer';
-import { IconFileWithCode } from 'src/components/Icon/icons/IconFileWithCode';
 
 const options = {
   fixedOverflowWidgets: true,
@@ -114,19 +115,15 @@ const styles = {
   `,
   splash: css`
     display: flex;
-    flex-direction: column;
     flex-grow: 1;
     align-items: center;
     justify-content: center;
-    text-align: center;
-    color: rgba(0, 0, 0, 0.25);
-    font-size: 14px;
   `,
-  splashIcon: css`
-    width: 35px;
-    height: 35px;
-    margin-bottom: 16px;
-  `
+  selectFileIcon: css`
+    width: 80px;
+    height: 112px;
+    margin-bottom: 24px;
+  `,
 };
 
 type CodeState = {
@@ -146,6 +143,17 @@ type CodeProps = {
   selectedFile: FileItem | null,
   dispatch: Function,
 }
+
+
+const IconSelectFile = () => (
+  <svg
+    viewBox={splashSelectFileSvg.viewBox}
+    className={styles.selectFileIcon}
+  >
+    <use xlinkHref={`#${splashSelectFileSvg.id}`}/>
+  </svg>
+);
+
 
 class Code extends React.Component<CodeProps, CodeState> {
   state = {
@@ -425,10 +433,11 @@ class Code extends React.Component<CodeProps, CodeState> {
                 />
               </>
               :
-              <div className={styles.splash}>
-                <IconFileWithCode className={styles.splashIcon} />
-                Please select a file
-              </div>
+              <NonIdealState
+                icon={IconSelectFile}
+                title='Please select a file'
+                className={styles.splash}
+              />
             }
           </div>
           {operableFile && typeof operableFile.type === 'string' && (

--- a/webui/src/store/reducers/app.reducer.js
+++ b/webui/src/store/reducers/app.reducer.js
@@ -1,6 +1,4 @@
 // @flow
-import { isGraphqlErrorResponse, isGraphqlAccessDeniedError } from 'src/api/graphql';
-import { isRestErrorResponse, isRestAccessDeniedError } from 'src/api/rest';
 import {
   APP_DID_MOUNT,
   APP_DATA_REQUEST,
@@ -34,7 +32,7 @@ type AppMessage = {
 export type AppState = {
   appMount: boolean,
   appDataRequestStatus: RequestStatusType,
-  appDataRequestErrorMessage: null,
+  appDataRequestError: ?Error,
   clusterSelf: {
     uri: ?string,
     uuid: ?string,
@@ -48,20 +46,20 @@ export type AppState = {
   failover_params: FailoverApi,
   messages: AppMessage[],
   authParams: {
-    enabled: ?false,
-    implements_add_user: ?false,
-    implements_check_password: ?false,
-    implements_list_users: ?false,
-    implements_edit_user: ?false,
-    implements_remove_user: ?false,
-    username: ?null
+    enabled?: boolean,
+    implements_add_user?: boolean,
+    implements_check_password?: boolean,
+    implements_list_users?: boolean,
+    implements_edit_user?: boolean,
+    implements_remove_user?: boolean,
+    username?: ?string
   },
 };
 
 const initialState: AppState = {
   appMount: false,
   appDataRequestStatus: getInitialRequestStatus(),
-  appDataRequestErrorMessage: null,
+  appDataRequestError: null,
   clusterSelf: {},
   connectionAlive: true,
   failover_params: {
@@ -87,38 +85,20 @@ export const reducer = baseReducer(
   appMountReducer,
   appDataRequestReducer,
 )(
-  (state, action) => {
+  (state: AppState, action): AppState => {
     switch (action.type) {
       case APP_DATA_REQUEST:
         return {
           ...state,
-          appDataRequestErrorMessage: null
+          appDataRequestError: null
         };
 
       case APP_DATA_REQUEST_ERROR: {
         const { error } = action;
 
-        if (isRestErrorResponse(error) && !isRestAccessDeniedError(error)) {
-          return {
-            ...state,
-            appDataRequestErrorMessage: {
-              text: error.responseText
-            }
-          };
-        }
-
-        if (isGraphqlErrorResponse(error) && !isGraphqlAccessDeniedError(error)) {
-          return {
-            ...state,
-            appDataRequestErrorMessage: {
-              text: error
-            }
-          };
-        }
-
         return {
           ...state,
-          appDataRequestErrorMessage: {}
+          appDataRequestError: error
         };
       }
 


### PR DESCRIPTION
Close #634

- Neater error displaying
- Accompanying change: in common getErrorMessage() we now detect Network errors also, and use its `bodyText` field, if present (it contains server response body). So now we can get understandable "_Error occured while trying to proxy to: localhost:3000/admin/api_" instead of confusing "_Network error: Unexpected token E in JSON at position 0_"

- - - - -

Example
BEFORE:
<img width="929" alt="изображение" src="https://user-images.githubusercontent.com/7147989/80009303-8e616400-84d1-11ea-90f3-ea39d00a6e81.png">

AFTER:
<img width="930" alt="изображение" src="https://user-images.githubusercontent.com/7147989/79991691-42a3c000-84bb-11ea-8d28-58985ecd4b9a.png">

- - - - -
Images (big icons) have also changed in a couple of places:
<img width="929" alt="изображение" src="https://user-images.githubusercontent.com/7147989/80021241-e48ad300-84e2-11ea-96d8-9652ed8d4524.png">
<img width="928" alt="изображение" src="https://user-images.githubusercontent.com/7147989/80021528-4fd4a500-84e3-11ea-9c00-fccb3f0f25bc.png">



I didn't forget about

- [ ] Tests
- [x] Changelog
- [ ] Documentation


