### PR TITLE
Enable stateboard in development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,6 @@ add_test(
 ## Install ####################################################################
 ###############################################################################
 
-file(
-    WRITE ${CMAKE_CURRENT_BINARY_DIR}/stateboard
-    "#!/usr/bin/env tarantool\n\nrequire('cartridge.stateboard').cfg()\n"
-)
-
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}
@@ -178,8 +173,9 @@ install(
 )
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/stateboard
+  PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/stateboard.init.lua
   DESTINATION ${TARANTOOL_INSTALL_BINDIR}
+  RENAME stateboard
 )
 
 install(

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ or with binary protocol:
 tarantoolctl connect admin@localhost:3301
 ```
 
+If stateful failover mode is also needed, one should launch external
+state provider - `stateboard`:
+
+```sh
+.rocks/bin/cartridge start --stateboard
+```
+
+And set failover params according to `instances.yml`. The defaults are:
+
+* State provider URI: `localhost:4401`;
+* Password: `qwerty`.
+
 For more detailed information about `cartridge-cli`
 [see here](https://github.com/tarantool/cartridge-cli#readme).
 

--- a/instances.yml
+++ b/instances.yml
@@ -25,3 +25,8 @@ cartridge.srv-5:
     workdir: ./dev/3305
     advertise_uri: localhost:3305
     http_port: 8085
+
+cartridge-stateboard:
+    workdir: ./dev/stateboard
+    password: qwerty
+    listen: 4401

--- a/stateboard.init.lua
+++ b/stateboard.init.lua
@@ -1,0 +1,3 @@
+#!/usr/bin/env tarantool
+
+require('cartridge.stateboard').cfg()


### PR DESCRIPTION
These changes are necessary to easily configure stateful failover in development environment

I didn't forget about

- [x] Tests (unnecessary)
- [x] Changelog (unnecessary)
- [x] Documentation
