### PR TITLE
graphql: show at least object kind in case of null value

### DIFF
--- a/cartridge/graphql/util.lua
+++ b/cartridge/graphql/util.lua
@@ -146,7 +146,7 @@ local function coerceValue(node, schemaType, variables, opts)
   if schemaType.__type == 'Scalar' then
     if schemaType.parseLiteral(node) == nil then
       error(('Could not coerce "%s" to "%s"'):format(
-        tostring(node.value), schemaType.name))
+        node.value or node.kind, schemaType.name))
     end
 
     return schemaType.parseLiteral(node)

--- a/test/integration/graphql_test.lua
+++ b/test/integration/graphql_test.lua
@@ -177,6 +177,24 @@ g.test_upload = function()
         }) end
     )
 
+    t.assert_error_msg_equals(
+        'Could not coerce "inputObject" to "String"',
+        function() return server:graphql({
+            query = [[
+                query { test(arg: {a: "123"}, arg4: 123) }
+            ]], variables = {}
+        }) end
+    )
+
+    t.assert_error_msg_equals(
+        'Could not coerce "list" to "String"',
+        function() return server:graphql({
+            query = [[
+                query { test(arg: ["123"], arg4: 123) }
+            ]], variables = {}
+        }) end
+    )
+
     -- Errors in handlers
     server.net_box:eval([[
         package.loaded['test']['test'] = function(root, args)
@@ -646,6 +664,17 @@ g.test_custom_type_scalar_variables = function()
         variables = {field = 'echo'}}
         ).data.test_custom_type_scalar_list, 'echo'
     )
+
+    t.assert_error_msg_equals('Could not coerce "inputObject" to "CustomString"', function()
+        return server:graphql({
+            query = [[
+                query {
+                    test_custom_type_scalar_list(
+                        fields: [{a: "2"}]
+                    )
+                }
+            ]]})
+    end)
 
     t.assert_error_msg_equals('Variable "field" type mismatch: ' ..
             'the variable type "NonNull(String)" is not compatible with the argument type '..


### PR DESCRIPTION
Before this patch when we tried to coerse inputObject/list to
Scalar type we got an error:
```
graphql internal error: Could not coerce "nil" to "String"
```

It's completely non-informative. This patch fixes it and changes
message to:
```
graphql internal error: Could not coerce "inputObject" to "String"
```

Closes #935
