### PR TITLE
Fix running tests locally

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -7,7 +7,7 @@ local helpers = table.copy(require('cartridge.test-helpers'))
 helpers.project_root = fio.dirname(debug.sourcedir())
 
 fio.tempdir = function(base)
-    base = base or os.getenv('TMPDIR')
+    base = base or os.getenv('TMPDIR') or '/tmp'
     local random = digest.urandom(9)
     local suffix = digest.base64_encode(random, {urlsafe = true})
     local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)


### PR DESCRIPTION
Recent #1059 introduced a problem: when TMPDIR environment variable isn't specified tests raise the error: 'fio.pathjoin(): undefined path part 1'. This patch fixes it by specifying a default tempdir base as `/tmp`.