### PR TITLE
Adapt cartridge-cli v2.0+

### DIFF
--- a/.cartridge.yml
+++ b/.cartridge.yml
@@ -1,5 +1,11 @@
 ---
-run_dir: 'dev'
 cfg: instances.yml
 script: test/entrypoint/srv_basic.lua
+
+# for CLI < 2.0
+run_dir: 'dev'
+
+# for CLI >= 2.0
+run-dir: './tmp/run'
+data-dir: './tmp/data'
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 .cache
 .doctrees
 __pycache__
-dev
+/dev
+/tmp
 doc
 release
 release-doc

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ And set failover parameters according to ``instances.yml``. The defaults are:
 * Password: ``qwerty``.
 
 For more details about ``cartridge-cli``, see its
-[usage](https://github.com/tarantool/cartridge-cli#usage).
+`usage <https://github.com/tarantool/cartridge-cli#usage>`_.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Auto-generated sources

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Prerequisites
 To get a template application that uses Tarantool Cartridge and run it,
 you need to install several packages:
 
-* ``tarantool``, ``tarantool-dev``, ``cartridge-cli``
+* ``tarantool`` and ``tarantool-dev``
   (see these `instructions <https://www.tarantool.io/en/download/>`_);
 * ``git``, ``gcc``, ``cmake`` and ``make``.
 

--- a/README.rst
+++ b/README.rst
@@ -65,22 +65,28 @@ Getting started
 --------------------------------------------------------------------------------
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Create your first application
+Prerequisites
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To get a template application that uses Tarantool Cartridge and run it,
-you need to install the `cartridge-cli` utility (supposing that
-`Tarantool <https://www.tarantool.io/en/download/>`_ is already installed).
+you need to install several packages:
+
+* ``tarantool``, ``tarantool-dev``, ``cartridge-cli``
+  (see these `instructions <https://www.tarantool.io/en/download/>`_);
+* ``git``, ``gcc``, ``cmake`` and ``make``.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create your first application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Long story short, copy-paste this into the console:
 
 .. code-block:: bash
 
-    tarantoolctl rocks install cartridge-cli
-    .rocks/bin/cartridge create --name myapp
+    cartridge create --name myapp
     cd myapp
-    ../.rocks/bin/cartridge build
-    ../.rocks/bin/cartridge start
+    cartridge build
+    cartridge start
 
 That's all! Now you can visit http://localhost:8081 and see your application's
 Admin Web UI:
@@ -114,11 +120,6 @@ and running tests.
 Building from source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Prerequisites:
-
-* ``tarantool``, ``tarantool-dev`` (see these `instructions <https://www.tarantool.io/en/download/?v=1.10>`_);
-* ``git``, ``gcc``, ``cmake``.
-
 The fastest way to build the project is to skip building the Web UI:
 
 .. code-block:: bash
@@ -150,11 +151,10 @@ but can also be useful for demo purposes or experiments:
 
 .. code-block:: bash
 
-    tarantoolctl rocks install cartridge-cli
-    .rocks/bin/cartridge start
+    cartridge start
 
     # or select a specific entry point
-    # .rocks/bin/cartridge start --script ./test/entrypoint/srv_basic.lua
+    # cartridge start --script ./test/entrypoint/srv_vshardless.lua
 
 It can be accessed through the Web UI (http://localhost:8081)
 or via the binary protocol:
@@ -168,15 +168,15 @@ If you also need the stateful failover mode, launch an external state provider
 
 .. code-block:: bash
 
-    .rocks/bin/cartridge start --stateboard
+    cartridge start --stateboard
 
 And set failover parameters according to ``instances.yml``. The defaults are:
 
 * State provider URI: ``localhost:4401``;
 * Password: ``qwerty``.
 
-For more details about ``cartridge-cli``, see
-https://github.com/tarantool/cartridge-cli#readme.
+For more details about ``cartridge-cli``, see its
+https://github.com/tarantool/cartridge-cli#usage.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Auto-generated sources

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ you need to install several packages:
 * ``tarantool`` and ``tarantool-dev``
   (see these `instructions <https://www.tarantool.io/en/download/>`_);
 * ``cartridge-cli``
-  (see these `<instructions https://github.com/tarantool/cartridge-cli#installation>`_)
+  (see these `instructions <https://github.com/tarantool/cartridge-cli#installation>`_)
 * ``git``, ``gcc``, ``cmake`` and ``make``.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ you need to install several packages:
 
 * ``tarantool`` and ``tarantool-dev``
   (see these `instructions <https://www.tarantool.io/en/download/>`_);
+* ``cartridge-cli``
+  (see these `<instructions https://github.com/tarantool/cartridge-cli#installation>`_)
 * ``git``, ``gcc``, ``cmake`` and ``make``.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ And set failover parameters according to ``instances.yml``. The defaults are:
 * Password: ``qwerty``.
 
 For more details about ``cartridge-cli``, see its
-https://github.com/tarantool/cartridge-cli#usage.
+[usage](https://github.com/tarantool/cartridge-cli#usage).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Auto-generated sources


### PR DESCRIPTION
In new major version of CLI the layout was changed.
This patch adds relevant comments and gitignore paths.

I didn't forget about

- [x] Tests (unnecessary)
- [x] Changelog (unnecessary)
- [x] Documentation

