### PR TITLE
Fix remote-control test for Tarantool 2.4+

### DIFF
--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -530,7 +530,6 @@ function g.test_call()
         )
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.PROC_LUA)
         t.assert_equals(err.message, 'ScriptError')
 
         local ok, err = pcall(conn.call, conn, 'eval', {[1] = [[
@@ -541,7 +540,6 @@ function g.test_call()
         ]]})
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.PROC_LUA)
         t.assert_equals(err.message, 'TableError')
 
         local ok, err = pcall(conn.call, conn, 'eval',
@@ -559,7 +557,6 @@ function g.test_call()
         )
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.SYSTEM)
         t.assert_equals(err.message, 'timed out')
 
         t.assert_not(conn.error)
@@ -606,7 +603,6 @@ function g.test_eval()
         )
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.PROC_LUA)
         t.assert_equals(err.message, 'ScriptError')
 
         local ok, err = pcall(conn.eval, conn, [[
@@ -617,7 +613,6 @@ function g.test_eval()
         ]])
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.PROC_LUA)
         t.assert_equals(err.message, 'TableError')
 
         local ok, err = pcall(conn.eval, conn,
@@ -633,7 +628,6 @@ function g.test_eval()
         )
         t.assert_not(ok)
         t.assert_equals(type(err), 'cdata')
-        t.assert_equals(err.code, box.error.SYSTEM)
         t.assert_equals(err.message, 'timed out')
 
         t.assert_not(conn.error)


### PR DESCRIPTION
Up to Tarantool 2.4 errors that come through net.box were treated as ClientError. However, since 2.4 they pass through net.box transparently preserving their error type but not the error code. That being said, remote-control behave similarly to the older versions of Tarantool and provide error codes even if there are missing. So, tests were actualized for both versions of `box.error`.

I didn't forget about

- [x] Tests
- [ ] Changelog
- [ ] Documentation

Close #1058 
