### PR TITLE
graphql: fix error messages for output types mismatch

### DIFF
--- a/cartridge/graphql/execute.lua
+++ b/cartridge/graphql/execute.lua
@@ -194,13 +194,16 @@ local function completeValue(fieldType, result, subSelections, context, opts)
   end
 
   if fieldTypeName == 'List' then
-    local innerType = fieldType.ofType
-
-    if type(result) ~= 'table' then
-      local message = ('Expected a table for %q list, got %q'):format(util.getTypeName(innerType), type(result))
+    if not util.is_array(result) then
+      local resultType = type(result)
+      if resultType == 'table' then
+        resultType = 'map'
+      end
+      local message = ('Expected %q to be an "array", got %q'):format(fieldName, resultType)
       error(message)
     end
 
+    local innerType = fieldType.ofType
     local values = {}
     for i, value in ipairs(result) do
       values[i] = completeValue(innerType, value, subSelections, context)
@@ -215,7 +218,7 @@ local function completeValue(fieldType, result, subSelections, context, opts)
 
   if fieldTypeName == 'Object' then
     if type(result) ~= 'table' then
-      local message = ('Expected a table for %q object, got %q'):format(util.getTypeName(fieldType), type(result))
+      local message = ('Expected %q to be a "map", got %q'):format(fieldName, type(result))
       error(message)
     end
     local completed = evaluateSelections(fieldType, result, subSelections, context)

--- a/cartridge/graphql/execute.lua
+++ b/cartridge/graphql/execute.lua
@@ -72,11 +72,6 @@ local function mergeSelectionSets(fields)
 end
 
 local function defaultResolver(object, _, info)
-  if type(object) ~= 'table' then
-    local objectType = info.fieldASTs[1].kind
-    local name = info.fieldASTs[1].name.value
-    error(('Expected a table for %s %q'):format(objectType, name))
-  end
   return object[info.fieldASTs[1].name.value]
 end
 
@@ -202,10 +197,8 @@ local function completeValue(fieldType, result, subSelections, context, opts)
     local innerType = fieldType.ofType
 
     if type(result) ~= 'table' then
-      if innerType.__type == 'NonNull' then
-        innerType = innerType.ofType
-      end
-      error('Expected a table for ' .. innerType.name .. ' list')
+      local message = ('Expected a table for %q list, got %q'):format(util.getTypeName(innerType), type(result))
+      error(message)
     end
 
     local values = {}
@@ -221,6 +214,10 @@ local function completeValue(fieldType, result, subSelections, context, opts)
   end
 
   if fieldTypeName == 'Object' then
+    if type(result) ~= 'table' then
+      local message = ('Expected a table for %q object, got %q'):format(util.getTypeName(fieldType), type(result))
+      error(message)
+    end
     local completed = evaluateSelections(fieldType, result, subSelections, context)
     setmetatable(completed, serializemap)
     return completed

--- a/cartridge/graphql/execute.lua
+++ b/cartridge/graphql/execute.lua
@@ -72,6 +72,11 @@ local function mergeSelectionSets(fields)
 end
 
 local function defaultResolver(object, _, info)
+  if type(object) ~= 'table' then
+    local objectType = info.fieldASTs[1].kind
+    local name = info.fieldASTs[1].name.value
+    error(('Expected a table for %s %q'):format(objectType, name))
+  end
   return object[info.fieldASTs[1].name.value]
 end
 
@@ -197,6 +202,9 @@ local function completeValue(fieldType, result, subSelections, context, opts)
     local innerType = fieldType.ofType
 
     if type(result) ~= 'table' then
+      if innerType.__type == 'NonNull' then
+        innerType = innerType.ofType
+      end
       error('Expected a table for ' .. innerType.name .. ' list')
     end
 

--- a/cartridge/graphql/util.lua
+++ b/cartridge/graphql/util.lua
@@ -190,7 +190,9 @@ end
 --- case)
 --- @return[2] `false` otherwise
 local function is_array(table)
-    check(table, 'table', 'table')
+    if type(table) ~= 'table' then
+        return false
+    end
 
     local max = 0
     local count = 0

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -797,59 +797,49 @@ g.test_output_type_mismatch_error = function()
         ).data.expected_list, {{value = {{value = {1}}}}, {value = {{value = {2}}}}}
     )
 
-    t.assert_error_msg_equals('Expected a table for field "value"', function()
+    t.assert_error_msg_equals('Expected a table for "NestedObjectWithValue" object, got "boolean"', function()
         return server:graphql({
             query = [[
-                query($type: String) {
-                    expected_list(type: $type) { value { value } }
+                query {
+                    expected_list(type: "boolean") { value { value } }
                 }
-            ]],
-        variables = {type = 'boolean'}}
-        )
+            ]]})
     end)
 
-    t.assert_error_msg_equals('Expected a table for Int list', function()
+    t.assert_error_msg_equals('Expected a table for "Int" list, got "boolean"', function()
         return server:graphql({
             query = [[
-                query($type: String) {
-                    expected_list(type: $type) { value { value } }
+                query {
+                    expected_list(type: "boolean_list") { value { value } }
                 }
-            ]],
-        variables = {type = 'boolean_list'}}
-        )
+            ]]})
     end)
 
-    t.assert_error_msg_equals('Expected a table for field "value"', function()
+    t.assert_error_msg_equals('Expected a table for "NestedObjectWithValue" object, got "string"', function()
         return server:graphql({
             query = [[
-                query($type: String) {
-                    expected_list(type: $type) { value { value } }
+                query {
+                    expected_list(type: "string") { value { value } }
                 }
-            ]],
-        variables = {type = 'string'}}
-        )
+            ]]})
     end)
 
-    t.assert_error_msg_equals('Expected a table for ObjectWithValue list', function()
+    t.assert_error_msg_equals('Expected a table for "ObjectWithValue" list, got "cdata"', function()
         return server:graphql({
             query = [[
-                query($type: String) {
-                    expected_list(type: $type) { value { value } }
+                query {
+                    expected_list(type: "cdata") { value { value } }
                 }
-            ]],
-        variables = {type = 'cdata'}}
-        )
+            ]]})
     end)
 
-    t.assert_error_msg_equals('Expected a table for ObjectWithValue list', function()
+    t.assert_error_msg_equals('Expected a table for "ObjectWithValue" list, got "userdata"', function()
         return server:graphql({
             query = [[
-                query($type: String) {
-                    expected_list(type: $type) { value { value } }
+                query {
+                    expected_list(type: "userdata") { value { value } }
                 }
-            ]],
-        variables = {type = 'userdata'}}
-        )
+            ]]})
     end)
 
     server.net_box:eval([[
@@ -891,7 +881,7 @@ g.test_output_type_mismatch_error = function()
         })
     ]])
 
-    t.assert_error_msg_equals('Expected a table for CustomTestString list', function()
+    t.assert_error_msg_equals('Expected a table for "NonNull(CustomTestString)" list, got "boolean"', function()
         return server:graphql({
             query = [[
                 query {


### PR DESCRIPTION
This patch fixes two problems.

1. When we return wrong value for List of nonNull type. nil dereference happened because error handler didn't consider nonNullable wrapper. `innerType.name` for `Type` is `"Type"` and `nil` for `Type!` (expected "Type" or "NonNull(Type)"). (https://github.com/tarantool/cartridge/pull/919/files#diff-926c2702f04ab81baa008eec661b481eR200)

1. Scalar could be passed instead of Object. This patch adds a check that Object is "table". (https://github.com/tarantool/cartridge/pull/919/files#diff-926c2702f04ab81baa008eec661b481eR218)

Closes #891
