### PR TITLE
Eliminate Gitlab CI pipeline warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+workflow:
+  # Eliminate Gitlab CI warnings:
+  # jobs may allow multiple pipelines to run for a single action due to
+  # `rules:when` clause with no `workflow:rules` - read more:
+  # https://docs.gitlab.com/ee/ci/troubleshooting.html#pipeline-warnings
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - # else
+      when: always
+
 variables:
   GIT_STRATEGY: clone
   ROCK_NAME: cartridge


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2205188/91162705-21571880-e6d5-11ea-95bb-c9de75e22c96.png)

Example: https://gitlab.com/tarantool/cartridge/-/pipelines/180555497

When you use rules with a when: clause without an if: clause, multiple
pipelines may run. Usually this occurs when you push a commit to a
branch that has an open merge request associated with it.

To prevent duplicate pipelines, use workflow: rules or rewrite your
rules to control which pipelines can run.

Since our main repo is github we don't open merge requests on gitlab and
can safely get rid of pipeline warnings.
