### PR TITLE
Update tarantool repo in Gitlab CI base image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ docker-build-ce-1.10:
   variables:
     IMAGE_NAME: &IMAGE_NAME_CE_1_10 base-ce-1.10
     BUILD_ARGS: >
-      --build-arg TARANTOOL_BRANCH=1_10
+      --build-arg TARANTOOL_BRANCH=1.10
     DOCKER_FILE: Dockerfile.base-ce
 
 docker-build-ce-2.3:
@@ -66,7 +66,7 @@ docker-build-ce-2.3:
   variables:
     IMAGE_NAME: &IMAGE_NAME_CE_2_3 base-ce-2.3
     BUILD_ARGS: >
-      --build-arg TARANTOOL_BRANCH=2_3
+      --build-arg TARANTOOL_BRANCH=2.3
     DOCKER_FILE: Dockerfile.base-ce
 
 ########################################################################
@@ -83,6 +83,7 @@ docker-build-ce-2.3:
     - export CMAKE_DUMMY_WEBUI=YES
     - tarantoolctl rocks make
     - tarantoolctl rocks list
+    - tarantool --version
   after_script:
     # avoid caching cartridge rock
     - tarantoolctl rocks remove cartridge

--- a/Dockerfile.base-ce
+++ b/Dockerfile.base-ce
@@ -17,7 +17,7 @@ RUN npm install \
     && npx cypress verify
 
 RUN set -x &&\
-    curl -s https://packagecloud.io/install/repositories/tarantool/${TARANTOOL_BRANCH}/script.rpm.sh | bash &&\
+    curl -L https://tarantool.io/installer.sh | VER=${TARANTOOL_BRANCH} bash &&\
     yum -y install tarantool tarantool-devel
 
 RUN yum clean all &&\


### PR DESCRIPTION
Tarantool repo was moved from packagecloud to S3. It's time to update CI.