### PR TITLE
Fix flaky test_console_sock

### DIFF
--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -258,8 +258,13 @@ g.test_console_sock = function()
     -- The message differs in 2.3.2+
     local e2 = 'failed to create server unix/:' .. sock_name ..
         ': ' .. errno.strerror(errno.ENOBUFS)
-    if err.err ~= e1 and not err.err:match(e2) then
-        error(string.format('Unexpected error:\n%s', err))
+    if err.err ~= e1 and not err.err:endswith(e2) then
+        error(
+            'Unexpected error message:\n' ..
+            'expected: ' .. e1 .. '\n' ..
+            '      or: ' .. e2 .. '\n' ..
+            '  actual: ' .. tostring(err)
+        )
     end
 end
 


### PR DESCRIPTION
The test sometimes fails in CI when tempdir name includes hyphen symbol:
the test uses regex matching which treats it as a special character.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
