### PR TITLE
Set syslog identity to appname.instancename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- When running under systemd use `<APP_NAME>.<INSTANCE_NAME>` as
+  default syslog identity.
+
 ### Enhanced in WebUI
 
 - Prettier errors displaying.

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -258,7 +258,11 @@ local function cfg(opts, box_opts)
     -- makes it possible to filter by severity with
     -- systemctl
     if utils.under_systemd() and box_opts.log == nil then
-        box_opts.log = 'syslog:identity=tarantool'
+        local identity = table.concat({
+            args.app_name or 'tarantool',
+            args.instance_name
+        }, '.')
+        box_opts.log = string.format('syslog:identity=%s', identity)
     end
 
     if box_opts.custom_proc_title == nil and args.instance_name ~= nil then


### PR DESCRIPTION
When running under systemd use `<APP_NAME>.<INSTANCE_NAME>` as default syslog identity.

I didn't forget about

- [x] Tests (unnecessary)
- [x] Changelog
- [x] Documentation (unnecessary)

Close #880