### PR TITLE
Implement roles hot-reload

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -27,11 +27,11 @@ jobs:
 
       # Setup sphinx
       - name: Cache pip packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: cache-misc-venv
         with:
           path: ./venv
-          key: cache-misc-venv-${{ matrix.runs-on }}
+          key: cache-misc-venv-${{ matrix.runs-on }}-01
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,10 @@ Added
   It'll unlock two-phase commit (remove ``config.prepare`` lock), upload the
   active config from the current instance and reconfigure all roles.
 
+- New feature for hot reloading roles code without restarting an instance --
+  ``cartridge.reload_roles``. The feature is experimental and should be
+  enabled explicitly: ``cartridge.cfg({roles_reload_allowed = true})``.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -72,7 +72,7 @@ local function whitelist_fibers(tbl)
         or v == 'main'
         or v:endswith('(net.box)')
         then
-            log.debug('Refusing to whitelist fiber %q', v)
+            log.debug("Fiber %q can't be whitelisted", v)
         else
             log.debug('Avoid cancelling fiber %q on hot-reload', v)
             vars.fibers[v] = true
@@ -130,7 +130,6 @@ local function load_state()
 
     for k, _ in pairs(package.loaded) do
         if not vars.packages[k] then
-            -- log.info('Unloading package %q', k)
             package.loaded[k] = nil
         end
     end

--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -149,17 +149,22 @@ local function load_state()
         end
 
         if f.fid == 101
+        or f.name == 'checkpoint'
+        or f.name == 'raft_worker'
+        or f.name:startswith('vinyl.')
+        or f.name:startswith('vshard.')
         or f.name:startswith('console/')
         or f.name:startswith('applier/')
         or f.name:startswith('applierw/')
+        or f.name:startswith('watchdog_')
         then
             -- Ignore system fibers
-            log.info('Preserving system fiber %q (%d)', f.name, f.fid)
+            log.debug('Preserving system fiber %q (%d)', f.name, f.fid)
             goto continue
         end
 
         if vars.fibers[f.name] then
-            log.info('Preserving whitelisted fiber %q (%d)', f.name, f.fid)
+            log.debug('Preserving whitelisted fiber %q (%d)', f.name, f.fid)
         else
             log.info('Killing fiber %q (%d)', f.name, f.fid)
             fiber.kill(f.fid)

--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -1,0 +1,143 @@
+local log = require('log')
+local fiber = require('fiber')
+local checks = require('checks')
+
+local vars = require('cartridge.vars').new('cartridge.hotreload')
+local service_registry = require('cartridge.service-registry')
+
+vars:new('packages', nil)
+vars:new('globals', nil)
+vars:new('routes', nil)
+vars:new('fibers', {})
+
+local function snap_fibers()
+    local ret = {}
+
+    for _, f in pairs(fiber.info()) do
+        ret[f.name] = true
+    end
+
+    return ret
+end
+
+local function diff(t1, t2)
+    local ret = {}
+    for k, _ in pairs(t2) do
+        if not t1[k] then
+            table.insert(ret, k)
+        end
+    end
+
+    table.sort(ret)
+    return ret
+end
+
+local function save_state()
+    if vars.packages == nil then
+        vars.packages = table.copy(package.loaded)
+        for k, _ in pairs(vars.packages) do
+            vars.packages[k] = true
+        end
+    end
+
+    if vars.globals == nil then
+        vars.globals = setmetatable(table.copy(_G), nil)
+        for k, _ in pairs(vars.globals) do
+            vars.globals[k] = true
+        end
+    end
+
+    if vars.routes == nil then
+        local httpd = service_registry.get('httpd')
+        vars.routes = #httpd.routes
+    end
+end
+
+local function load_state()
+    for k, _ in pairs(package.loaded) do
+        if not vars.packages[k] then
+            -- log.info('Unloading package %q', k)
+            package.loaded[k] = nil
+        end
+    end
+
+    for k, _ in pairs(_G) do
+        if not vars.globals[k] then
+            log.info('Unsetting global %q', k)
+            _G[k] = nil
+        end
+    end
+
+    local fiber_info = fiber.info()
+    for _, f in pairs(fiber_info) do
+        if f.fid == fiber.id() then
+            -- don't kill self
+            goto continue
+        end
+
+        if f.fid == 101
+        or f.name == 'on_shutdown'
+        or f.name:startswith('console/')
+        or f.name:startswith('applier/')
+        or f.name:startswith('applierw/')
+        then
+            -- Ignore system fibers
+            log.info('Preserving system fiber %q (%d)', f.name, f.fid)
+            goto continue
+        end
+
+        if vars.fibers[f.name] then
+            log.info('Preserving whitelisted fiber %q (%d)', f.name, f.fid)
+        else
+            log.info('Killing fiber %q (%d)', f.name, f.fid)
+            fiber.kill(f.fid)
+        end
+
+        ::continue::
+    end
+
+    local httpd = service_registry.get('httpd')
+    if httpd ~= nil then
+        for n = #httpd.routes, vars.routes + 1, -1 do
+            local r = httpd.routes[n]
+            log.info('Removing HTTP route %q (%s)', r.path, r.method)
+            if httpd.iroutes[r.name] ~= nil then
+                httpd.iroutes[r.name] = nil
+            end
+            httpd.routes[n] = nil
+        end
+    end
+end
+
+local function whitelist_globals(tbl)
+    checks('table')
+    for _, v in ipairs(tbl) do
+        log.debug('Avoid hot-reloading global %q', v)
+        vars.globals[v] = true
+    end
+end
+
+local function whitelist_fibers(tbl)
+    checks('table')
+    for _, v in ipairs(tbl) do
+        if v == 'lua'
+        or v:endswith('(net.box)')
+        then
+            log.debug('Refusing to whitelist fiber %q', v)
+        else
+            log.debug('Avoid hot-reloading fiber %q', v)
+            vars.fibers[v] = true
+        end
+    end
+end
+
+return {
+    save_state = save_state,
+    load_state = load_state,
+
+    snap_fibers = snap_fibers,
+    diff = diff,
+
+    whitelist_fibers = whitelist_fibers,
+    whitelist_globals = whitelist_globals,
+}

--- a/cartridge/roles.lua
+++ b/cartridge/roles.lua
@@ -454,6 +454,10 @@ local function reload()
     end
 
     hotreload.load_state()
+
+    -- Collect the garbage from unloaded modules.
+    -- Why call it twice? See PiL 3rd edition, §17.6 Finalizers.
+    -- Especially for the term "resurrection". 🧟‍ Grr... argh!
     collectgarbage()
     collectgarbage()
 

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -72,7 +72,6 @@ local function apply_config(conf)
             log.info('Reconfiguring %s ...', router_name)
 
             local router = vars.routers[router_name]
-            local snap1 = hotreload.snap_fibers()
 
             if router ~= nil then
                 router:cfg(vshard_cfg)
@@ -89,9 +88,6 @@ local function apply_config(conf)
                     )
                 end
             end
-
-            local snap2 = hotreload.snap_fibers()
-            hotreload.whitelist_fibers(hotreload.diff(snap1, snap2))
 
             vars.routers[router_name] = router
             vars.vshard_cfg[router_name] = vshard_cfg

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -7,8 +7,18 @@ local vars = require('cartridge.vars').new('cartridge.roles.vshard-router')
 local pool = require('cartridge.pool')
 local utils = require('cartridge.utils')
 local twophase = require('cartridge.twophase')
+local hotreload = require('cartridge.hotreload')
 local confapplier = require('cartridge.confapplier')
 local vshard_utils = require('cartridge.vshard-utils')
+
+hotreload.whitelist_globals({
+    "__module_vshard_lua_gc",
+    "__module_vshard_router",
+    "__module_vshard_storage",
+    "__module_vshard_util",
+    "future_storage_call_result",
+    "gc_bucket_f",
+})
 
 local e_bootstrap_vshard = errors.new_class('Bootstrapping vshard failed')
 local e_create_router = errors.new_class('Error creating vshard-router')
@@ -62,6 +72,7 @@ local function apply_config(conf)
             log.info('Reconfiguring %s ...', router_name)
 
             local router = vars.routers[router_name]
+            local snap1 = hotreload.snap_fibers()
 
             if router ~= nil then
                 router:cfg(vshard_cfg)
@@ -78,6 +89,9 @@ local function apply_config(conf)
                     )
                 end
             end
+
+            local snap2 = hotreload.snap_fibers()
+            hotreload.whitelist_fibers(hotreload.diff(snap1, snap2))
 
             vars.routers[router_name] = router
             vars.vshard_cfg[router_name] = vshard_cfg

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -1,6 +1,6 @@
 local log = require('log')
-local checks = require('checks')
 local vshard = require('vshard')
+local checks = require('checks')
 
 local vars = require('cartridge.vars').new('cartridge.roles.vshard-storage')
 local pool = require('cartridge.pool')

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -36,11 +36,8 @@ local function apply_config(conf, _)
     end
 
     log.info('Reconfiguring vshard.storage...')
-    local snap1 = hotreload.snap_fibers()
     vshard.storage.cfg(vshard_cfg, box.info.uuid)
     vars.vshard_cfg = vshard_cfg
-    local snap2 = hotreload.snap_fibers()
-    hotreload.whitelist_fibers(hotreload.diff(snap1, snap2))
 end
 
 local function init()

--- a/cartridge/vshard-utils.lua
+++ b/cartridge/vshard-utils.lua
@@ -372,7 +372,9 @@ local function get_known_groups()
 
     for _, g in pairs(vshard_groups) do
         if g.rebalancer_max_receiving == nil then
-            g.rebalancer_max_receiving = vshard_consts.DEFAULT_REBALANCER_MAX_RECEIVING
+            g.rebalancer_max_receiving = assert(
+                vshard_consts.DEFAULT_REBALANCER_MAX_RECEIVING
+            )
         end
 
         if g.collect_lua_garbage == nil then
@@ -380,15 +382,19 @@ local function get_known_groups()
         end
 
         if g.sync_timeout == nil then
-            g.sync_timeout = vshard_consts.DEFAULT_SYNC_TIMEOUT
+            g.sync_timeout = assert(vshard_consts.DEFAULT_SYNC_TIMEOUT)
         end
 
         if g.collect_bucket_garbage_interval == nil then
-            g.collect_bucket_garbage_interval = vshard_consts.DEFAULT_COLLECT_BUCKET_GARBAGE_INTERVAL
+            g.collect_bucket_garbage_interval = assert(
+                vshard_consts.DEFAULT_COLLECT_BUCKET_GARBAGE_INTERVAL
+            )
         end
 
         if g.rebalancer_disbalance_threshold == nil then
-            g.rebalancer_disbalance_threshold = vshard_consts.DEFAULT_REBALANCER_DISBALANCE_THRESHOLD
+            g.rebalancer_disbalance_threshold = assert(
+                vshard_consts.DEFAULT_REBALANCER_DISBALANCE_THRESHOLD
+            )
         end
     end
 

--- a/cartridge/vshard-utils.lua
+++ b/cartridge/vshard-utils.lua
@@ -372,9 +372,7 @@ local function get_known_groups()
 
     for _, g in pairs(vshard_groups) do
         if g.rebalancer_max_receiving == nil then
-            g.rebalancer_max_receiving = assert(
-                vshard_consts.DEFAULT_REBALANCER_MAX_RECEIVING
-            )
+            g.rebalancer_max_receiving = vshard_consts.DEFAULT_REBALANCER_MAX_RECEIVING
         end
 
         if g.collect_lua_garbage == nil then
@@ -382,19 +380,15 @@ local function get_known_groups()
         end
 
         if g.sync_timeout == nil then
-            g.sync_timeout = assert(vshard_consts.DEFAULT_SYNC_TIMEOUT)
+            g.sync_timeout = vshard_consts.DEFAULT_SYNC_TIMEOUT
         end
 
         if g.collect_bucket_garbage_interval == nil then
-            g.collect_bucket_garbage_interval = assert(
-                vshard_consts.DEFAULT_COLLECT_BUCKET_GARBAGE_INTERVAL
-            )
+            g.collect_bucket_garbage_interval = vshard_consts.DEFAULT_COLLECT_BUCKET_GARBAGE_INTERVAL
         end
 
         if g.rebalancer_disbalance_threshold == nil then
-            g.rebalancer_disbalance_threshold = assert(
-                vshard_consts.DEFAULT_REBALANCER_DISBALANCE_THRESHOLD
-            )
+            g.rebalancer_disbalance_threshold = vshard_consts.DEFAULT_REBALANCER_DISBALANCE_THRESHOLD
         end
     end
 

--- a/test/compatibility/cartridge_upgrade_test.lua
+++ b/test/compatibility/cartridge_upgrade_test.lua
@@ -71,6 +71,7 @@ function g.test_upgrade()
         server_command = fio.abspath(helpers.entrypoint('srv_basic')),
         cookie = require('digest').urandom(6):hex(),
         use_vshard = true,
+        env = {TARANTOOL_FORBID_HOTRELOAD = 'true'},
         replicasets = {{
             uuid = helpers.uuid('a'),
             roles = {'vshard-router', 'vshard-storage'},
@@ -87,7 +88,7 @@ function g.test_upgrade()
                 http_port = 8082,
                 chdir = cartridge_older_path,
             }},
-        }}
+        }},
     })
 
     local leader = g.cluster:server('leader')

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -165,6 +165,7 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
         'mymodule',
     },
     webui_blacklist = webui_blacklist,
+    roles_reload_allowed = true,
 })
 if not ok then
     log.error('%s', err)

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -152,6 +152,11 @@ if webui_blacklist ~= nil then
     webui_blacklist = string.split(webui_blacklist, ':')
 end
 
+local roles_reload_allowed = nil
+if not os.getenv('TARANTOOL_FORBID_HOTRELOAD') then
+    roles_reload_allowed = true
+end
+
 local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     advertise_uri = 'localhost:3301',
     http_port = 8081,
@@ -165,7 +170,7 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
         'mymodule',
     },
     webui_blacklist = webui_blacklist,
-    roles_reload_allowed = true,
+    roles_reload_allowed = roles_reload_allowed,
 })
 if not ok then
     log.error('%s', err)

--- a/test/hotreload/forbidden_test.lua
+++ b/test/hotreload/forbidden_test.lua
@@ -1,0 +1,37 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_woauth'),
+        cookie = helpers.random_cookie(),
+        replicasets = {{
+            alias = 'A',
+            roles = {},
+            servers = 1,
+        }},
+    })
+    g.srv = g.cluster:server('A-1')
+    g.srv.env['TARANTOOL_CONSOLE_SOCK'] = g.srv.workdir .. '/console.sock'
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_errors()
+    local ok, err = g.srv.net_box:call('package.loaded.cartridge.reload_roles')
+
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'HotReloadError',
+        err = 'This application forbids reloading roles',
+    })
+end

--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -3,12 +3,17 @@ local yaml = require('yaml')
 local fiber = require('fiber')
 local httpc = require('http.client')
 local socket = require('socket')
+local utils = require('cartridge.utils')
 local t = require('luatest')
 local g = t.group()
 
 local helpers = require('test.helper')
 
 local function reload_myrole(fn)
+    -- For the sake of string.dump() function must have no upvalues.
+    -- https://www.lua.org/manual/5.1/manual.html#pdf-string.dump
+    utils.assert_upvalues(fn, {})
+
     local ok, err = g.srv.net_box:eval([[
         package.preload["mymodule"] = loadstring(...)
         return require("cartridge.roles").reload()

--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -1,0 +1,405 @@
+local fio = require('fio')
+local yaml = require('yaml')
+local fiber = require('fiber')
+local httpc = require('http.client')
+local socket = require('socket')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+local function reload_myrole(fn)
+    local ok, err = g.srv.net_box:eval([[
+        package.preload["mymodule"] = loadstring(...)
+        return require("cartridge.roles").reload()
+    ]], {string.dump(fn)})
+
+    t.assert_equals({ok, err}, {true, nil})
+end
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = helpers.random_cookie(),
+        replicasets = {{
+            alias = 'A',
+            roles = {'myrole'},
+            servers = 1,
+        }},
+    })
+    g.srv = g.cluster:server('A-1')
+    g.srv.env['TARANTOOL_CONSOLE_SOCK'] = g.srv.workdir .. '/console.sock'
+    g.cluster:start()
+
+    local ok, err = g.srv.net_box:eval([[
+        return require("cartridge.roles").reload()
+    ]])
+    t.assert_equals({ok, err}, {true, nil})
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_events()
+    reload_myrole(function()
+        rawset(_G, 'events', {})
+        table.insert(_G.events, 'require')
+        return {
+            role_name = 'myrole',
+            validate_config = function() table.insert(_G.events, 'validate') return true end,
+            apply_config = function() table.insert(_G.events, 'apply') end,
+            init = function() table.insert(_G.events, 'init') end,
+        }
+    end)
+
+    t.assert_equals(
+        g.srv.net_box:eval('return _G.events'),
+        {'require', 'validate', 'init', 'apply'}
+    )
+end
+
+function g.test_errors()
+    local ok, err = g.srv.net_box:eval([[
+        package.preload["mymodule"] = function() error("F", 0) end
+        return require("cartridge.roles").reload()
+    ]])
+
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'RegisterRoleError',
+        err = 'F',
+    })
+
+    local resp = g.srv:graphql({query = [[
+        {cluster { self {state error} }}
+    ]]})
+
+    t.assert_equals(resp.data.cluster.self, {
+        state = "ReloadError",
+        error = "F",
+    })
+
+    reload_myrole(function() return {role_name = 'myrole'} end)
+    g.cluster:wait_until_healthy()
+end
+
+function g.test_roledeps()
+    g.srv.net_box:eval([[
+        package.preload["role-a"] = function() return {} end
+        package.preload["role-b"] = function() return {} end
+    ]])
+
+    reload_myrole(function()
+        return {
+            role_name = 'myrole',
+            dependencies = {'role-a'},
+        }
+    end)
+
+    g.srv.net_box:eval([[
+        local cartridge = require('cartridge')
+        assert(package.loaded['role-a'])
+        assert(package.loaded['role-b'] == nil)
+        assert(cartridge.service_get('role-a'))
+        assert(cartridge.service_get('role-b') == nil)
+    ]])
+
+    reload_myrole(function()
+        return {
+            role_name = 'myrole',
+            dependencies = {'role-b'},
+        }
+    end)
+
+    g.srv.net_box:eval([[
+        local cartridge = require('cartridge')
+        assert(package.loaded['role-a'] == nil)
+        assert(package.loaded['role-b'])
+        assert(cartridge.service_get('role-a') == nil)
+        assert(cartridge.service_get('role-b'))
+    ]])
+end
+
+function g.test_rpc()
+    reload_myrole(function()
+        return {
+            role_name = 'myrole',
+            cheer = function() return 'Hello, Cartridge' end,
+        }
+    end)
+
+    -- New RPC works
+    t.assert_equals(g.srv.net_box:call(
+        'package.loaded.cartridge.rpc_call',
+        {'myrole', 'cheer'}
+    ), 'Hello, Cartridge')
+
+    reload_myrole(function()
+        return {
+            role_name = 'myrole',
+            echo = function(...) return ... end,
+        }
+    end)
+
+    -- Old RPC isn't available anymore
+    local ret, err = g.srv.net_box:call(
+        'package.loaded.cartridge.rpc_call',
+        {'myrole', 'cheer'}
+    )
+    t.assert_equals(ret, nil)
+    t.assert_covers(err, {
+        class_name = 'RemoteCallError',
+        err = 'Role "myrole" has no method "cheer"',
+    })
+
+    -- New RPC works
+    t.assert_equals(g.srv.net_box:call(
+        'package.loaded.cartridge.rpc_call',
+        {'myrole', 'echo', {'2020-11-10'}}
+    ), '2020-11-10')
+end
+
+function g.test_netbox()
+    reload_myrole(function()
+        rawset(_G, 'hang', function()
+            local log = require('log')
+            local fiber = require('fiber')
+            fiber.name('weirdo_netbox')
+            log.info('Weird netbox call')
+            rawset(_G, 'test_ready', true)
+            fiber.sleep(math.huge)
+            return true
+        end)
+        return {role_name = 'myrole'}
+    end)
+
+    local future = g.srv.net_box:call('hang', nil, {is_async = true})
+    helpers.retrying({}, function()
+        g.srv.net_box:eval('return test_ready')
+    end)
+
+    -- require('fiber').sleep(1)
+    reload_myrole(function()
+        return {role_name = 'myrole'}
+    end)
+
+    -- The call is aborted
+    local ok, err = future:wait_result(1)
+    t.assert_equals(ok, nil)
+    t.assert_equals(type(err), 'cdata')
+    t.assert_equals(tostring(err), 'fiber is cancelled')
+
+    -- But connection remains alive
+    t.assert_equals(g.srv.net_box:ping(), true)
+    t.assert_covers(g.srv.net_box, {state = 'active'})
+end
+
+function g.test_routes()
+    reload_myrole(function()
+        local service_registry = require('cartridge.service-registry')
+        local httpd = service_registry.get('httpd')
+
+        local function echo(req)
+            return {
+                status = 200,
+                body = ('Echo 1 %s %s'):format(req.method, req.path),
+            }
+        end
+        httpd:route({method = 'ANY', path = '/route-a'}, echo)
+        httpd:route({method = 'GET', path = '/route-b'}, echo)
+
+        return {role_name = 'myrole'}
+    end)
+
+    t.assert_covers(
+        httpc.get('localhost:8081/route-a'),
+        {status = 200, body = 'Echo 1 GET /route-a'}
+    )
+    t.assert_covers(
+        httpc.put('localhost:8081/route-a'),
+        {status = 200, body = 'Echo 1 PUT /route-a'}
+    )
+    t.assert_covers(
+        httpc.get('localhost:8081/route-b'),
+        {status = 200, body = 'Echo 1 GET /route-b'}
+    )
+    t.assert_covers(
+        httpc.put('localhost:8081/route-b'),
+        {status = 404}
+    )
+
+    reload_myrole(function()
+        local service_registry = require('cartridge.service-registry')
+        local httpd = service_registry.get('httpd')
+
+        local function echo(req)
+            return {
+                status = 200,
+                body = ('Echo 2 %s %s'):format(req.method, req.path),
+            }
+        end
+        httpd:route({method = 'GET', path = '/route-a'}, echo)
+        httpd:route({method = 'POST', path = '/route-c'}, echo)
+
+        return {role_name = 'myrole'}
+    end)
+
+
+    t.assert_covers(
+        httpc.get('localhost:8081/route-a'),
+        {status = 200, body = 'Echo 2 GET /route-a'}
+    )
+    t.assert_covers(
+        httpc.put('localhost:8081/route-a'),
+        {status = 404}
+    )
+    t.assert_covers(
+        httpc.get('localhost:8081/route-b'),
+        {status = 404}
+    )
+    t.assert_covers(
+        httpc.post('localhost:8081/route-c'),
+        {status = 200, body = 'Echo 2 POST /route-c'}
+    )
+
+    reload_myrole(function()
+        local log = require('log')
+        local fiber = require('fiber')
+        local service_registry = require('cartridge.service-registry')
+        local httpd = service_registry.get('httpd')
+        httpd:route({method = 'GET', path = '/sleep'}, function()
+            fiber.name('weirdo_http')
+            log.info('Weird http callback')
+            rawset(_G, 'test_ready', true)
+            fiber.sleep(math.huge)
+            return {status = 200}
+        end)
+        return {role_name = 'myrole'}
+    end)
+
+    local f = fiber.new(httpc.get, 'localhost:8081/sleep')
+    f:name('http_get')
+    f:set_joinable(true)
+    helpers.retrying({}, function()
+        g.srv.net_box:eval('return test_ready')
+    end)
+
+    reload_myrole(function()
+        return {role_name = 'myrole'}
+    end)
+
+    local ok, resp = f:join()
+    t.assert_equals(ok, true)
+    t.assert_covers(resp, {status = 500})
+    t.assert_str_matches(resp.body, 'Unhandled error: fiber is cancelled\n.+')
+
+    t.assert_covers(
+        httpc.get('localhost:8081/sleep'),
+        {status = 404}
+    )
+end
+
+function g.test_globals()
+    local function inspect(var)
+        return g.srv.net_box:eval([[
+            return rawget(_G, ...)
+        ]], {var})
+    end
+
+    reload_myrole(function()
+        rawset(_G, '__var_on_require', true)
+        rawset(_G, '__var_whitelisted', true)
+        require('cartridge.hotreload').whitelist_globals({'__var_whitelisted'})
+        return {
+            role_name = 'myrole',
+            apply_config = function()
+                rawset(_G, '__var_on_apply', true)
+            end
+        }
+    end)
+
+    t.assert_equals(inspect('__var_whitelisted'), true)
+    t.assert_equals(inspect('__var_on_require'), true)
+    t.assert_equals(inspect('__var_on_apply'), true)
+
+    reload_myrole(function()
+        return {role_name = 'myrole'}
+    end)
+
+    t.assert_equals(inspect('__var_whitelisted'), true)
+    t.assert_equals(inspect('__var_on_require'), nil)
+    t.assert_equals(inspect('__var_on_apply'), nil)
+end
+
+function g.test_fibers()
+    g.srv.net_box:eval([[
+        local fiber = require('fiber')
+        fiber.fibers = {}
+        function fiber.spawn(name, fn, ...)
+            local f = fiber.new(fn, ...)
+            f:name(name)
+            fiber.fibers[name] = f
+            return f
+        end
+    ]])
+
+    local function inspect(fname)
+        return g.srv.net_box:eval([[
+            return require('fiber').fibers[...]:status()
+        ]], {fname})
+    end
+
+    reload_myrole(function()
+        local fiber = require('fiber')
+        local hotreload = require('cartridge.hotreload')
+        local f_managed
+        return {
+            role_name = 'myrole',
+            init = function()
+                f_managed = fiber.spawn('managed', fiber.sleep, math.huge)
+                fiber.spawn('infsleep', fiber.sleep, math.huge)
+                fiber.spawn('whitelisted', fiber.sleep, math.huge)
+                hotreload.whitelist_fibers({'managed'})
+                hotreload.whitelist_fibers({'whitelisted'})
+            end,
+            stop = function()
+                f_managed:cancel()
+            end,
+        }
+    end)
+
+    t.assert_equals(inspect('managed'), 'suspended')
+    t.assert_equals(inspect('infsleep'), 'suspended')
+    t.assert_equals(inspect('whitelisted'), 'suspended')
+
+    reload_myrole(function()
+        return {role_name = 'myrole'}
+    end)
+
+    t.assert_equals(inspect('managed'), 'dead')
+    t.assert_equals(inspect('infsleep'), 'dead')
+    t.assert_equals(inspect('whitelisted'), 'suspended')
+end
+
+function g.test_console()
+    local s = socket.tcp_connect(
+        'unix/', g.srv.env.TARANTOOL_CONSOLE_SOCK
+    )
+    t.assert(s)
+    local greeting = s:read('\n', 0.1)
+    t.assert(greeting)
+    t.assert_str_matches(greeting:strip(), 'Tarantool.*%(Lua console%)')
+    s:read('\n', 0)
+
+    reload_myrole(function()
+        return {role_name = 'myrole'}
+    end)
+
+    s:write('return "of reckoning"\n')
+    local resp = s:read('...\n', 1)
+    t.assert_equals(resp, yaml.encode({'of reckoning'}))
+end

--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -166,12 +166,9 @@ end
 function g.test_netbox()
     reload_myrole(function()
         rawset(_G, 'hang', function()
-            local log = require('log')
-            local fiber = require('fiber')
-            fiber.name('weirdo_netbox')
-            log.info('Weird netbox call')
             rawset(_G, 'test_ready', true)
-            fiber.sleep(math.huge)
+            require('log').info('Weird netbox call')
+            require('fiber').sleep(math.huge)
             return true
         end)
         return {role_name = 'myrole'}
@@ -267,15 +264,12 @@ function g.test_routes()
     )
 
     reload_myrole(function()
-        local log = require('log')
-        local fiber = require('fiber')
         local service_registry = require('cartridge.service-registry')
         local httpd = service_registry.get('httpd')
         httpd:route({method = 'GET', path = '/sleep'}, function()
-            fiber.name('weirdo_http')
-            log.info('Weird http callback')
             rawset(_G, 'test_ready', true)
-            fiber.sleep(math.huge)
+            require('log').info('Weird http callback')
+            require('fiber').sleep(math.huge)
             return {status = 200}
         end)
         return {role_name = 'myrole'}

--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -179,7 +179,6 @@ function g.test_netbox()
         g.srv.net_box:eval('return test_ready')
     end)
 
-    -- require('fiber').sleep(1)
     reload_myrole(function()
         return {role_name = 'myrole'}
     end)

--- a/test/hotreload/vshard_test.lua
+++ b/test/hotreload/vshard_test.lua
@@ -1,0 +1,199 @@
+local fio = require('fio')
+local log = require('log')
+local fiber = require('fiber')
+local errors = require('errors')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+local function reload(srv)
+    local ok, err = srv.net_box:eval([[
+        return require("cartridge.roles").reload()
+    ]])
+
+    t.assert_equals({ok, err}, {true, nil})
+end
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = true,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = '', -- helpers.random_cookie(),
+        replicasets = {
+            {alias = 'R', roles = {'vshard-router'}, servers = 1},
+            {alias = 'SA', roles = {'vshard-storage'}, servers = 2},
+            {alias = 'SB', roles = {'vshard-storage'}, servers = 2}
+        },
+        -- replicasets = {{
+        --     alias = 'R',
+        --     uuid = helpers.uuid('a'),
+        --     roles = {'vshard-router'},
+        --     servers = {{instance_uuid = helpers.uuid('a', 'a', 1)}},
+        -- }, {
+        --     alias = 'SA',
+        --     uuid = helpers.uuid('f', 'a'),
+        --     roles = {'vshard-storage'},
+        --     servers = {
+        --         {instance_uuid = helpers.uuid('f', 'a', 1)},
+        --         {instance_uuid = helpers.uuid('f', 'a', 2)},
+        --     },
+        -- }, {
+        --     alias = 'SB',
+        --     uuid = helpers.uuid('e', 'b'),
+        --     roles = {'vshard-storage'},
+        --     servers = {
+        --         {instance_uuid = helpers.uuid('e', 'b', 1)},
+        --         {instance_uuid = helpers.uuid('e', 'b', 2)},
+        --     },
+        -- }},
+
+    })
+    g.cluster:start()
+
+    local test_schema = {
+        engine = 'memtx',
+        is_local = false,
+        temporary = false,
+        format = {
+            {name = 'bucket_id', type = 'unsigned', is_nullable = false},
+            {name = 'record_id', type = 'unsigned', is_nullable = false},
+        },
+        indexes = {{
+            name = 'pk', type = 'TREE', unique = true,
+            parts = {{path = 'record_id', is_nullable = false, type = 'unsigned'}},
+        },  {
+            name = 'bucket_id', type = 'TREE', unique = false,
+            parts = {{path = 'bucket_id', is_nullable = false, type = 'unsigned'}},
+        }},
+        sharding_key = {'record_id'},
+    }
+    g.cluster.main_server.net_box:call('cartridge_set_schema',
+        {require('yaml').encode({spaces = {test = test_schema}})}
+    )
+
+    g.R1 = assert(g.cluster:server('R-1'))
+    g.SA1 = assert(g.cluster:server('SA-1'))
+    g.SA2 = assert(g.cluster:server('SA-2'))
+
+    g.insertions_passed = {}
+    g.insertions_failed = {}
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+local function _insert(cnt, label)
+    local ret, err = g.R1.net_box:eval([[
+        local ret, err = package.loaded.vshard.router.callrw(...)
+        if ret == nil then
+            return nil, tostring(err)
+        end
+        return ret
+    ]], {1, 'box.space.test:insert', {{1, cnt, label}}})
+
+    if ret == nil then
+        log.error('CNT %d: %s', cnt, err)
+        table.insert(g.insertions_failed, {cnt = cnt, err = err})
+    else
+        table.insert(g.insertions_passed, ret)
+    end
+    return true
+end
+
+local highload_cnt = 0
+local function highload_loop(label)
+    fiber.name('test.highload')
+    log.warn('Highload started ----------')
+    while true do
+        highload_cnt = highload_cnt + 1
+        local ok, err = errors.pcall('E', _insert, highload_cnt, label)
+        if ok == nil then
+            log.error('CNT %d: %s', highload_cnt, err)
+        end
+        fiber.sleep(0.001)
+    end
+end
+
+g.after_each(function()
+    if g.highload_fiber ~= nil
+    and g.highload_fiber:status() == 'suspended'
+    then
+        g.highload_fiber:cancel()
+    end
+
+    log.warn(
+        'Total insertions: %d (%d good, %d failed)',
+        highload_cnt, #g.insertions_passed, #g.insertions_failed
+    )
+    for _, e in ipairs(g.insertions_failed) do
+        log.error('#%d: %s', e.cnt, e.err)
+    end
+end)
+
+function g.test_router()
+    g.highload_fiber = fiber.new(highload_loop, 'A')
+
+    g.cluster:retrying({}, function()
+        t.assert_equals(
+            g.insertions_passed[#g.insertions_passed][3],
+            'A', 'No workload for label A'
+        )
+    end)
+
+    reload(g.R1)
+
+    local cnt = #g.insertions_passed
+    g.cluster:retrying({}, function()
+        assert(#g.insertions_passed > cnt)
+    end)
+
+    g.highload_fiber:cancel()
+
+    t.assert_equals(
+        g.R1.net_box:call(
+            'package.loaded.vshard.router.callrw',
+            {1, 'box.space.test:select'}
+        ),
+        g.insertions_passed
+    )
+
+    -- t.assert_equals(g.insertions_failed, {})
+end
+
+
+function g.test_storage()
+    g.highload_fiber = fiber.new(highload_loop, 'B')
+
+    g.cluster:retrying({}, function()
+        t.assert_equals(
+            g.insertions_passed[#g.insertions_passed][3],
+            'B', 'No workload for label B'
+        )
+    end)
+
+    reload(g.SA1)
+    -- require('fiber').sleep(1)
+    -- do return end
+
+    local cnt = #g.insertions_passed
+    if not pcall(g.cluster.retrying, g.cluster, {timeout = 1}, function()
+        helpers.assert_ge(#g.insertions_passed, cnt+1)
+    end) then g.highload_fiber:cancel() fiber.sleep(10000) end
+
+    g.highload_fiber:cancel()
+
+    t.assert_equals(
+        g.R1.net_box:call(
+            'package.loaded.vshard.router.callrw',
+            {1, 'box.space.test:select'}
+        ),
+        g.insertions_passed
+    )
+
+    t.assert_equals(g.insertions_failed, {})
+
+end


### PR DESCRIPTION
This patch allows hot-reload of cartridge roles code without restarting an instance - `cartridge.reload_roles`.

Reloading starts by stopping all roles and restoring the initial state. It's supposed that a role cleans up the global state when stopped, but even if it doesn't, cartridge kills all fibers and removes global variables and HTTP routes.

All Lua modules that were loaded during `cartridge.cfg` are unloaded, including supplementary modules required by a role. Modules, loaded before `cartridge.cfg` aren't affected.

Instance performs roles reload in a dedicated state `ReloadingRoles`. If reload fails, the instance enters the `ReloadError` state, which can later be retried. Otherwise, if reload succeeds, instance proceeds to the `ConfiguringRoles` state and initializes them as usual with `validate_config()`, `init()`, and `apply_config()` callbacks.

This is an experimental feature, it's only allowed if the application enables it explicitly: `cartridge.cfg({roles_reload_allowed = true})`.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1100 
