### PR TITLE
Report role init/apply_conf/stop errors immediately

### DIFF
--- a/cartridge/roles.lua
+++ b/cartridge/roles.lua
@@ -306,9 +306,8 @@ local function apply_config(conf, opts)
                 if _err ~= nil then
                     if err == nil then
                         err = _err
-                    else
-                        log.error('%s', _err)
                     end
+                    log.error('%s', _err)
                     goto continue
                 end
             end
@@ -322,9 +321,8 @@ local function apply_config(conf, opts)
                 if _err ~= nil then
                     if err == nil then
                         err = _err
-                    else
-                        log.error('%s', _err)
                     end
+                    log.error('%s', _err)
                 end
             end
         else
@@ -338,9 +336,8 @@ local function apply_config(conf, opts)
                 if _err ~= nil then
                     if err == nil then
                         err = _err
-                    else
-                        log.error('%s', _err)
                     end
+                    log.error('%s', _err)
                 end
             end
 


### PR DESCRIPTION
If you have many roles, it is significantly more useful to log errors from `init`, `apply_conf` and `stop` at the time when they occur, rather than later on.  This is done for subsequent errors anyway (since `apply_config()` can only return a single error). But not for the initial error. Aside from being inconsistent, this can also be confusing...

Consider a scenario in which you have multiple roles/dependencies.  E.g., imagine roles A and B both depend on role C.  If role C's `init()` fails, it will not log the error and role C will not be entered in to the service registry.  Subsequently, roles A and B, which may fail to fetch role C from the service registry, may report errors. Roles A and B will log their errors *first* and only afterwards will the error from role C -- the actual cause of the problem -- be reported. To make matters worse, when it is reported, there is no indication that the final error originated from role C either.

I think it would be more consistent to simply log the errors when they occur.
