### PR TITLE
Stop vshard storage role when it's disabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Fixed
   operable in this case.
 - Allow applying config when instance is in ``OperationError``. It doesn't cause
   loss of quorum anymore.
+- Stop vshard fibers when the corresponding role is disabled.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -106,7 +106,7 @@ local function stop()
         vars.vshard_cfg[router_name] = nil
 
         if router.failover_fiber ~= nil
-        and router.failover_fiber:status() == 'suspended'
+        and router.failover_fiber:status() ~= 'dead'
         then
             router.failover_fiber:cancel()
             router.failover_fiber = nil

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -8,7 +8,7 @@ local utils = require('cartridge.utils')
 local vshard_utils = require('cartridge.vshard-utils')
 
 vars:new('vshard_cfg')
-local _G_vhsard_backup
+local _G_vshard_backup
 
 local function apply_config(conf, _)
     checks('table', {is_master = 'boolean'})
@@ -31,7 +31,7 @@ local function apply_config(conf, _)
 end
 
 local function init()
-    _G_vhsard_backup = rawget(_G, 'vshard')
+    _G_vshard_backup = rawget(_G, 'vshard')
     rawset(_G, 'vshard', vshard)
 end
 
@@ -57,7 +57,8 @@ local function stop()
         }}
     }, instance_uuid)
     vars.vshard_cfg = nil
-    rawset(_G, 'vshard', _G_vhsard_backup)
+    rawset(_G, 'vshard', _G_vshard_backup)
+    _G_vshard_backup = nil
 end
 
 return {

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -8,6 +8,7 @@ local utils = require('cartridge.utils')
 local vshard_utils = require('cartridge.vshard-utils')
 
 vars:new('vshard_cfg')
+local _G_vhsard_backup
 
 local function apply_config(conf, _)
     checks('table', {is_master = 'boolean'})
@@ -30,6 +31,7 @@ local function apply_config(conf, _)
 end
 
 local function init()
+    _G_vhsard_backup = rawget(_G, 'vshard')
     rawset(_G, 'vshard', vshard)
 end
 
@@ -45,6 +47,7 @@ local function stop()
     vshard.storage.cfg({
         listen = box.cfg.listen,
         read_only = box.cfg.read_only,
+        replication = box.cfg.replication,
         sharding = {[replicaset_uuid] = {
             replicas = {[instance_uuid] = {
                 uri = pool.format_uri(advertise_uri),
@@ -54,7 +57,7 @@ local function stop()
         }}
     }, instance_uuid)
     vars.vshard_cfg = nil
-    rawset(_G, 'vshard', nil)
+    rawset(_G, 'vshard', _G_vhsard_backup)
 end
 
 return {

--- a/test/integration/rebalancing_test.lua
+++ b/test/integration/rebalancing_test.lua
@@ -139,7 +139,6 @@ function g.test()
         expel_sA1
     )
 
-    -- Speed up rebalancing
     g.sA1.net_box:call('vshard.storage.rebalancer_enable')
     helpers.retrying({}, function()
         g.sA1.net_box:call('vshard.storage.rebalancer_wakeup')

--- a/test/integration/rebalancing_test.lua
+++ b/test/integration/rebalancing_test.lua
@@ -8,36 +8,53 @@ g.before_all = function()
     g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = helpers.entrypoint('srv_basic'),
-        cookie = require('digest').urandom(6):hex(),
+        cookie = helpers.random_cookie(),
         use_vshard = true,
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {'vshard-router', 'vshard-storage'},
-                servers = {
-                    {
-                        alias = 'router',
-                        http_port = 8081,
-                        advertise_port = 13301,
-                        instance_uuid = helpers.uuid('a', 'a', 1)
-                    }
-                },
-            },
-            {
-                uuid = helpers.uuid('b'),
-                roles = {'vshard-storage'},
-                servers = {
-                    {
-                        alias = 'storage-1',
-                        http_port = 8082,
-                        advertise_port = 13302,
-                        instance_uuid = helpers.uuid('b', 'b', 1)
-                    }
-                },
-            },
-        },
+        replicasets = {{
+            alias = 'sA',
+            uuid = helpers.uuid('a'),
+            roles = {'myrole', 'vshard-router', 'vshard-storage'},
+            servers = {{instance_uuid = helpers.uuid('a', 'a', 1)}},
+        }, {
+            alias = 'sB',
+            uuid = helpers.uuid('b'),
+            roles = {'myrole', 'vshard-router', 'vshard-storage'},
+            servers = {{instance_uuid = helpers.uuid('b', 'b', 1)}},
+        }},
     })
     g.cluster:start()
+    g.sA1 = g.cluster:server('sA-1')
+    g.sB1 = g.cluster:server('sB-1')
+
+    local test_schema = {
+        engine = 'memtx',
+        is_local = false,
+        temporary = false,
+        format = {
+            {name = 'bucket_id', type = 'unsigned', is_nullable = false},
+            {name = 'record_id', type = 'unsigned', is_nullable = false},
+        },
+        indexes = {{
+            name = 'pk', type = 'TREE', unique = true,
+            parts = {{path = 'record_id', is_nullable = false, type = 'unsigned'}},
+        },  {
+            name = 'bucket_id', type = 'TREE', unique = false,
+            parts = {{path = 'bucket_id', is_nullable = false, type = 'unsigned'}},
+        }},
+        sharding_key = {'record_id'},
+    }
+    g.cluster.main_server.net_box:call('cartridge_set_schema',
+        {require('yaml').encode({spaces = {test = test_schema}})}
+    )
+
+    g.cluster.main_server.net_box:eval([[
+        for i = 1, 3000 do
+            vshard.router.callrw(
+                i, 'box.space.test:insert',
+                {{i, i, string.format('i%04d', i)}}
+            )
+        end
+    ]])
 end
 
 g.after_all = function()
@@ -47,14 +64,9 @@ end
 
 local function set_weight(srv, weight)
     g.cluster.main_server:graphql({
-        query = [[
-            mutation ($uuid: String! $weight: Float!) {
-                edit_replicaset(
-                    uuid: $uuid
-                    weight: $weight
-                )
-            }
-        ]],
+        query = [[mutation ($uuid: String! $weight: Float!) {
+            edit_replicaset(uuid: $uuid weight: $weight)
+        }]],
         variables = {
             uuid = srv.replicaset_uuid,
             weight = weight,
@@ -62,76 +74,131 @@ local function set_weight(srv, weight)
     })
 end
 
-local function disable_storage_role(srv)
+local function set_roles(srv, roles)
     g.cluster.main_server:graphql({
-        query = [[
-            mutation ($uuid: String!) {
-                edit_replicaset(
-                    uuid: $uuid
-                    roles: []
-                )
-            }
-        ]],
+        query = [[mutation ($uuid: String! $roles: [String!]) {
+            edit_replicaset(uuid: $uuid roles: $roles)
+        }]],
         variables = {
             uuid = srv.replicaset_uuid,
+            roles = roles,
         },
     })
 end
 
-local function expel_server(srv)
-    g.cluster.main_server:graphql({
-        query = [[
-            mutation ($uuid: String!) {
-                expel_server(uuid: $uuid)
-            }
-        ]],
-        variables = {
-            uuid = srv.instance_uuid,
-        },
-    })
+local function expel_sA1()
+    return g.sB1:graphql({query = string.format(
+        'mutation{ expel_server(uuid: %q) }',
+        g.sA1.instance_uuid
+    )})
+end
+
+local function get(srv, i)
+    return srv.net_box:eval(
+        'return require("vshard").router.callro(...)',
+        {i, 'box.space.test:get', {i}}
+    )
 end
 
 function g.test()
-    local srv = g.cluster:server('storage-1')
+    t.assert_equals(g.sA1.net_box:call('box.space.test:len'), 1500)
+    t.assert_equals(g.sB1.net_box:call('box.space.test:len'), 1500)
+
+    -- Rebalancer runs on sA1
+    g.sA1.net_box:eval([[assert(vshard.storage.internal.rebalancer_fiber ~= nil)]])
+    g.sB1.net_box:eval([[assert(vshard.storage.internal.rebalancer_fiber == nil)]])
 
     -- Can't disable vshard-storage role with non-zero weight
     t.assert_error_msg_contains(
-        "replicasets[bbbbbbbb-0000-0000-0000-000000000000]" ..
+        "replicasets[aaaaaaaa-0000-0000-0000-000000000000]" ..
         " is a vshard-storage which can't be removed",
-        disable_storage_role, srv
+        set_roles, g.sA1, {}
     )
 
     -- It's prohibited to expel storage with non-zero weight
     t.assert_error_msg_contains(
-        "replicasets[bbbbbbbb-0000-0000-0000-000000000000]" ..
+        "replicasets[aaaaaaaa-0000-0000-0000-000000000000]" ..
         " is a vshard-storage which can't be removed",
-        expel_server, srv
+        expel_sA1
     )
 
-    set_weight(srv, 0)
+    g.sA1.net_box:call('vshard.storage.rebalancer_disable')
+    set_weight(g.sA1, 0)
 
     -- Can't disable vshard-storage role until rebalancing finishes
     t.assert_error_msg_contains(
-        "replicasets[bbbbbbbb-0000-0000-0000-000000000000]" ..
+        "replicasets[aaaaaaaa-0000-0000-0000-000000000000]" ..
         " rebalancing isn't finished yet",
-        disable_storage_role, srv
+        set_roles, g.sA1, {}
     )
 
     -- It's prohibited to expel storage until rebalancing finishes
-    t.assert_error_msg_contains(
-        "replicasets[bbbbbbbb-0000-0000-0000-000000000000]" ..
+    t.assert_error_msg_equals(
+        "replicasets[aaaaaaaa-0000-0000-0000-000000000000]" ..
         " rebalancing isn't finished yet",
-        expel_server, srv
+        expel_sA1
     )
 
     -- Speed up rebalancing
-    srv.net_box:eval([[
-        while vshard.storage.buckets_count() > 0 do
-            vshard.storage.rebalancer_wakeup()
-            require('fiber').sleep(0.1)
+    g.sA1.net_box:call('vshard.storage.rebalancer_enable')
+    helpers.retrying({}, function()
+        g.sA1.net_box:call('vshard.storage.rebalancer_wakeup')
+
+        t.assert_equals(g.sA1.net_box:call('vshard.storage.buckets_count'), 0)
+        t.assert_equals(g.sB1.net_box:call('vshard.storage.buckets_count'), 3000)
+        t.assert_equals(g.sA1.net_box:call('box.space.test:len'), 0)
+        t.assert_equals(g.sB1.net_box:call('box.space.test:len'), 3000)
+    end)
+
+    set_roles(g.sA1, {'myrole'})
+
+    local ok, err = get(g.sA1, 1500)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        type = 'ShardingError',
+        name = 'MISSING_MASTER',
+        replicaset_uuid = g.sA1.replicaset_uuid,
+        message = 'Master is not configured for' ..
+            ' replicaset ' .. g.sA1.replicaset_uuid,
+    })
+    t.assert_equals(get(g.sB1, 1), {1, 1, 'i0001'})
+    t.assert_equals(get(g.sB1, 3000), {3000, 3000, 'i3000'})
+
+    helpers.retrying({}, function() g.sA1.net_box:eval([[
+        for _, f in pairs(require('fiber').info()) do
+            if f.name:startswith('vshard.') then
+                error('Fiber ' .. f.name .. ' still alive', 0)
+            end
         end
+    ]]) end)
+
+    -- sB1 remains the only storage, rebalancer should be there.
+    g.sB1.net_box:eval([[
+        assert(vshard.storage.internal.rebalancer_fiber ~= nil)
+    ]])
+    -- And not on sA1.
+    g.sA1.net_box:eval([[
+        assert(rawget(_G, 'vshard') == nil)
+        assert(_G.__module_vshard_storage.rebalancer_fiber == nil)
+        assert(not box.info.ro)
     ]])
 
-    disable_storage_role(srv)
-    expel_server(srv)
+    -- Check that re-enabling vshard works
+    set_roles(g.sA1, {'myrole', 'vshard-router', 'vshard-storage'})
+    set_weight(g.sA1, 2)
+
+    helpers.retrying({}, function()
+        t.assert_equals(g.sA1.net_box:call('vshard.storage.buckets_count'), 2000)
+        t.assert_equals(g.sB1.net_box:call('vshard.storage.buckets_count'), 1000)
+    end)
+
+    t.assert_equals(g.sA1.net_box:call('vshard.router.bucket_count'), 3000)
+    t.assert_equals(g.sB1.net_box:call('vshard.router.bucket_count'), 3000)
+    t.assert_equals(g.sA1.net_box:call('box.space.test:len'), 2000)
+    t.assert_equals(g.sB1.net_box:call('box.space.test:len'), 1000)
+
+    t.assert_equals(get(g.sA1, 1), {1, 1, 'i0001'})
+    t.assert_equals(get(g.sB1, 1), {1, 1, 'i0001'})
+    t.assert_equals(get(g.sA1, 3000), {3000, 3000, 'i3000'})
+    t.assert_equals(get(g.sB1, 3000), {3000, 3000, 'i3000'})
 end


### PR DESCRIPTION
This patch workarounds disabling of vshard-storage and vshard-router roles. Instead of fair stopping (which isn't implemented in vshard), we apply a fake empty config. The test ensures that the rebalancer keeps working on at most one of the storages and that both roles can be re-enabled later.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1120
