### PR TITLE
feedback: include rocks versions from manifest into report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Added
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Improved rocks detection for feedback daemon. Besides cartridge version it
+  now parses manifest file from the .rocks/ directory and collects rocks
+  versions.
 - Make uuid parameters optional for test helpers. Make `servers` option accept
   number of servers in replicaset.
 

--- a/test/integration/feedback_test.lua
+++ b/test/integration/feedback_test.lua
@@ -51,6 +51,7 @@ g.before_all = function()
     })
     g.cluster:start()
 end
+
 g.after_all = function()
     g.httpd:stop()
     g.cluster:stop()
@@ -64,4 +65,5 @@ function g.test_feedback()
     t.assert_equals(msg.server_id, helpers.uuid('a', 'a', 1))
     t.assert_equals(msg.cluster_id, helpers.uuid('a'))
     t.assert_type(msg.rocks.cartridge, 'string')
+    t.assert_type(msg.rocks.http, 'string')
 end


### PR DESCRIPTION
Before only cartridge version was detected and reported by feedback daemon.

This patch reads manifest file, parses it and include rocks versions in it into feedback report

Example:

    {
      "cartridge": "scm-1",
      "lulpeg": "0.1.2-1",
      "cartridge-cli": "scm-1",
      "membership": "2.2.0-1",
      "frontend-core": "6.5.1-1",
      "errors": "2.1.3-1",
      "vshard": "0.1.15-1",
      "http": "1.1.0-1",
      "ddl": "1.1.0-1",
      "checks": "3.0.1-1"
    }

- [x] Tests
- [x] Changelog
- [ ] Documentation

Relates to https://github.com/tarantool/tarantool/issues/4391