### PR TITLE
use monotonic clocks for timeouts

### DIFF
--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -153,8 +153,8 @@ local function wish_state(state, timeout)
         timeout = vars.state_notification_timeout
     end
 
-    local deadline = fiber.time() + timeout
-    while fiber.time() < deadline do
+    local deadline = fiber.clock() + timeout
+    while fiber.clock() < deadline do
         if vars.state == state then
             -- Wish granted
             break
@@ -163,7 +163,7 @@ local function wish_state(state, timeout)
             break
         else
             -- Wish could be granted soon, just wait a little bit
-            vars.state_notification:wait(deadline - fiber.time())
+            vars.state_notification:wait(deadline - fiber.clock())
         end
     end
 

--- a/cartridge/etcd2-client.lua
+++ b/cartridge/etcd2-client.lua
@@ -258,11 +258,11 @@ end
 local function longpoll(client, timeout)
     checks('etcd2_client', 'number')
 
-    local deadline = fiber.time() + timeout
+    local deadline = fiber.clock() + timeout
 
     while true do
         local session = client:get_session()
-        local timeout = deadline - fiber.time()
+        local timeout = deadline - fiber.clock()
 
         local resp, err
         if session.longpoll_index == nil then
@@ -282,7 +282,7 @@ local function longpoll(client, timeout)
             return json.decode(resp.node.value)
         end
 
-        if fiber.time() < deadline then
+        if fiber.clock() < deadline then
             -- connection refused etc.
             fiber.sleep(session.connection.request_timeout)
         elseif err.http_code == 408 then

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -237,7 +237,7 @@ local function constitute_oneself(active_leaders, opts)
         return true
     end
 
-    local deadline = fiber.time() + opts.timeout
+    local deadline = fiber.clock() + opts.timeout
 
     -- Go to the external state provider
     local session = assert(vars.client):get_session()
@@ -273,7 +273,7 @@ local function constitute_oneself(active_leaders, opts)
 
         local vclockkeeper_uri = vclockkeeper_srv.uri
 
-        local timeout = deadline - fiber.time()
+        local timeout = deadline - fiber.clock()
         -- WARNING: implicit yield
         local vclockkeeper_info, err = errors.netbox_call(
             pool.connect(vclockkeeper_uri, {wait_connected = false}),
@@ -288,7 +288,7 @@ local function constitute_oneself(active_leaders, opts)
 
         -- Wait async replication to arrive
         -- WARNING: implicit yield
-        local timeout = deadline - fiber.time()
+        local timeout = deadline - fiber.clock()
         local ok = utils.wait_lsn(
             vclockkeeper_info.id,
             vclockkeeper_info.lsn,
@@ -335,13 +335,13 @@ local function reconfigure_all(active_leaders)
 
 ::start_over::
 
-    local t1 = fiber.time()
+    local t1 = fiber.clock()
     -- WARNING: implicit yield
     local ok, _ = constitute_oneself(active_leaders, {
         timeout = vars.options.WAITLSN_TIMEOUT,
     })
     fiber.testcancel()
-    local t2 = fiber.time()
+    local t2 = fiber.clock()
 
     if not ok then
         fiber.sleep(t1 + vars.options.WAITLSN_TIMEOUT - t2)

--- a/cartridge/lua-api/deprecated.lua
+++ b/cartridge/lua-api/deprecated.lua
@@ -97,10 +97,10 @@ local function join_server(args)
         return true
     end
 
-    local deadline = fiber.time() + timeout
+    local deadline = fiber.clock() + timeout
     local cond = membership.subscribe()
     local conn = nil
-    while not conn and fiber.time() < deadline do
+    while not conn and fiber.clock() < deadline do
         cond:wait(0.2)
 
         local member = membership.get_member(args.uri)

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -51,8 +51,8 @@ local function pack_decision(leader_uuid)
     checks('string')
     return {
         leader = leader_uuid,
-        immunity = fiber.time() + vars.options.IMMUNITY_TIMEOUT,
-        -- decision is immune if fiber.time() < immunity
+        immunity = fiber.clock() + vars.options.IMMUNITY_TIMEOUT,
+        -- decision is immune if fiber.clock() < immunity
     }
 end
 
@@ -61,7 +61,7 @@ local function make_decision(ctx, replicaset_uuid)
 
     local current_decision = ctx.decisions[replicaset_uuid]
     if current_decision ~= nil then
-        if fiber.time() < current_decision.immunity
+        if fiber.clock() < current_decision.immunity
         or vars.healthcheck(ctx.members, current_decision.leader)
         then
             return nil
@@ -110,7 +110,7 @@ local function control_loop(session)
             end
         end
 
-        local now = fiber.time()
+        local now = fiber.clock()
         if next(updates) ~= nil then
             -- TODO vclockkeeper handling in etcd2
             if vars.client.state_provider ~= 'etcd2' then
@@ -218,10 +218,10 @@ local function take_control_loop(client)
     checks('stateboard_client|etcd2_client')
 
     while true do
-        local t1 = fiber.time()
+        local t1 = fiber.clock()
         local ok, err = CoordinatorError:pcall(take_control, client)
         fiber.testcancel()
-        local t2 = fiber.time()
+        local t2 = fiber.clock()
 
         if ok == nil then
             log.error('%s', type(err) == 'table' and err.err or err)

--- a/cartridge/stateboard-client.lua
+++ b/cartridge/stateboard-client.lua
@@ -229,11 +229,11 @@ end
 local function longpoll(client, timeout)
     checks('stateboard_client', 'number')
 
-    local deadline = fiber.time() + timeout
+    local deadline = fiber.clock() + timeout
 
     while true do
         local session = client:get_session()
-        local timeout = deadline - fiber.time()
+        local timeout = deadline - fiber.clock()
 
         local ret, err = errors.netbox_call(session.connection,
             'longpoll', {timeout},
@@ -244,7 +244,7 @@ local function longpoll(client, timeout)
             return ret
         end
 
-        if fiber.time() < deadline then
+        if fiber.clock() < deadline then
             fiber.sleep(client.cfg.call_timeout)
             -- continue
         else

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -318,14 +318,14 @@ end
 -- @treturn boolean true / false
 local function wait_lsn(id, lsn, pause, timeout)
     checks('number', 'number', 'number', 'number')
-    local deadline = fiber.time() + timeout
+    local deadline = fiber.clock() + timeout
 
     while true do
         if (box.info.vclock[id] or 0) >= lsn then
             return true
         end
 
-        if fiber.time() >= deadline then
+        if fiber.clock() >= deadline then
             return false
         end
 


### PR DESCRIPTION
Change
    clock.time -> clock.monotonic
    fiber.time -> fiber.clock

fiber.time() is realtime, not suitable for relative timeouts.
For that purpose always should be used monotonic clock.

Closes #957
