### PR TITLE
Option to disable UDP broadcast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
 
 - New GraphQL API: ``{cluster {suggestions {refine_uri {}}}}`` to heal the
   cluster after relocation of servers ``advertise_uri``.
+- New `cartridge.cfg` option `swim_broadcast` (default true) to disable
+  instances discovery on start.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -90,6 +90,7 @@ local cluster_opts = {
     auth_enabled = 'boolean', -- **boolean**
     bucket_count = 'number', -- **number**
     upgrade_schema = 'boolean', -- **boolean**
+    swim_broadcast = 'boolean', -- **boolean**
 }
 
 --- Common [box.cfg](https://www.tarantool.io/en/doc/latest/reference/configuration/) tuning options.

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -320,12 +320,14 @@ end
 
 g.test_positive = function()
     g.mock_membership()
+    membership.broadcast = function() error('Forbidden', 0) end
     -- Test successful cartridge.cfg
 
     local opts = {
             workdir = '/tmp',
             advertise_uri = 'unused:0',
             http_enabled = false,
+            swim_broadcast = false,
         roles = {
             'cartridge.roles.vshard-storage',
             'cartridge.roles.vshard-router',


### PR DESCRIPTION
Introducing new `cartridge.cfg` option `swim_broadcast` (default true) to disable instances discovery on start.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1057
