### PR TITLE
New patch_clusterwide option to avoid skipping 2pc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,16 @@ and this project adheres to
 -------------------------------------------------------------------------------
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Added
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- New option in ``cartridge.config_patch_clusterwide``: ``{never_skip = true}``
+  to avoid skipping two-phase commit even the patch doesn't introduce any
+  changes. By default it's now applied to the HTTP config upload API
+  ``PUT /admin/config`` and to the GraphQL ``cluster{ sections(){} }`` mutation.
+  In all other cases old behavior is preserved for the sake of compatibility.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cartridge/webui/api-config.lua
+++ b/cartridge/webui/api-config.lua
@@ -126,7 +126,7 @@ local function upload_config(clusterwide_config)
         end
     end
 
-    return twophase.patch_clusterwide(patch)
+    return twophase.patch_clusterwide(patch, {never_skip = true})
 end
 
 local function upload_config_handler(req)
@@ -233,7 +233,7 @@ local function set_sections(_, args)
         table.insert(query_sections, input.filename)
     end
 
-    local ok, err = twophase.patch_clusterwide(patch)
+    local ok, err = twophase.patch_clusterwide(patch, {never_skip = true})
     if not ok then
         return nil, err
     end

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -485,16 +485,15 @@ function g.test_operation_error()
     ]])
 
     -- Dummy mutation doesn't trigger two-phase commit
-    g.cluster.main_server:graphql({
-        query = [[
-            mutation { cluster { config(sections: []) {} } }
-        ]],
-    })
+    local ok, err = g.cluster.main_server.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide', {{}}
+    )
+    t.assert_equals({ok, err}, {true, nil})
 
     -- Real tho-phase commit fails on apply stage with artificial error
     local resp = g.cluster.main_server:graphql({
         query = [[
-            mutation { cluster { schema(as_yaml: "{}") {} } }
+            mutation { cluster { config(sections: []) {} } }
         ]],
         raise = false,
     })


### PR DESCRIPTION
Don't skip two-phase commit even if the patch doesn't introduce any changes.

By default it's now applied for the http upload API and for GraphQL mutation `cluster { sections }`.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Part of #566