### PR TITLE
Invalidate user's cookie after password change

### DIFF
--- a/cartridge/auth-backend.lua
+++ b/cartridge/auth-backend.lua
@@ -119,7 +119,8 @@ local function add_user(username, password, fullname, email)
         fullname = fullname,
         email = email,
         created_at = fiber.time64(),
-        password_data = create_password(password)
+        password_data = create_password(password),
+        version = 1,
     }
 
     local ok, err = cartridge.config_patch_clusterwide({users_acl = users_acl})
@@ -160,6 +161,11 @@ local function edit_user(username, password, fullname, email)
 
     if password ~= nil then
         user.password_data = update_password(password, user.password_data)
+        if user.version == nil then
+            user.version = 1
+        else
+            user.version = user.version + 1
+        end
     end
 
     if uid == nil then

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -746,3 +746,31 @@ function g.test_cookie_expiry()
     set_max_age(3600)
     t.assert_equals(get_username(), USERNAME)
 end
+
+function g.test_invalidate_cookie_on_password_change()
+    local USERNAME = 'Niles Rumfoord'
+    local PASSWORD = 'Beatrice'
+    local server = g.cluster:server('master')
+    set_auth_enabled_internal(g.cluster, true)
+    _add_user(server, USERNAME, PASSWORD)
+
+    local resp = _login(server, USERNAME, PASSWORD)
+    log.info('login successful')
+    t.assert_equals(resp.status, 200)
+    t.assert_not_equals(resp.cookies['lsid'], nil)
+    local lsid = resp.cookies['lsid'][1]
+    local cookie_lsid = 'lsid=' .. lsid
+    check_200(server, {headers = {cookie = cookie_lsid}})
+
+    local NEW_PASSWORD = 'Salo'
+    _edit_user(server, USERNAME, NEW_PASSWORD)
+    check_401(server, {headers = {cookie = cookie_lsid}})
+
+    resp = _login(server, USERNAME, NEW_PASSWORD)
+    log.info('login successful')
+    t.assert_equals(resp.status, 200)
+    t.assert_not_equals(resp.cookies['lsid'], nil)
+    lsid = resp.cookies['lsid'][1]
+    cookie_lsid = 'lsid=' .. lsid
+    check_200(server, {headers = {cookie = cookie_lsid}})
+end

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -773,4 +773,24 @@ function g.test_invalidate_cookie_on_password_change()
     lsid = resp.cookies['lsid'][1]
     cookie_lsid = 'lsid=' .. lsid
     check_200(server, {headers = {cookie = cookie_lsid}})
+
+    local function edit_user(cookie, vars)
+        return server:http_request('post', '/admin/api', {
+            http = {headers = {cookie = cookie}},
+            json = {
+                query = [[
+                mutation($username:String! $password:String) {
+                    cluster {
+                        edit_user(username:$username password:$password) { username }
+                    }
+                }]],
+                variables = vars,
+            },
+            raise = false,
+        })
+    end
+
+    local resp = edit_user(cookie_lsid, {username = USERNAME, password = PASSWORD})
+    local cookie = resp.headers['set-cookie']
+    check_200(server, {headers = {cookie = cookie}})
 end


### PR DESCRIPTION
This patch introduces new field in user model - version. We will
increment version after each password change. This approach allows
us to deny all sessions that were created before password was
changed.

Closes #840
Closes #72
