### PR TITLE
Fix CI for tarantool 2.4+

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -6,18 +6,13 @@ local helpers = table.copy(require('cartridge.test-helpers'))
 
 helpers.project_root = fio.dirname(debug.sourcedir())
 
-local __fio_tempdir = fio.tempdir
 fio.tempdir = function(base)
     base = base or os.getenv('TMPDIR')
-    if base == nil or base == '/tmp' then
-        return __fio_tempdir()
-    else
-        local random = digest.urandom(9)
-        local suffix = digest.base64_encode(random, {urlsafe = true})
-        local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)
-        fio.mktree(path)
-        return path
-    end
+    local random = digest.urandom(9)
+    local suffix = digest.base64_encode(random, {urlsafe = true})
+    local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)
+    fio.mktree(path)
+    return path
 end
 
 function helpers.entrypoint(name)


### PR DESCRIPTION
CI for Tarantool 2.6 [fails](https://gitlab.com/tarantool/cartridge/-/jobs/754399625) for two reasons:

1. Errors API was significantly refactored in scope of https://github.com/tarantool/tarantool/issues/4398.

2. Recently in [1] we've monkey-patched `fio.tempdir` implementation because it didn't respect `$TMPDIR` env variable. In [2] we've extended it with `base` agrument because etcd required another temp directory (`/dev/shm` tmpfs in Gitlab CI runner wasn't large enough).  Later, TMPDIR was supported in tarantool (see [3]), but it still doesn't support passing `base` as an argument.

This patch fixes the second problem only - it completely eliminates the use of built-in `fio.tempdir` implementation in favor of ours.
The first one will be fixed separately (maybe in tarantool)

[1] https://github.com/tarantool/cartridge/pull/613
[2] https://github.com/tarantool/cartridge/pull/966
[3] https://github.com/tarantool/tarantool/issues/4794

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Part of #1058
