### PR TITLE
Refine servers URIs according to membership info

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Enhanced is WebUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Indicate config checksum mismatch in issues list.
+- Indicate the change of `arvertise_uri` in issues list.
 
 -------------------------------------------------------------------------------
 [2.3.0] - 2020-08-26

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -284,8 +284,9 @@ local function _clusterwide(patch)
     -- Prepare a server group to be configured
     local uri_list = {}
     local abortion_list = {}
-    for _, _, srv in fun.filter(topology.not_disabled, topology_new.servers) do
-        table.insert(uri_list, srv.uri)
+    local refined_uri_list = topology.refine_servers_uri(topology_new)
+    for _, uuid, _ in fun.filter(topology.not_disabled, topology_new.servers) do
+        table.insert(uri_list, refined_uri_list[uuid])
     end
 
     -- this is mostly for testing purposes

--- a/test/integration/api_edit_test.lua
+++ b/test/integration/api_edit_test.lua
@@ -1,6 +1,5 @@
 local fio = require('fio')
 local t = require('luatest')
-local errno = require('errno')
 local g = t.group()
 
 local helpers = require('test.helper')
@@ -110,17 +109,6 @@ function g.test_edit_server()
             variables = vars
         })
     end
-
-    local _, actual_error = pcall(edit_server_req,
-        {
-            uuid = helpers.uuid('a', 'a', 1),
-            uri = 'localhost:3303'
-        }
-    )
-    t.assert_items_include({
-        '"localhost:3303": ' .. errno.strerror(errno.ENETUNREACH),
-        '"localhost:3303": ' .. errno.strerror(errno.ECONNREFUSED),
-    }, {tostring(actual_error)})
 
     t.assert_error_msg_contains(
         'servers[bbbbbbbb-bbbb-0000-0000-000000000001].uri' ..


### PR DESCRIPTION
Sustain cartridge operability in case of `advertise_uri` change. The uri map is composed basing on `topology_cfg`, but if some of them turns out to be dead, the member with corresponding `payload.uuid` is searched beyond.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1024 
Close #971
