### PR TITLE
WIP: roles: introduce metrics role

### DIFF
--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -14,6 +14,7 @@ dependencies = {
     'vshard == 0.1.15-1',
     'membership == 2.2.0-1',
     'frontend-core == 6.5.1-1',
+    'metrics == 0.2.0'
 }
 
 external_dependencies = {

--- a/cartridge/roles/instrumentation/metrics.lua
+++ b/cartridge/roles/instrumentation/metrics.lua
@@ -1,0 +1,66 @@
+local cartridge = require("cartridge")
+local argparse = require("cartridge.argparse")
+local metrics = require("metrics")
+
+local handlers = {
+  ['json'] = function(req)
+      local json_exporter = require("metrics.plugins.json")
+      return req:render({ text = json_exporter.export() })
+  end,
+  ['prometheus'] = function(...)
+      local http_handler = require("metrics.plugins.prometheus").collect_http
+      return http_handler(...)
+  end,
+}
+
+local collectors = {
+  ['default'] = function(...)
+      metrics.enable_default_metrics()
+  end
+}
+
+local function init()
+    local params, err = argparse.parse()
+    if err ~= nil then
+        return err
+    end
+end
+
+local function validate_config(conf_new, conf_old)
+    --[[
+    metrics:
+      export:
+        - path: "/metrics/json"
+          format: "json"
+        - path: "/metrics/prom"
+          format: "prometheus"
+      collect:
+        default:
+    ]]
+
+    return true
+end
+
+local function apply_config(conf)
+    local metrics_conf = conf.metrics
+    if metrics_conf == nil then
+        return true
+    end
+
+    for name, opts in pairs(metrics_conf.collect) do
+        collectors[name](opts)
+    end
+
+    local httpd = cartridge.service_get("httpd")
+    for _, exporter in ipairs(metrics_conf.export) do
+        httpd:route({method = "GET", path = exporter.path}, handlers[exporter.format])
+    end
+end
+
+return {
+    role_name = 'metrics',
+
+    init = init,
+    validate_config = validate_config,
+    apply_config = apply_config
+}

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -139,6 +139,7 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     roles = {
         'cartridge.roles.vshard-storage',
         'cartridge.roles.vshard-router',
+        'cartridge.roles.instrumentation.metrics',
         'mymodule-dependency',
         'mymodule-permanent',
         'mymodule-hidden',

--- a/test/integration/metrics_test.lua
+++ b/test/integration/metrics_test.lua
@@ -1,0 +1,67 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+local json = require("json")
+
+local helpers = require('test.helper')
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = require('digest').urandom(6):hex(),
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                roles = {
+                  'metrics'
+                },
+                servers = {
+                    {
+                        alias = 'main',
+                        http_port = 8081,
+                        advertise_port = 13301,
+                        instance_uuid = helpers.uuid('a', 'a', 1)
+                    }
+                },
+            },
+        },
+    })
+    g.cluster:start()
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+g.test_role_enabled = function()
+    local resp = g.cluster.main_server.net_box:eval([[
+      local cartridge = require("cartridge")
+      return cartridge.service_get("metrics") == nil
+    ]])
+    t.assert_equals(resp, false)
+end
+
+g.test_role_add_metrics_http_endpoint = function()
+    local server = g.cluster.main_server
+    local resp = server:http_request('put', '/admin/config', {
+        body = json.encode({
+          metrics = {
+            export = {
+              {
+                path = "/metrics",
+                format = "json"
+              }
+            },
+            collect = {
+              default = {},
+            }
+          }
+        }),
+        raise = false
+    })
+
+    local resp = server:http_request('get', '/metrics')
+    t.assert_equals(resp.status, 200)
+end


### PR DESCRIPTION
WIP: lets agree on configuration format and I'll complete this pr with tests, expose metrics as a service in service_registry 

proposed configuration format:

```yaml
metrics:
      export:
        - path: "/metrics/json"
          format: "json"
        - path: "/metrics/prom"
          format: "prometheus"
      collect:
        default:
```

where 

- ```metrics``` is a top level section name
- ```export``` is exporter configuration, e.g. [1] is a way to enable json metrics via http endpoint /metrics/json
- ```collect``` is a collectors configuration, e.g. ```default``` means that enable_json_metrics will be called, required for further extensions, for example upcoming metrics ```psutils``` 

What has been done? New builtin role to expose metrics.

Why? Lack of standard and simple way to expose metrics

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #92
