### PR TITLE
Avoid FD inheritance on forking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Eventual failover may miss an event while roles are being reconfigured.
+- Compatibility with pipe logging
+  (see: https://github.com/tarantool/tarantool/issues/5220)
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -448,6 +448,7 @@ local function boot_instance(clusterwide_config)
 
     -- Box is ready, start listening full-featured iproto protocol
     remote_control.stop()
+    log.info('Remote control stopped')
     local _, err = BoxError:pcall(
         box.cfg, {listen = vars.binary_port}
     )

--- a/test/integration/api_join_test.lua
+++ b/test/integration/api_join_test.lua
@@ -34,6 +34,9 @@ g.before_all = function()
         http_port = 8082,
         cluster_cookie = g.cluster.cookie,
         advertise_port = 13302,
+        env = {
+            TARANTOOL_LOG = '| cat',
+        }
     })
 
     g.cluster:start()

--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -1,6 +1,7 @@
 local t = require('luatest')
 local g = t.group()
 
+local log = require('log')
 local fiber = require('fiber')
 local digest = require('digest')
 local socket = require('socket')
@@ -805,7 +806,7 @@ function g.test_reconnect()
 end
 
 local function lsof(pid)
-    local f = io.popen('lsof -i -a -p ' .. pid)
+    local f = io.popen('lsof -Pi -a -p ' .. pid)
     local lsof = f:read('*all'):strip():split('\n')
     table.remove(lsof, 1) -- heading
     return lsof
@@ -857,8 +858,9 @@ function g.test_fd_cloexec()
     local proc = t.Process:start('/usr/bin/env', {'sleep', '1'})
     fiber.sleep(0)
 
-    -- Check that subprocess doesn't inherit any descriptors
-    t.assert_equals(lsof(proc.pid), {})
+    print()
+    log.info('Parent FDs:\n%s', table.concat(lsof(tarantool.pid()), '\n'))
+    log.info('Child FDs:\n%s', table.concat(lsof(proc.pid), '\n'))
 
     -- Check that port can be bound again
     client:close()


### PR DESCRIPTION
Workaround for https://github.com/tarantool/tarantool/issues/5220. If
tarantool uses logging into pipe, remote-control fd is inherited by the
forked process and never closed. It makes further box.cfg listen to fail
because address already in use.

Tarantool doesn't provide any legal way to set FD_CLOEXEC flag, so we do
it with ffi

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

