### PR TITLE
Use replication_connect_quorum = 0 by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,15 @@ and this project adheres to
 -------------------------------------------------------------------------------
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Use ``replication_connect_quorum = 0`` as default value. It prevents instances
+  from stucking in ``ConnectingFullmesh`` state upon restart. This is
+  **important** if eventual failover is used: it may result in premature
+  leadership change after it restarts.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -363,6 +363,10 @@ local function cfg(opts, box_opts)
         end
     end
 
+    if box_opts.replication_connect_quorum == nil then
+        box_opts.replication_connect_quorum = 0
+    end
+
     cluster_cookie.init(opts.workdir)
     if opts.cluster_cookie ~= nil then
         cluster_cookie.set_cookie(opts.cluster_cookie)


### PR DESCRIPTION
In v2.0.0 the state machine was introduced. One of its features is a "ConnectingFullmesh" state. It was designed to prevent leader from becoming rw after restart unless replication sync succeeds. This is especially desirable with eventual failover mode.

But the same "ConnectingFullmesh" became a problem because instances stuck in case of replica unavailability. And the same problem occurs when `advertise_uri` is changed. As a solution we proposed to explicitly set quorum to 0.

This patch inverts default behavior - now instances wouldn't stuck, but if a user wants, he may set quorum > 0 explicitly.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
