### PR TITLE
Add failover_timeout param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Added
 - Implement a fencing feature. It protects a replicaset from the presence of
   multiple leaders when the network is partitioned and forces the leader to
   become read-only.
+- New failover parameter ``failover_timout`` specifies the time (in seconds)
+  used by membership to mark ``suspect`` members as ``dead`` which triggers
+  failover.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -683,6 +683,9 @@ local function cfg(clusterwide_config)
         )
     end
 
+    require("membership.options").SUSPECT_TIMEOUT_SECONDS =
+        failover_cfg.failover_timeout
+
     accept_appointments(first_appointments)
 
     local ok, err = constitute_oneself(vars.cache.active_leaders, {

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -29,7 +29,7 @@ local function get_params()
     -- @tfield ?string state_provider
     --   Supported state providers are "tarantool" and "etcd2".
     -- @tfield number failover_timeout
-    --   (added in v2.3.0-48)
+    --   (added in v2.3.0-52)
     --   Timeout (in seconds), used by membership to
     --   mark `suspect` members as `dead` (default: 3)
     -- @tfield ?table tarantool_params
@@ -60,6 +60,8 @@ end
 -- @tparam table opts
 -- @tparam ?string opts.mode
 -- @tparam ?string opts.state_provider
+-- @tparam ?string opts.failover_timeout
+--   (added in v2.3.0-52)
 -- @tparam ?table opts.tarantool_params
 -- @tparam ?table opts.etcd2_params
 --   (added in v2.1.2-26)

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -28,6 +28,10 @@ local function get_params()
     --   Supported modes are "disabled", "eventual" and "stateful"
     -- @tfield ?string state_provider
     --   Supported state providers are "tarantool" and "etcd2".
+    -- @tfield number failover_timeout
+    --   (added in v2.3.0-48)
+    --   Timeout (in seconds), used by membership to
+    --   mark `suspect` members as `dead` (default: 3)
     -- @tfield ?table tarantool_params
     --   (added in v2.0.2-2)
     -- @tfield string tarantool_params.uri
@@ -37,7 +41,7 @@ local function get_params()
     -- @tfield string etcd2_params.prefix
     --   Prefix used for etcd keys: `<prefix>/lock` and
     --   `<prefix>/leaders`
-    -- @tfield ?number lock_delay
+    -- @tfield ?number etcd2_params.lock_delay
     --   Timeout (in seconds), determines lock's time-to-live (default: 10)
     -- @tfield ?table etcd2_params.endpoints
     --   URIs that are used to discover and to access etcd cluster instances.
@@ -68,6 +72,7 @@ local function set_params(opts)
         state_provider = '?string',
         tarantool_params = '?table',
         etcd2_params = '?table',
+        failover_timeout = '?number',
     })
 
     local topology_cfg = confapplier.get_deepcopy('topology')
@@ -100,6 +105,10 @@ local function set_params(opts)
     end
     if opts.etcd2_params ~= nil then
         topology_cfg.failover.etcd2_params = opts.etcd2_params
+    end
+
+    if opts.failover_timeout ~= nil then
+        topology_cfg.failover.failover_timeout = opts.failover_timeout
     end
 
     local ok, err = twophase.patch_clusterwide({topology = topology_cfg})

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -35,6 +35,7 @@ vars:new('known_roles', {
         --     username = nil | string,
         --     password = nil | string,
         -- },
+        -- failover_timeout = nil | number,
     },
     servers = {
         -- ['instance-uuid-1'] = 'expelled',
@@ -341,6 +342,13 @@ local function validate_failover_schema(field, topology)
             field, topology.failover.mode
         )
 
+        e_config:assert(
+            topology.failover.failover_timeout == nil or
+            type(topology.failover.failover_timeout) == 'number',
+            '%s.failover.failover_timeout must be a number, got %s',
+            field, type(topology.failover.failover_timeout)
+        )
+
         if topology.failover.mode == 'stateful' then
             e_config:assert(
                 topology.failover.state_provider ~= nil,
@@ -507,6 +515,7 @@ local function validate_failover_schema(field, topology)
             -- See bug https://github.com/tarantool/cartridge/issues/754
             ['enabled'] = true,
             ['coordinator_uri'] = true,
+            ['failover_timeout'] = true,
         }
         for k, _ in pairs(topology.failover) do
             e_config:assert(
@@ -692,6 +701,7 @@ local function get_failover_params(topology_cfg)
             state_provider = topology_cfg.failover.state_provider,
             tarantool_params = topology_cfg.failover.tarantool_params,
             etcd2_params = table.deepcopy(topology_cfg.failover.etcd2_params),
+            failover_timeout = topology_cfg.failover.failover_timeout,
         }
 
         if ret.etcd2_params ~= nil then
@@ -750,6 +760,10 @@ local function get_failover_params(topology_cfg)
 
     if ret.etcd2_params.password == nil then
         ret.etcd2_params.password = ""
+    end
+
+    if ret.failover_timeout == nil then
+        ret.failover_timeout = 3
     end
 
     return ret

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -342,12 +342,18 @@ local function validate_failover_schema(field, topology)
             field, topology.failover.mode
         )
 
-        e_config:assert(
-            topology.failover.failover_timeout == nil or
-            type(topology.failover.failover_timeout) == 'number',
-            '%s.failover.failover_timeout must be a number, got %s',
-            field, type(topology.failover.failover_timeout)
-        )
+        if topology.failover.failover_timeout ~= nil then
+            e_config:assert(
+                type(topology.failover.failover_timeout) == 'number',
+                '%s.failover.failover_timeout must be a number, got %s',
+                field, type(topology.failover.failover_timeout)
+            )
+            e_config:assert(
+                topology.failover.failover_timeout >= 0,
+                '%s.failover.failover_timeout must be non-negative, got %s',
+                field, topology.failover.failover_timeout
+            )
+        end
 
         if topology.failover.mode == 'stateful' then
             e_config:assert(

--- a/cartridge/webui/api-failover.lua
+++ b/cartridge/webui/api-failover.lua
@@ -61,6 +61,7 @@ local gql_type_userapi = gql_types.object({
                 ' failover mode. Supported types are "tarantool" and' ..
                 ' "etcd2".',
         },
+        failover_timeout = gql_types.float,
         tarantool_params = gql_type_tarantool_cfg,
         etcd2_params = gql_type_etcd2_cfg,
     }
@@ -138,6 +139,7 @@ local function init(graphql)
         args = {
             mode = gql_types.string,
             state_provider = gql_types.string,
+            failover_timeout = gql_types.float,
             tarantool_params = gql_type_tarantool_cfg_input,
             etcd2_params = gql_type_etcd2_cfg_input,
         },

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Tue Oct 13 2020 16:59:24 GMT+0300 (Moscow Standard Time)
+# timestamp: Thu Nov 19 2020 17:14:28 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -103,14 +103,16 @@ type Error {
 
 """Failover parameters managent"""
 type FailoverAPI {
-  """Supported modes are "disabled", "eventual" and "stateful"."""
-  mode: String!
-  tarantool_params: FailoverStateProviderCfgTarantool
+  failover_timeout: Float
 
   """
   Type of external storage for the stateful failover mode. Supported types are "tarantool" and "etcd2".
   """
   state_provider: String
+  tarantool_params: FailoverStateProviderCfgTarantool
+
+  """Supported modes are "disabled", "eventual" and "stateful"."""
+  mode: String!
   etcd2_params: FailoverStateProviderCfgEtcd2
 }
 
@@ -207,7 +209,7 @@ type MutationApicluster {
   failover(enabled: Boolean!): Boolean!
 
   """Configure automatic failover."""
-  failover_params(mode: String, tarantool_params: FailoverStateProviderCfgInputTarantool, state_provider: String, etcd2_params: FailoverStateProviderCfgInputEtcd2): FailoverAPI!
+  failover_params(failover_timeout: Float, state_provider: String, tarantool_params: FailoverStateProviderCfgInputTarantool, mode: String, etcd2_params: FailoverStateProviderCfgInputEtcd2): FailoverAPI!
 
   """Checks that schema can be applied on cluster"""
   check_schema(as_yaml: String!): DDLCheckResult!

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -63,10 +63,10 @@ instance in the cluster thinks that the leader is the first **healthy** instance
 in the failover priority list, while instance health is determined according to
 the membership status (the SWIM protocol).
 
-The member is considered to be healthy if both is true:
+The member is considered healthy if both are true:
 
 1. It reports either ``ConfiguringRoles`` or ``RolesConfigured`` state;
-2. And it's SWIM status is either ``alive`` or ``suspect``.
+2. Its SWIM status is either ``alive`` or ``suspect``.
 
 A ``suspect`` member becomes ``dead`` after the ``failover_timout`` expires.
 

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -63,6 +63,13 @@ instance in the cluster thinks that the leader is the first **healthy** instance
 in the failover priority list, while instance health is determined according to
 the membership status (the SWIM protocol).
 
+The member is considered to be healthy if both is true:
+
+1. It reports either ``ConfiguringRoles`` or ``RolesConfigured`` state;
+2. And it's SWIM status is either ``alive`` or ``suspect``.
+
+A ``suspect`` member becomes ``dead`` after the ``failover_timout`` expires.
+
 Leader election is done as follows.
 Suppose there are two replica sets in the cluster:
 
@@ -121,7 +128,7 @@ algorithm is slightly different from that in case of eventual failover:
   appoints the first leader according to the failover priority, regardless of
   the SWIM status.
 
-* If a leader becomes degraded, the coordinator makes a decision. A new
+* If a leader becomes ``dead``, the coordinator makes a decision. A new
   leader is the first healthy instance from the failover priority list.
   If an old leader recovers, no leader change is made until the current
   leader down. Changing failover priority doesn't affect this.
@@ -215,6 +222,8 @@ These are clusterwide parameters:
 
 * ``mode``: "disabled" / "eventual" / "stateful".
 * ``state_provider``: "tarantool" / "etcd".
+* ``failover_timeout`` -- time (in seconds) to mark ``suspect`` members
+  as ``dead`` and trigger failover.
 * ``tarantool_params``: ``{uri = "...", password = "..."}``.
 * ``etcd2_params``: ``{endpoints = {...}, prefix = "/", lock_delay = 10, username = "", password = ""}``.
 * ``fencing_pause`` -- the period of performing the check;

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -305,10 +305,15 @@ g.test_api_failover = function()
     t.assert_covers(_call('failover_get_params'), {mode = 'eventual'})
 
     t.assert_covers(set_failover_params(
-        {failover_timeout = 5}),
-        {failover_timeout = 5}
+        {failover_timeout = 0}),
+        {failover_timeout = 0}
     )
-    t.assert_covers(get_failover_params(), {failover_timeout = 5})
+    t.assert_covers(get_failover_params(), {failover_timeout = 0})
+    t.assert_equals(
+        cluster.main_server.net_box:eval([[
+            return require('membership.options').SUSPECT_TIMEOUT_SECONDS
+        ]]), 0
+    )
 
     -- Set with new GraphQL API
     t.assert_error_msg_equals(
@@ -340,7 +345,7 @@ g.test_api_failover = function()
             etcd2_params = {lock_delay = 36.6, prefix = 'kv'},
         }), {
             mode = 'eventual',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = {
                 prefix = 'kv',
                 lock_delay = 36.6,
@@ -358,7 +363,7 @@ g.test_api_failover = function()
             etcd2_params = {endpoints = {'goo.gl:9'}},
         }), {
             mode = 'eventual',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = {
                 prefix = '/',
                 lock_delay = 10,
@@ -373,7 +378,7 @@ g.test_api_failover = function()
         get_failover_params(),
         {
             mode = 'eventual',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = etcd2_params,
         }
     )
@@ -383,7 +388,7 @@ g.test_api_failover = function()
         set_failover_params({tarantool_params = tarantool_params}),
         {
             mode = 'eventual',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = etcd2_params,
             tarantool_params = tarantool_params,
         }
@@ -393,7 +398,7 @@ g.test_api_failover = function()
         {
             mode = 'stateful',
             state_provider = 'tarantool',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = etcd2_params,
             tarantool_params = tarantool_params,
         }
@@ -404,7 +409,7 @@ g.test_api_failover = function()
         {
             mode = 'stateful',
             state_provider = 'tarantool',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = etcd2_params,
             tarantool_params = tarantool_params,
         }
@@ -414,7 +419,7 @@ g.test_api_failover = function()
         {
             mode = 'stateful',
             state_provider = 'tarantool',
-            failover_timeout = 5,
+            failover_timeout = 0,
             etcd2_params = etcd2_params,
             tarantool_params = tarantool_params,
         }
@@ -424,7 +429,7 @@ g.test_api_failover = function()
     -- Set with new Lua API
     t.assert_equals(_call('failover_set_params', {
         mode = 'disabled',
-        failover_timeout = 5,
+        failover_timeout = 3,
         etcd2_params = {},
     }), true)
 
@@ -444,7 +449,7 @@ g.test_api_failover = function()
         {
             mode = 'disabled',
             state_provider = 'tarantool',
-            failover_timeout = 5,
+            failover_timeout = 3,
             etcd2_params = etcd2_defaults,
             tarantool_params = tarantool_params,
         }
@@ -454,16 +459,10 @@ g.test_api_failover = function()
         {
             mode = 'disabled',
             state_provider = 'tarantool',
-            failover_timeout = 5,
+            failover_timeout = 3,
             tarantool_params = tarantool_params,
             etcd2_params = etcd2_defaults,
         }
-    )
-
-    -- set failover_timeout to default
-    t.assert_covers(set_failover_params(
-        {failover_timeout = 3}),
-        {failover_timeout = 3}
     )
 end
 

--- a/test/integration/fencing_test.lua
+++ b/test/integration/fencing_test.lua
@@ -176,6 +176,10 @@ local q_set_fencing_params = [[
 
     failover.cfg(confapplier.get_active_config())
 ]]
+local q_get_failover_params = [[
+    local cartridge = require('cartridge')
+    return cartridge.failover_get_params()
+]]
 local q_is_vclockkeeper = [[
     local failover = require('cartridge.failover')
     return failover.is_vclockkeeper()
@@ -184,6 +188,51 @@ local q_leadership = [[
     local failover = require('cartridge.failover')
     return failover.get_active_leaders()[...]
 ]]
+
+add('test_failover_timeout', function()
+    A1:graphql({
+        query = [[
+            mutation {
+                cluster {
+                    failover_params(failover_timeout: 4) {}
+                }
+            }
+        ]],
+    })
+
+
+    local failover_params = A1.net_box:eval(q_get_failover_params)
+    local membership_suspect = A1.net_box:eval([[
+        return require('membership.options').SUSPECT_TIMEOUT_SECONDS
+    ]])
+    t.assert_equals(failover_params.failover_timeout, 4)
+    t.assert_equals(failover_params.failover_timeout, membership_suspect)
+
+    t.assert_error_msg_contains(
+        'bad argument opts.failover_timeout'..
+        ' to nil (?number expected, got string)',
+        function()
+            A1.net_box:eval(
+                [[return require('cartridge').failover_set_params(...)]],
+                {{failover_timeout = 'kinda sus'}}
+            )
+        end
+    )
+
+    A1.net_box:eval([[
+        local cartridge = require('cartridge')
+        cartridge.failover_set_params({
+            failover_timeout = 0,
+        })
+    ]])
+
+    local failover_params = A1.net_box:eval(q_get_failover_params)
+    local membership_suspect = A1.net_box:eval([[
+        return require('membership.options').SUSPECT_TIMEOUT_SECONDS
+    ]])
+    t.assert_equals(failover_params.failover_timeout, 0)
+    t.assert_equals(membership_suspect, 0)
+end)
 
 add('test_basics', function(g)
     t.assert(g.session:set_leaders({{uB, uB1}}))

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -167,11 +167,32 @@ failover:
   state_provider: joe
 ...]])
 
+    check_config('topology_new.failover.failover_timeout must be a number, got string',
+[[---
+failover:
+  mode: disabled
+  failover_timeout: kinda sus
+...]])
+
+    check_config('topology_new.failover.failover_timeout must be non-negative, got -1',
+[[---
+failover:
+  mode: disabled
+  failover_timeout: -1
+...]])
+
+    check_config('topology_new.failover.failover_timeout must be non-negative, got nan',
+[[---
+failover:
+  mode: disabled
+  failover_timeout: NaN
+...]])
 
     check_config('topology_new.failover.tarantool_params.uri: Invalid URI ":-0"',
 [[---
 failover:
   mode: eventual
+  failover_timeout: 0
   tarantool_params: {uri: ":-0"}
 ...]])
 
@@ -868,6 +889,7 @@ auth: true
 failover:
   mode: stateful
   state_provider: tarantool
+  failover_timeout: Inf
   tarantool_params:
     uri: stateboard.com:4401
     password: ''


### PR DESCRIPTION
Prerequisite for #1107. `failover_timeout` sets membership suspect timeout. It is available via lua-api : 

```lua
cartridge.failover_set_params({
    failover_timeout = 0,
})
```

and graphql-api:

```graphql
mutation {
    cluster {
        failover_params(failover_timeout: 0) {}
    }
}
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation
