### PR TITLE
Refactor use of box.cfg in unit tests

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -54,4 +54,17 @@ function helpers.list_cluster_issues(server)
     }]]}).data.cluster.issues
 end
 
+function helpers.box_cfg()
+    if type(box.cfg) ~= 'function' then
+        return
+    end
+
+    local tempdir = fio.tempdir()
+    box.cfg({
+        memtx_dir = tempdir,
+        wal_mode = 'none',
+    })
+    fio.rmtree(tempdir)
+end
+
 return helpers


### PR DESCRIPTION
Luatest initializes box.cfg to perform some of unit tests.
It's configured with `memtx_dir = fio.tempdir()`, which can't be
changed dynamically. To simplify reusing of box.cfg across multiple
different unit tests, this patch moves `box.cfg` call to test helpers.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

