### PR TITLE
Refresh period & interval in tarantool_variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Enhanced is WebUI
 - Indicate the change of `arvertise_uri` in issues list.
 - Upated layout of config management page.
 - Refresh interval and stat refresh period variables can be customized via
-  frontend-core's ``set_variable`` feature or in the runtime.
+  frontend-core's ``set_variable`` feature or at runtime.
 
 -------------------------------------------------------------------------------
 [2.3.0] - 2020-08-26

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Enhanced is WebUI
 - Indicate config checksum mismatch in issues list.
 - Indicate the change of `arvertise_uri` in issues list.
 - Upated layout of config management page.
+- Refresh interval and stat refresh period variables can be customized via
+  frontend-core's ``set_variable`` feature or in the runtime.
 
 -------------------------------------------------------------------------------
 [2.3.0] - 2020-08-26

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -11,6 +11,14 @@ errors.set_deprecation_handler(function(err)
     os.exit(1)
 end)
 
+local frontend = require('frontend-core')
+if frontend.set_variable then
+    -- Compatibility tests run on cartridge 1.2.0
+    -- which doesn't support it yet.
+    frontend.set_variable('cartridge_refresh_interval', 500)
+    frontend.set_variable('cartridge_stat_period', 2)
+end
+
 package.preload['mymodule'] = function()
     local state = nil
     local master = nil

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,9 +1,17 @@
 # Cartridge frontend documentation
 
+## Configurable parameters via frontend core variables
+
+`cartridge_refresh_interval` - Cluster topology refresh interval.
+
+`cartridge_stat_period` - Refresh period for all cluster stats
+(includes issues, suggestions and server stats).
+
 ## Emittable frontend core events
 
 Events dispatchable by module `cartridge`:
 
-`cluster:login:done` - Emits after succesful authorization. Provides object describing auth state and username.
+`cluster:login:done` - Emits after succesful authorization.
+Provides object describing auth state and username.
 
 `cluster:logout:done` - Emits after succesful logging out.

--- a/webui/cypress/integration/failover.spec.js
+++ b/webui/cypress/integration/failover.spec.js
@@ -126,7 +126,6 @@ describe('Failover', () => {
   })
 
   it('Check issues', () => {
-    cy.reload();
     cy.contains('Replica sets');
     cy.get('.meta-test__ClusterIssuesButton').should('be.enabled');
     cy.get('.meta-test__ClusterIssuesButton').contains('Issues: 4');

--- a/webui/src/constants.js
+++ b/webui/src/constants.js
@@ -1,6 +1,6 @@
 export const PROJECT_NAME = 'cluster';
 export const REFRESH_LIST_INTERVAL = 2500;
-export const STAT_REQUEST_PERIOD = 10;
+export const STAT_REQUEST_PERIOD = 3;
 export const VSHARD_STORAGE_ROLE_NAME = 'vshard-storage';
 export const VSHARD_ROUTER_ROLE_NAME = 'vshard-router';
 export const DEFAULT_VSHARD_GROUP_NAME = 'default'; // indicates vshard groups are disabled

--- a/webui/src/constants.js
+++ b/webui/src/constants.js
@@ -1,5 +1,6 @@
 export const PROJECT_NAME = 'cluster';
 export const REFRESH_LIST_INTERVAL = 2500;
+export const STAT_REQUEST_PERIOD = 10;
 export const VSHARD_STORAGE_ROLE_NAME = 'vshard-storage';
 export const VSHARD_ROUTER_ROLE_NAME = 'vshard-router';
 export const DEFAULT_VSHARD_GROUP_NAME = 'default'; // indicates vshard groups are disabled

--- a/webui/src/store/saga/clusterInstancePage.saga.js
+++ b/webui/src/store/saga/clusterInstancePage.saga.js
@@ -31,7 +31,8 @@ const pageDataRequestSaga = getSignalRequestSaga(
 
 function* refreshInstanceStatsSaga() {
   while (true) {
-    yield delay(REFRESH_LIST_INTERVAL);
+    const { cartridge_refresh_interval } = (window.__tarantool_variables || {});
+    yield delay(parseInt(cartridge_refresh_interval || REFRESH_LIST_INTERVAL));
     yield put({ type: CLUSTER_INSTANCE_REFRESH_REQUEST });
 
     let response;

--- a/webui/src/store/saga/clusterPage.saga.js
+++ b/webui/src/store/saga/clusterPage.saga.js
@@ -65,9 +65,7 @@ import {
   changeFailover
 } from 'src/store/request/clusterPage.requests';
 import { graphqlErrorNotification } from 'src/misc/graphqlErrorNotification';
-import { REFRESH_LIST_INTERVAL } from 'src/constants';
-
-const STAT_REQUEST_PERIOD = 10;
+import { REFRESH_LIST_INTERVAL, STAT_REQUEST_PERIOD } from 'src/constants';
 
 const pageDataRequestSaga = getSignalRequestSaga(
   CLUSTER_PAGE_DID_MOUNT,
@@ -81,7 +79,8 @@ function* refreshListsTaskSaga() {
   let requestNum = 0;
 
   while (true) {
-    yield delay(REFRESH_LIST_INTERVAL);
+    const { cartridge_refresh_interval } = (window.__tarantool_variables || {});
+    yield delay(parseInt(cartridge_refresh_interval || REFRESH_LIST_INTERVAL));
     requestNum++;
     yield refreshListsSaga(requestNum);
   }
@@ -92,7 +91,9 @@ function* refreshListsSaga(requestNum = 0) {
 
   let response;
   try {
-    const shouldRequestStat = requestNum % STAT_REQUEST_PERIOD === 0;
+    const { cartridge_stat_period } = (window.__tarantool_variables || {});
+    const shouldRequestStat =
+      requestNum % parseInt(cartridge_stat_period || STAT_REQUEST_PERIOD) === 0;
     if (shouldRequestStat) {
       response = yield call(refreshLists, { shouldRequestStat: true });
     } else {


### PR DESCRIPTION
Refresh interval and stat refresh period variables can be customized via frontend-core's `set_variable` feature or in the runtime.

Variables:

* `cartridge_refresh_interval` - time in milliseconds to poll topology
* `cartridge_stat_period` - poll stat once in a nubmer refreshes

Example for browser runtime:

```js
if (!window.__tarantool_variables) window.__tarantool_variables = {};
window.__tarantool_variables.cartridge_refresh_interval = 2500; // ms
window.__tarantool_variables.cartridge_stat_period = 3;
```

Example to fine-tune in from backend:

```lua
local frontend = require('frontend-core')
frontend.set_variable('cartridge_refresh_interval', 2500) -- ms
frontend.set_variable('cartridge_stat_period', 3)
```

- [ ] Tests
- [x] Changelog
- [x] Documentation