### PR TITLE
Reorganize get_topology code

### DIFF
--- a/cartridge/lua-api/get-topology.lua
+++ b/cartridge/lua-api/get-topology.lua
@@ -11,91 +11,50 @@ local failover = require('cartridge.failover')
 local topology = require('cartridge.topology')
 local confapplier = require('cartridge.confapplier')
 
-local function get_server_info(members, uuid, uri)
-    local member = members[uri]
-    local alias = nil
-    if member and member.payload then
-        alias = member.payload.alias
-    end
+--- Replicaset general information.
+-- @tfield string uuid
+--   The replicaset UUID.
+-- @tfield {string,...}  roles
+--   Roles enabled on the replicaset.
+-- @tfield string status
+--   Replicaset health.
+-- @tfield ServerInfo master
+--   Replicaset leader according to configuration.
+-- @tfield ServerInfo active_master
+--   Active leader.
+-- @tfield number weight
+--   Vshard replicaset weight.
+--   Matters only if vshard-storage role is enabled.
+-- @tfield string vshard_group
+--   Name of vshard group the replicaset belongs to.
+-- @tfield boolean all_rw
+--   A flag indicating that all servers in the replicaset should be read-write.
+-- @tfield string alias
+--   Human-readable replicaset name.
+-- @tfield {ServerInfo,...} servers
+--   Circular reference to all instances in the replicaset.
+-- @table ReplicasetInfo
 
-    --- Instance general information.
-    -- @tfield
-    --   string alias
-    --   Human-readable instance name.
-    -- @tfield string uri
-    -- @tfield string uuid
-    -- @tfield boolean disabled
-    -- @tfield
-    --   string status
-    --   Instance health.
-    -- @tfield
-    --   string message
-    --   Auxilary health status.
-    -- @tfield
-    --   ReplicasetInfo replicaset
-    --   Circular reference to a replicaset.
-    -- @tfield
-    --   number priority
-    --   Leadership priority for automatic failover.
-    -- @tfield
-    --   number clock_delta
-    --   Difference between remote clock and the current one (in
-    --   seconds), obtained from the membership module (SWIM protocol).
-    --   Positive values mean remote clock are ahead of local, and vice
-    --   versa.
-    -- @table ServerInfo
-    local ret = {
-        alias = alias,
-        uri = uri,
-        uuid = uuid,
-        clock_delta = nil,
-    }
-
-    -- find the most fresh information
-    -- among the members with given uuid
-    for _, m in pairs(members) do
-        if m.payload.uuid == uuid
-        and m.timestamp > (member and member.timestamp or 0) then
-            member = m
-        end
-    end
-
-    if not member or member.status == 'left' then
-        ret.status = 'not found'
-        ret.message = 'Server uri is not in membership'
-    elseif member.payload.uuid ~= nil and member.payload.uuid ~= uuid then
-        ret.status = 'not found'
-        ret.message = string.format('Alien uuid %q (%s)', member.payload.uuid, member.status)
-    elseif member.status ~= 'alive' then
-        ret.status = 'unreachable'
-        ret.message = string.format('Server status is %q', member.status)
-    elseif member.payload.uuid == nil then
-        ret.status = 'unconfigured'
-        ret.message = member.payload.state or ''
-    elseif member.payload.state == 'ConfiguringRoles'
-    or member.payload.state == 'RolesConfigured' then
-        ret.status = 'healthy'
-        ret.message = ''
-    elseif member.payload.state == 'InitError'
-    or member.payload.state == 'BootError'
-    or member.payload.state == 'OperationError' then
-        ret.status = 'error'
-        ret.message = member.payload.state
-    else
-        ret.status = 'warning'
-        ret.message = member.payload.state or 'UnknownState'
-    end
-
-    if member and member.status == 'alive' and member.clock_delta ~= nil then
-        ret.clock_delta = member.clock_delta * 1e-6
-    end
-
-    if member and member.uri ~= nil then
-        members[member.uri] = nil
-    end
-
-    return ret
-end
+--- Instance general information.
+-- @tfield string alias
+--   Human-readable instance name.
+-- @tfield string uri
+-- @tfield string uuid
+-- @tfield boolean disabled
+-- @tfield string status
+--   Instance health.
+-- @tfield string message
+--   Auxilary health status.
+-- @tfield ReplicasetInfo replicaset
+--   Circular reference to a replicaset.
+-- @tfield number priority
+--   Leadership priority for automatic failover.
+-- @tfield number clock_delta
+--   Difference between remote clock and the current one (in
+--   seconds), obtained from the membership module (SWIM protocol).
+--   Positive values mean remote clock are ahead of local, and vice
+--   versa.
+-- @table ServerInfo
 
 --- Get servers and replicasets lists.
 -- @function get_topology
@@ -125,39 +84,6 @@ local function get_topology()
     local leaders_order = {}
     local failover_cfg = topology.get_failover_params(topology_cfg)
 
-    --- Replicaset general information.
-    -- @tfield
-    --   string uuid
-    --   The replicaset UUID.
-    -- @tfield
-    --   {string,...}  roles
-    --   Roles enabled on the replicaset.
-    -- @tfield
-    --   string status
-    --   Replicaset health.
-    -- @tfield
-    --   ServerInfo master
-    --   Replicaset leader according to configuration.
-    -- @tfield
-    --   ServerInfo active_master
-    --   Active leader.
-    -- @tfield
-    --   number weight
-    --   Vshard replicaset weight.
-    --   Matters only if vshard-storage role is enabled.
-    -- @tfield
-    --   string vshard_group
-    --   Name of vshard group the replicaset belongs to.
-    -- @tfield
-    --   boolean all_rw
-    --   A flag indicating that all servers in the replicaset should be read-write.
-    -- @tfield
-    --   string alias
-    --   Human-readable replicaset name.
-    -- @tfield
-    --   {ServerInfo,...} servers
-    --   Circular reference to all instances in the replicaset.
-    -- @table ReplicasetInfo
     for replicaset_uuid, replicaset in pairs(topology_cfg.replicasets) do
         replicasets[replicaset_uuid] = {
             uuid = replicaset_uuid,
@@ -202,7 +128,62 @@ local function get_topology()
     local active_leaders = failover.get_active_leaders()
 
     for _, instance_uuid, server in fun.filter(topology.not_expelled, topology_cfg.servers) do
-        local srv = get_server_info(members, instance_uuid, server.uri)
+        local uri = server.uri
+        local member = members[uri]
+        local alias = nil
+        if member and member.payload then
+            alias = member.payload.alias
+        end
+
+        local srv = {
+            uri = uri,
+            uuid = instance_uuid,
+            alias = alias,
+            clock_delta = nil,
+        }
+
+        -- find the most fresh information
+        -- among the members with given uuid
+        for _, m in pairs(members) do
+            if m.payload.uuid == instance_uuid
+            and m.timestamp > (member and member.timestamp or 0) then
+                member = m
+            end
+        end
+
+        if not member or member.status == 'left' then
+            srv.status = 'not found'
+            srv.message = 'Server uri is not in membership'
+        elseif member.payload.uuid ~= nil and member.payload.uuid ~= instance_uuid then
+            srv.status = 'not found'
+            srv.message = string.format('Alien uuid %q (%s)', member.payload.uuid, member.status)
+        elseif member.status ~= 'alive' then
+            srv.status = 'unreachable'
+            srv.message = string.format('Server status is %q', member.status)
+        elseif member.payload.uuid == nil then
+            srv.status = 'unconfigured'
+            srv.message = member.payload.state or ''
+        elseif member.payload.state == 'ConfiguringRoles'
+        or member.payload.state == 'RolesConfigured' then
+            srv.status = 'healthy'
+            srv.message = ''
+        elseif member.payload.state == 'InitError'
+        or member.payload.state == 'BootError'
+        or member.payload.state == 'OperationError' then
+            srv.status = 'error'
+            srv.message = member.payload.state
+        else
+            srv.status = 'warning'
+            srv.message = member.payload.state or 'UnknownState'
+        end
+
+        if member and member.status == 'alive' and member.clock_delta ~= nil then
+            srv.clock_delta = member.clock_delta * 1e-6
+        end
+
+        if member and member.uri ~= nil then
+            members[member.uri] = nil
+        end
 
         srv.disabled = not topology.not_disabled(instance_uuid, server)
         srv.replicaset = replicasets[server.replicaset_uuid]


### PR DESCRIPTION
Just merge two functions. It's necessary for further refactoring.

I didn't forget about

- [x] Tests (preserved green)
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

