### PR TITLE
Allow recovering from OperationError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Fixed
 - Don't stuck in ``ConnectingFullmesh`` state when instance is restarted with a
   different ``advertise_uri``. Also keep "Server details" dialog in WebUI
   operable in this case.
+- Allow applying config when instance is in ``OperationError``. It doesn't cause
+  loss of quorum anymore.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -97,7 +97,7 @@ local state_transitions = {
 -- errors
     ['InitError'] = {},
     ['BootError'] = {},
-    ['OperationError'] = {}, -- {'BoxConfigured'}
+    ['OperationError'] = {'ConfiguringRoles'}
     -- Disabled
     -- Expelled
 }
@@ -223,6 +223,7 @@ local function apply_config(clusterwide_config)
     assert(clusterwide_config.locked)
     assert(
         vars.state == 'BoxConfigured'
+        or vars.state == 'OperationError'
         or vars.state == 'RolesConfigured',
         'Unexpected state ' .. vars.state
     )

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -65,7 +65,10 @@ local function prepare_2pc(data)
     end
 
     local state = confapplier.wish_state('RolesConfigured')
-    if state ~= 'Unconfigured' and state ~= 'RolesConfigured' then
+    if state ~= 'Unconfigured'
+    and state ~= 'RolesConfigured'
+    and state ~= 'OperationError'
+    then
         local err = Prepare2pcError:new(
             "Instance state is %s, can't apply config in this state",
             state
@@ -136,7 +139,7 @@ local function commit_2pc()
 
     if state == 'Unconfigured' then
         return confapplier.boot_instance(prepared_config)
-    elseif state == 'RolesConfigured' then
+    elseif state == 'RolesConfigured' or state == 'OperationError' then
         return confapplier.apply_config(prepared_config)
     else
         local err = Commit2pcError:new(


### PR DESCRIPTION
This patch allows to re-apply clusterwide configuration when an instance is in `OperationError` state.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #566 
