### PR TITLE
Refine uri when querying topology

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Don't stuck in ``ConnectingFullmesh`` state when instance is restarted with a
-  different ``advertise_uri``.
+  different ``advertise_uri``. Also keep "Server details" dialog in WebUI
+  operable in this case.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -84,3 +84,26 @@ function g.test_issues()
         }}
     )
 end
+
+function g.test_topology_query()
+    local servers = g.cluster.main_server:graphql({
+        query = [[{
+            servers {
+                uri uuid alias
+                boxinfo { general { listen ro } }
+            }
+        }]]
+    }).data.servers
+
+    t.assert_items_include(servers, {{
+        uri = 'localhost:13311',
+        uuid = g.A1.instance_uuid,
+        alias = 'A-1',
+        boxinfo = {general = {listen = '13311', ro = false}},
+    }, {
+        uri = 'localhost:13312',
+        uuid = g.B1.instance_uuid,
+        alias = 'B-1',
+        boxinfo = {general = {listen = '13312', ro = false}},
+    }})
+end


### PR DESCRIPTION
The old algorithm was getting info from a member with the latest timestamp.
There are two problems with this approach:

1. Timestamp is declared as internal in membership module.
2. It's only updated when new gossip arrives.

In some cases it could result in status "blinking".

This patch makes use of `topology.refine_servers_uri` to resemble other cartridge modules.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1037