### PR TITLE
Fix flaky state_machine test

### DIFF
--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -388,6 +388,11 @@ function g.test_fiber_cancel()
     -- m  : repairs
     --   s: Trigger failover (is_leader = false)
 
+    local future = g.slave.net_box:eval(
+        'return pcall(box.ctl.wait_rw)', nil,
+        {is_async = true}
+    )
+
     g.slave.net_box:eval('loadstring(...)()', {
         string.dump(function()
             local log = require('log')
@@ -430,9 +435,7 @@ function g.test_fiber_cancel()
         end)
     })
 
-    t.helpers.retrying({}, function()
-        t.assert_equals(is_master(g.slave), true)
-    end)
+    t.assert_equals(future:wait_result(3), {true})
     t.helpers.retrying({}, function()
         t.assert_equals(is_master(g.slave), false)
     end)


### PR DESCRIPTION
In test_fiber_cancel we check that instance becomes a leader under some
circumstances, but the check is incorrect. It queries if instance is writable
in several consequent calls, but the instance may trigger state more quickly.

With this patch the check is performed using async call, which tells if
an instance was writable at least for a moment.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

