### PR TITLE
Box options in stateboard implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix fd leak during box recovery.
 
-- Support `console_sock` option in stateboard
-
-- Box options support in stateboard
+- Support `console_sock` option in stateboard as well as notify socket
+  and other box options similar to regular cartridge instances.
 
 ## [2.1.1] - 2020-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support `console_sock` option in stateboard
 
+- Box options support in stateboard
+
 ## [2.1.1] - 2020-04-20
 
 ### Fixed

--- a/cartridge/stateboard.lua
+++ b/cartridge/stateboard.lua
@@ -157,7 +157,13 @@ local function cfg()
         error(err, 0)
     end
 
-    box.cfg({ work_dir = opts.workdir })
+    local box_opts, err = argparse.get_box_opts()
+    if err ~= nil then
+        error('Configuration error: ' .. tostring(err), 0)
+    end
+    box_opts.work_dir = opts.workdir
+
+    box.cfg(box_opts)
 
     if opts.console_sock ~= nil then
         local sock = console.listen('unix/:' .. opts.console_sock)

--- a/cartridge/stateboard.lua
+++ b/cartridge/stateboard.lua
@@ -161,9 +161,10 @@ local function cfg()
     if err ~= nil then
         error('Box configuration error: ' .. tostring(err), 0)
     end
-    box_opts.work_dir = opts.workdir
+
     -- listen will be enabled when all spaces are set up
     box_opts.listen = nil
+    box_opts.work_dir = opts.workdir
 
     box.cfg(box_opts)
 
@@ -276,6 +277,22 @@ local function cfg()
 
     -- Enable listen port only after all spaces are set up
     box.cfg({ listen = opts.listen })
+
+    -- Emulate support for NOTIFY_SOCKET in old tarantool.
+    -- NOTIFY_SOCKET is fully supported in >= 2.2.2
+    local tnt_version = string.split(_TARANTOOL, '.')
+    local tnt_major = tonumber(tnt_version[1])
+    local tnt_minor = tonumber(tnt_version[2])
+    local tnt_patch = tonumber(tnt_version[3]:split('-')[1])
+    if (tnt_major < 2) or (tnt_major == 2 and tnt_minor < 2) or
+            (tnt_major == 2 and tnt_minor == 2 and tnt_patch < 2) then
+        local notify_socket = os.getenv('NOTIFY_SOCKET')
+        if notify_socket then
+            local socket = require('socket')
+            local sock = assert(socket('AF_UNIX', 'SOCK_DGRAM', 0), 'Can not create socket')
+            sock:sendto('unix/', notify_socket, 'READY=1')
+        end
+    end
 
     ------------------------------------------------------------------------
 

--- a/cartridge/stateboard.lua
+++ b/cartridge/stateboard.lua
@@ -159,9 +159,11 @@ local function cfg()
 
     local box_opts, err = argparse.get_box_opts()
     if err ~= nil then
-        error('Configuration error: ' .. tostring(err), 0)
+        error('Box configuration error: ' .. tostring(err), 0)
     end
     box_opts.work_dir = opts.workdir
+    -- listen will be enabled when all spaces are set up
+    box_opts.listen = nil
 
     box.cfg(box_opts)
 

--- a/test/integration/stateboard_test.lua
+++ b/test/integration/stateboard_test.lua
@@ -306,7 +306,7 @@ function g.test_client_drop_session()
 end
 
 function g.test_stateboard_console()
-    local s = require('socket').tcp_connect(
+    local s = socket.tcp_connect(
         'unix/', g.stateboard.env.TARANTOOL_CONSOLE_SOCK
     )
     t.assert(s)


### PR DESCRIPTION
Stateboard now supports box options.
Tests for `pid_file` a `custom_proc_title` are provided.
Support notify socket in older tarantool versions.

I didn't forget about

- [x] Tests
- [x] Changelog

Close #802
Close #800 