### PR TITLE
Add support of a flaky test monitor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,7 @@ docker-build-ce-2.6:
   after_script:
     # avoid caching cartridge rock
     - tarantoolctl rocks remove cartridge
+    - ./push_test_results.sh
   cache:
     key: ${IMAGE_NAME}-fake-ui
     paths:
@@ -122,7 +123,7 @@ integration-ee-1.10:
     IMAGE_NAME: *IMAGE_NAME_EE_1_10
   script:
     - pytest -v
-    - luatest -v -x cypress.*
+    - luatest -v -x cypress.* | tee luatest.log
 
 .integration-ce:
   extends: .test-template
@@ -130,7 +131,7 @@ integration-ee-1.10:
     - yum -y upgrade tarantool
     - tarantool --version
     - pytest -v
-    - luatest -v -x cypress.*
+    - luatest -v -x cypress.* | tee luatest.log
   rules:
     - if: '$NIGHTLY_TEST == "true"'
       when: always

--- a/push_test_results.sh
+++ b/push_test_results.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Sending list of test results to ${MONITOR_HOST}..."
+curl -s --data-binary "@luatest.log" --cookie "token=${MONITOR_TOKEN}" \
+    "${MONITOR_HOST}/api_result/${CI_PROJECT_NAME}/${CI_COMMIT_REF_NAME}/${CI_COMMIT_SHA}/${CI_JOB_ID}/luatest"
+
+if [ "${CI_COMMIT_REF_NAME}" = "master" ]; then
+    echo "Sending list of updated tests..."
+    LAST_COMMIT=$(curl --cookie "token=${MONITOR_TOKEN}" "${MONITOR_HOST}/api_last/${CI_PROJECT_NAME}")
+    DIFF=$(git diff --name-only "${LAST_COMMIT}")
+    curl -s -d "${DIFF}" --cookie "token=${MONITOR_TOKEN}" \
+        "${MONITOR_HOST}/api_diff/${CI_PROJECT_NAME}/${CI_COMMIT_SHA}"
+fi


### PR DESCRIPTION
Tests results from CI now can be stored in the flaky test monitor. 

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #1039 
