### PR TITLE
Split etcd into a separate test helper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 - Add `probe_uri_timeout` argparse option responsible for retrying
   "Can't ping myself" error on startup.
 - "Force leader promotion" action for current leader in webui.
+- New test helper: ``cartridge.test-helpers.etcd``.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/test-helpers.lua
+++ b/cartridge/test-helpers.lua
@@ -11,8 +11,13 @@ local helpers = table.copy(luatest.helpers)
 --- Extended luatest.server class to run tarantool instance.
 -- @see cartridge.test-helpers.server
 helpers.Server = require('cartridge.test-helpers.server')
+
 --- Class to run and manage multiple tarantool instances.
 -- @see cartridge.test-helpers.cluster
 helpers.Cluster = require('cartridge.test-helpers.cluster')
+
+--- Class to run and manage etcd node.
+-- @see cartridge.test-helpers.etcd
+helpers.Etcd = require('cartridge.test-helpers.etcd')
 
 return helpers

--- a/cartridge/test-helpers/etcd.lua
+++ b/cartridge/test-helpers/etcd.lua
@@ -64,11 +64,9 @@ end
 
 --- Start the node.
 function Etcd:start()
-    local env = os.environ()
     local log_cmd = {}
     for k, v in pairs(self.env) do
         table.insert(log_cmd, string.format('%s=%q', k, v))
-        env[k] = v
     end
     table.insert(log_cmd, self.command)
     for _, v in ipairs(self.args) do
@@ -77,7 +75,7 @@ function Etcd:start()
 
     log.debug(table.concat(log_cmd, ' '))
 
-    self.process = Process:start(self.etcd_path, self.args, env, {
+    self.process = Process:start(self.etcd_path, self.args, self.env, {
         output_prefix = 'etcd-' .. self.name,
     })
     log.debug('Started server PID: ' .. self.process.pid)

--- a/cartridge/test-helpers/etcd.lua
+++ b/cartridge/test-helpers/etcd.lua
@@ -1,0 +1,114 @@
+--- Class to run and manage etcd node.
+--
+-- @classmod cartridge.test-helpers.etcd
+
+local checks = require('checks')
+local log = require('log')
+local fun = require('fun')
+local httpc = require('http.client')
+
+local luatest = require('luatest')
+local Process = require('luatest.process')
+
+-- Defaults.
+local Etcd = {
+    workdir = nil,
+    etcd_path = nil,
+    name = 'default',
+    peer_url = 'http://127.0.0.1:17001',
+    client_url = 'http://127.0.0.1:14001',
+    args = {},
+    env = {},
+}
+
+function Etcd:inherit(object)
+    setmetatable(object, self)
+    self.__index = self
+    return object
+end
+
+--- Build etcd node object.
+-- @param object
+-- @string object.name Human-readable node name.
+-- @string object.workdir Path to the data directory.
+-- @string object.etcd_path Path to the etcd executable.
+-- @string object.peer_url URL to listen on for peer traffic.
+-- @string object.client_url URL to listen on for client traffic.
+-- @tab[opt] object.env Environment variables passed to the process.
+-- @tab[opt] object.args Command-line arguments passed to the process.
+-- @return object
+function Etcd:new(object)
+    checks('table', {
+        name = '?string',
+        workdir = 'string',
+        etcd_path = 'string',
+        peer_url = '?string',
+        client_url = '?string',
+        args = '?table',
+        env = '?table',
+    })
+    self:inherit(object)
+    object:initialize()
+    return object
+end
+
+function Etcd:initialize()
+    self.env = fun.chain({
+        ETCD_NAME = self.name,
+        ETCD_DATA_DIR = self.workdir,
+        ETCD_LISTEN_PEER_URLS = self.peer_url,
+        ETCD_LISTEN_CLIENT_URLS = self.client_url,
+        ETCD_ADVERTISE_CLIENT_URLS = self.client_url,
+    }, self.env):tomap()
+end
+
+--- Start the node.
+function Etcd:start()
+    local env = os.environ()
+    local log_cmd = {}
+    for k, v in pairs(self.env) do
+        table.insert(log_cmd, string.format('%s=%q', k, v))
+        env[k] = v
+    end
+    table.insert(log_cmd, self.command)
+    for _, v in ipairs(self.args) do
+        table.insert(log_cmd, string.format('%q', v))
+    end
+
+    log.debug(table.concat(log_cmd, ' '))
+
+    self.process = Process:start(self.etcd_path, self.args, env, {
+        output_prefix = 'etcd-' .. self.name,
+    })
+    log.debug('Started server PID: ' .. self.process.pid)
+
+    luatest.helpers.retrying({}, function()
+        local resp = httpc.put(self.client_url .. '/v2/keys/hello?value=world')
+        luatest.assert(resp.status == 200, resp.body)
+    end)
+
+    log.info(httpc.get(self.client_url .. '/version').body)
+end
+
+--- Stop the node.
+function Etcd:stop()
+    local process = self.process
+    if process == nil then
+        return
+    end
+    self.process:kill()
+    luatest.helpers.retrying({}, function()
+        luatest.assert_not(process:is_alive(),
+            'etcd-%s is still running', self.name
+        )
+    end)
+    log.warn('etcd-%s killed', self.name)
+    self.process = nil
+end
+
+function Etcd.connect_net_box()
+    -- Do nothing, mimic tarantool server API
+    return nil
+end
+
+return Etcd

--- a/config.ld
+++ b/config.ld
@@ -16,6 +16,7 @@ file = {
     "cartridge/test-helpers.lua",
     "cartridge/test-helpers/cluster.lua",
     "cartridge/test-helpers/server.lua",
+    "cartridge/test-helpers/etcd.lua",
     "cartridge/remote-control.lua",
     "cartridge/service-registry.lua",
     "cartridge/user-defined-role.lua",


### PR DESCRIPTION
Starting etcd becomes popular in tests, so it's split into a separate test helper.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Part of #950
