### PR TITLE
Disable consistency for single-instance replicaset

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -512,8 +512,13 @@ local function cfg(clusterwide_config)
         vars.failover_fiber:name('cartridge.eventual-failover')
 
     elseif failover_cfg.mode == 'stateful' then
-        if topology_cfg.replicasets[box.info.cluster.uuid].all_rw then
+        local replicaset_uuid = box.info.cluster.uuid
+        if topology_cfg.replicasets[replicaset_uuid].all_rw then
             -- Replicasets with all_rw flag imply that
+            -- consistent switchover isn't necessary
+            vars.consistency_needed = false
+        elseif #topology.get_leaders_order(topology_cfg, replicaset_uuid) == 1 then
+            -- Replicaset consists of a single server
             -- consistent switchover isn't necessary
             vars.consistency_needed = false
         else

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -176,6 +176,11 @@ options: to revert promotion (to re-promote the old leader) or to force it
 inconsistently (all kinds of ``failover_promote`` API has
 ``force_inconsistency`` flag).
 
+Consistent promotion doesn't work for replicasets with `all_rw` flag enabled
+and for single-instance replicasets. In these two cases an instance doesn't
+even try to query `vclockkeeper` and to perform `wait_lsn`. But the coordinator
+still appoints a new leader if the current one dies.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Failover configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Single-instance replicasets has no need to care about consistency.
This patch is inspired by fencing, which shouldn't set read-only
all_rw instances. And so it shouldn't affect loners.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation
