### PR TITLE
GraphQL bugfixes

### DIFF
--- a/cartridge/graphql/rules.lua
+++ b/cartridge/graphql/rules.lua
@@ -521,6 +521,19 @@ local function isVariableTypesValid(argument, argumentType, context,
         'is not compatible with the argument type "%s"'):format(variableName,
         util.getTypeName(variableType), util.getTypeName(argumentType))
     end
+  elseif argument.value.kind == 'list' then
+    -- find variables deeper
+    local parentType = argumentType
+    if parentType.__type == 'NonNull' then
+      parentType = parentType.ofType
+    end
+    local childType = parentType.ofType
+
+    for _, child in ipairs(argument.value.values) do
+      local ok, err = isVariableTypesValid({value = child}, childType, context,
+              variableMap)
+      if not ok then return false, err end
+    end
   elseif argument.value.kind == 'inputObject' then
     -- find variables deeper
     for _, child in ipairs(argument.value.values) do

--- a/cartridge/graphql/types.lua
+++ b/cartridge/graphql/types.lua
@@ -84,6 +84,7 @@ end
 function types.scalar(config)
   assert(type(config.name) == 'string', 'type name must be provided as a string')
   assert(type(config.serialize) == 'function', 'serialize must be a function')
+  assert(type(config.isValueOfTheType) == 'function', 'isValueOfTheType must be a function')
   if config.parseValue or config.parseLiteral then
     assert(
       type(config.parseValue) == 'function' and type(config.parseLiteral) == 'function',
@@ -373,13 +374,22 @@ types.boolean = types.scalar({
   end,
 })
 
+--[[
+The ID scalar type represents a unique identifier,
+often used to refetch an object or as the key for a cache.
+The ID type is serialized in the same way as a String;
+however, defining it as an ID signifies that it is not intended to be human‐readable.
+--]]
 types.id = types.scalar({
   name = 'ID',
   serialize = tostring,
   parseValue = tostring,
   parseLiteral = function(node)
     return node.kind == 'string' or node.kind == 'int' and node.value or nil
-  end
+  end,
+  isValueOfTheType = function(value)
+    return type(value) == 'string'
+  end,
 })
 
 function types.directive(config)

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -151,10 +151,28 @@ g.test_upload = function()
     )
 
     t.assert_error_msg_equals(
+        'Could not coerce "123.4" to "Int"',
+        function() return server:graphql({
+            query = [[
+                query { test(arg: "", arg3: 123.4) }
+            ]], variables = {}
+        }) end
+    )
+
+    t.assert_error_msg_equals(
         'Could not coerce "18446744073709551614" to "Long"',
         function() return server:graphql({
             query = [[
                 query { test(arg: "", arg4: 18446744073709551614) }
+            ]], variables = {}
+        }) end
+    )
+
+    t.assert_error_msg_equals(
+        'Could not coerce "123.4" to "Long"',
+        function() return server:graphql({
+            query = [[
+                query { test(arg: "", arg4: 123.4) }
             ]], variables = {}
         }) end
     )

--- a/test/unit/graphql_test.lua
+++ b/test/unit/graphql_test.lua
@@ -769,6 +769,7 @@ function g.test_rules_unambiguousSelections()
         }
     }]])
 end
+
 function g.test_rules_uniqueArgumentNames()
     local message = 'Encountered multiple arguments named'
 
@@ -913,4 +914,36 @@ function g.test_rules_directivesAreDefined()
 
     -- passes if directives exists
     expectError(nil, 'query @skip {}')
+end
+
+function g.test_types_isValueOfTheType_for_scalars()
+    t.assert_error(function()
+        types.scalar({
+            name = 'MyString',
+            description = "Custom string type",
+            serialize = tostring,
+            parseValue = tostring,
+            parseLiteral = function(node)
+                if node.kind == 'string' then
+                    return node.value
+                end
+            end,
+        })
+    end)
+
+    local CustomString = types.scalar({
+        name = 'MyString',
+        description = "Custom string type",
+        serialize = tostring,
+        parseValue = tostring,
+        parseLiteral = function(node)
+            if node.kind == 'string' then
+                return node.value
+            end
+        end,
+        isValueOfTheType = function(value)
+            return type(value) == 'string'
+        end,
+    })
+    t.assert_equals(CustomString.__type, 'Scalar')
 end


### PR DESCRIPTION
This patchset solves several problems.

Firstly it improves validation for custom types - makes "isValueOfTheType" callback is mandatory. As anyway it will be required by runtime checks [1]

Secondly it add missed validation for list type. Before it was allowed to use different types for variable and an argument. This patch fixes such behaviour and check that this types are the same.

Close #853
Close #854

[1] https://github.com/tarantool/cartridge/blob/master/cartridge/graphql/validate_variables.lua#L98
