### PR TITLE
Add assert_upvalues util

### DIFF
--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -1,3 +1,8 @@
+--- Auxiliary functions (internal module).
+--
+-- @module cartridge.utils
+-- @local
+
 local fio = require('fio')
 local ffi = require('ffi')
 local bit = require('bit')
@@ -10,7 +15,6 @@ local FcntlError = errors.new_class('FcntlError')
 local OpenFileError = errors.new_class('OpenFileError')
 local ReadFileError = errors.new_class('ReadFileError')
 local WriteFileError = errors.new_class('WriteFileError')
-
 
 ffi.cdef[[
 int getppid(void);
@@ -99,6 +103,46 @@ local function table_append(to, from)
         table.insert(to, item)
     end
     return to
+end
+
+--- Verify function closure.
+--
+-- Raise an error when expectations aren't met.
+--
+-- @function assert_upvalues
+-- @local
+-- @tparam function fn
+-- @tparam {string,...} upvalues
+-- @raise "Unexpected upvalues"
+-- @usage
+--   local x, y
+--   local function foo() return x, y end
+--   assert_upvalues(foo, {'x'})
+--   -- error: Unexpected upvalues, [x] expected, got [x, y]
+local function assert_upvalues(fn, ups)
+    checks('function', 'table')
+
+    local got = {}
+    for i = 1, debug.getinfo(fn, 'u').nups do
+        got[i] = debug.getupvalue(fn, i)
+    end
+
+    table.sort(got)
+    table.sort(ups)
+
+    if #got ~= #ups then goto fail end
+    for i = 1, #ups do
+        if got[i] ~= ups[i] then goto fail end
+    end
+
+    do return end
+
+    ::fail::
+    local err = string.format(
+        'Unexpected upvalues, [%s] expected, got [%s]',
+        table.concat(ups, ', '), table.concat(got, ', ')
+    )
+    error(err, 2)
 end
 
 local function file_exists(name)
@@ -383,6 +427,8 @@ return {
     table_find = table_find,
     table_count = table_count,
     table_append = table_append,
+
+    assert_upvalues = assert_upvalues,
 
     mktree = mktree,
     file_read = file_read,

--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -1,0 +1,18 @@
+local t = require('luatest')
+local g = t.group()
+
+local utils = require('cartridge.utils')
+
+function g.test_upvalues()
+    local f
+    do
+        local t1, t2 = 1, 2
+        function f() return t1, t2 end
+    end
+
+    utils.assert_upvalues(f, {'t1', 't2'})
+    t.assert_error_msg_equals(
+        'Unexpected upvalues, [t3] expected, got [t1, t2]',
+        utils.assert_upvalues, f, {'t3'}
+    )
+end


### PR DESCRIPTION
It's necessary for hot-reload tests to ensure that functions make no
excess closures.

I didn't forget about

- [x] Tests
- [x] Changelog (not a public feature)
- [x] Documentation

Part of #1116
