### PR TITLE
allow to pass any value as user version

### DIFF
--- a/cartridge/auth.lua
+++ b/cartridge/auth.lua
@@ -180,7 +180,7 @@ local function get_params()
 end
 
 local function create_cookie(uid, version)
-    checks('string', '?number')
+    checks('string', '?')
     local ts = tostring(fiber.time())
     local key = cluster_cookie.cookie()
 


### PR DESCRIPTION
This patch fixes check for passed user.version. User could use
it's own auth backend where version is timestamp that is
represented via ULL number that has "cdata" type.

Follow-up 85dc120cc584707853adb19fb75a1a90bec11ef5

