### PR TITLE
Implement forced leader promotion API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,9 @@ Added
 
 - When failover mode is stateful, all manual leader promotions will be consistent:
   every instance before becoming writable performs `wait_lsn` operation to
-  sync with previous one.
+  sync with previous one. If consistency couldn't be reached due to replication
+  failure, a user could either revert it (promote previous leader), or force
+  promotion to be inconsistent.
 - Early logger initialization (for Tarantool > 2.5.0-100, which supports it).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -689,8 +689,14 @@ local function force_inconsistency(leaders)
 
     local err
     for replicaset_uuid, instance_uuid in pairs(leaders) do
-        local _, _err = session:set_vclockkeeper(replicaset_uuid, instance_uuid)
-        err = err or _err
+        local _ok, _err = session:set_vclockkeeper(replicaset_uuid, instance_uuid)
+        if _ok == nil then
+            err = _err
+            log.warn(
+                'Forcing inconsistency for %s failed: %s', instance_uuid,
+                errors.is_error_object(_err) and _err.err or _err
+            )
+        end
     end
 
     if err ~= nil then

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -675,11 +675,11 @@ end
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function force_inconsistency(leaders)
-    -- TODO vclockkeeper handling in etcd2
-    if vars.client.state_provider == 'etcd2' then
-        return nil, StateProviderError:new(
-            'Consistent switchover not implemented for etcd yet'
-        )
+    if vars.client == nil then
+        return nil, StateProviderError:new("No state provider configured")
+    elseif vars.client.state_provider == 'etcd2' then
+        -- TODO vclockkeeper handling in etcd2
+        return true
     end
 
     local session = vars.client.session

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -173,7 +173,7 @@ local function promote(replicaset_leaders, opts)
     local _, err = rpc.call(
             'failover-coordinator',
             'appoint_leaders',
-            {replicaset_leaders, opts},
+            {replicaset_leaders},
             { uri = coordinator.uri }
     )
 
@@ -181,10 +181,7 @@ local function promote(replicaset_leaders, opts)
         return nil, err
     end
 
-    if opts == nil
-    or opts.force_inconsistency == nil
-    or not opts.force_inconsistency -- beware box.NULL
-    then
+    if opts == nil or opts.force_inconsistency == false then
         return true
     end
 

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -316,8 +316,10 @@ local function apply_config(conf, _)
 end
 
 --- Manually set leaders.
+--
 -- @function appoint_leaders
 -- @tparam {[string]=string,...} replicaset_uuid to leader_uuid mapping
+--
 -- @treturn[1] boolean true
 -- @treturn[2] nil
 -- @treturn[2] table Error description

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -90,7 +90,11 @@ end
 local function promote(_, args)
     local replicaset_uuid = args['replicaset_uuid']
     local instance_uuid = args['instance_uuid']
-    return lua_api_failover.promote({[replicaset_uuid] = instance_uuid})
+    local opts = {
+        force_inconsistency = args['force_inconsistency']
+    }
+
+    return lua_api_failover.promote({[replicaset_uuid] = instance_uuid}, opts)
 end
 
 local function init(graphql)
@@ -148,6 +152,7 @@ local function init(graphql)
         args = {
             replicaset_uuid = gql_types.string.nonNull,
             instance_uuid = gql_types.string.nonNull,
+            force_inconsistency = gql_types.boolean,
         },
         kind = gql_types.boolean.nonNull,
         callback = module_name .. '.promote',

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Wed Jun 03 2020 13:01:27 GMT+0300 (Moscow Standard Time)
+# timestamp: Thu Jul 30 2020 12:28:54 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -223,7 +223,7 @@ type MutationApicluster {
   edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sync_timeout: Float, name: String!, rebalancer_disbalance_threshold: Float): VshardGroup!
 
   """Promote the instance to the leader of replicaset"""
-  failover_promote(replicaset_uuid: String!, instance_uuid: String!): Boolean!
+  failover_promote(force_inconsistency: Boolean, replicaset_uuid: String!, instance_uuid: String!): Boolean!
 
   """Remove user"""
   remove_user(username: String!): User

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -172,7 +172,7 @@ the external storage.
 
 If replication is stuck and consistent promotion isn't possible, a user has two
 options: revert promotion (re-promote the old one) or force it inconsistently
-(the GraphQL API for that will be added soon).
+(all kinds of ``failover_promote`` API has ``force_inconsistency`` flag).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Failover configuration


### PR DESCRIPTION
Lua:

```lua
cartridge.failover_promote(
    {[replicaset_uuid] = instnace_uuid},
    {force_inonsistency = true}
)
```

GraphQL:

```graphql
mutation{
  cluster{
    failover_promote(
      replicaset_uuid: "..."
      instance_uuid: "..."
      force_inconsistency: true
    )
  }
}
```

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #976 
