### PR TITLE
Implement etcd params handling

### DIFF
--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -23,8 +23,18 @@ vars:new('known_roles', {
     auth = false,
     failover = nil | boolean | {
         -- mode = 'disabled' | 'eventual' | 'stateful',
-        -- state_provider = nil | 'tarantool',
-        -- tarantool_params = nil | {uri = string, password = string},
+        -- state_provider = nil | 'tarantool' | 'etcd2',
+        -- tarantool_params = nil | {
+        --     uri = string,
+        --     password = string,
+        -- },
+        -- etcd2_params = nil | {
+        --     prefix = string,
+        --     lock_delay = number,
+        --     endpoints = nil | {string,...},
+        --     username = nil | string,
+        --     password = nil | string,
+        -- },
     },
     servers = {
         -- ['instance-uuid-1'] = 'expelled',
@@ -345,6 +355,12 @@ local function validate_failover_schema(field, topology)
                 '%s.failover missing tarantool_params',
                 field
             )
+        elseif topology.failover.state_provider == 'etcd2' then
+            e_config:assert(
+                topology.failover.etcd2_params ~= nil,
+                '%s.failover missing etcd2_params',
+                field
+            )
         elseif topology.failover.state_provider ~= nil then
             e_config:assert(false,
                 '%s.failover unknown state_provider %q',
@@ -396,6 +412,7 @@ local function validate_failover_schema(field, topology)
             ['mode'] = true,
             ['state_provider'] = true,
             ['tarantool_params'] = true,
+            ['etcd2_params'] = true,
             -- For the sake of backward compatibility with v2.0.1-78
             -- See bug https://github.com/tarantool/cartridge/issues/754
             ['enabled'] = true,
@@ -584,6 +601,7 @@ local function get_failover_params(topology_cfg)
             mode = topology_cfg.failover.mode,
             state_provider = topology_cfg.failover.state_provider,
             tarantool_params = topology_cfg.failover.tarantool_params,
+            etcd2_params = topology_cfg.failover.etcd2_params,
         }
 
         if ret.mode == nil

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -196,6 +196,117 @@ failover:
   tarantool_params: {uri: "localhost:9"}
 ...]])
 
+    check_config('topology_new.failover missing etcd2_params',
+[[---
+failover:
+  mode: stateful
+  state_provider: etcd2
+...]])
+
+    check_config('topology_new.failover.etcd2_params must be a table, got boolean',
+[[---
+failover:
+  mode: disabled
+  etcd2_params: false
+...]])
+
+    check_config('topology_new.failover.etcd2_params.prefix must be a string, got nil',
+[[---
+failover:
+  mode: disabled
+  etcd2_params: {}
+...]])
+
+    check_config('topology_new.failover.etcd2_params.lock_delay must be a number, got nil',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+...]])
+
+    check_config('topology_new.failover.etcd2_params.username must be a string, got table',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    username: {}
+...]])
+
+    check_config('topology_new.failover.etcd2_params.password must be a string, got number',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    username:
+    password: 0
+...]])
+
+    check_config('topology_new.failover.etcd2_params.endpoints must be a table, got string',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    endpoints: localhost
+...]])
+
+    check_config('topology_new.failover.etcd2_params.endpoints must have integer keys',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    endpoints:
+      localhost: true
+...]])
+
+    check_config('topology_new.failover.etcd2_params.endpoints must be a contiguous array of strings',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    endpoints: [1, 2, 3]
+...]])
+
+    check_config('topology_new.failover.etcd2_params.endpoints must be a contiguous array of strings',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    endpoints:
+      - null
+      - localhost:8080
+...]])
+
+    check_config('topology_new.failover.etcd2_params.endpoints[1]: Invalid URI "localhost" (missing port)',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    endpoints: ["localhost"]
+...]])
+
+    check_config('topology_new.failover.etcd2_params has unknown parameter "unknown"',
+[[---
+failover:
+  mode: disabled
+  etcd2_params:
+    prefix: /
+    lock_delay: 30
+    unknown:
+...]])
+
     check_config('topology_new.failover has unknown parameter "unknown"',
 [[---
 failover:
@@ -739,6 +850,12 @@ failover:
   tarantool_params:
     uri: stateboard.com:4401
     password: ''
+  etcd2_params:
+    prefix: /
+    lock_delay: 0
+    endpoints: null
+    username: null
+    password: null
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001


### PR DESCRIPTION
Another part of etcd client implementation

I didn't forget about

- [x] Tests
- [x] Changelog (later)
- [x] Documentation (unnecessary)
