### PR TITLE
Refactor internal roles API

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -587,15 +587,9 @@ local function cfg(opts, box_opts)
         service_registry.set('httpd', httpd)
     end
 
-    local ok, err = roles.register_role('cartridge.roles.coordinator')
+    local ok, err = roles.cfg(opts.roles)
     if not ok then
         return nil, err
-    end
-    for _, role in ipairs(opts.roles or {}) do
-        local ok, err = roles.register_role(role)
-        if not ok then
-            return nil, err
-        end
     end
 
     -- metrics.init()

--- a/cartridge/roles.lua
+++ b/cartridge/roles.lua
@@ -17,108 +17,132 @@ local errors = require('errors')
 
 local vars = require('cartridge.vars').new('cartridge.roles')
 local utils = require('cartridge.utils')
-local topology = require('cartridge.topology')
 local service_registry = require('cartridge.service-registry')
 
 local RegisterRoleError = errors.new_class('RegisterRoleError')
 local ValidateConfigError = errors.new_class('ValidateConfigError')
 local ApplyConfigError = errors.new_class('ApplyConfigError')
 
-vars:new('known_roles', {
-    -- [i] = mod,
-    -- [role_name] = mod,
-})
-vars:new('roles_dependencies', {
-    -- [role_name] = {role_name_1, role_name_2}
-})
-vars:new('roles_dependants', {
-    -- [role_name] = {role_name_1, role_name_2}
-})
+vars:new('by_number', {})
+vars:new('by_package', {})
+vars:new('by_role_name', {})
 
+local function register_role(ctx, module_name)
+    checks({
+        by_number = 'table',
+        by_package = 'table',
+        by_role_name = 'table',
+    }, 'string')
 
-local function register_role(module_name)
-    checks('string')
-    local function e(...)
-        vars.known_roles = {}
-        vars.roles_dependencies = {}
-        vars.roles_dependants = {}
-        return RegisterRoleError:new(2, ...)
-    end
-    local mod = package.loaded[module_name]
-    if type(mod) == 'table' and vars.known_roles[mod.role_name] then
+    if ctx.by_package[module_name] then
         -- Already loaded
-        return mod
+        return ctx.by_package[module_name]
     end
 
-    local mod, err = RegisterRoleError:pcall(require, module_name)
-    if not mod then
-        return nil, e(err)
-    elseif type(mod) ~= 'table' then
-        return nil, e('Module %q must return a table', module_name)
+    local M, err = RegisterRoleError:pcall(require, module_name)
+    if err ~= nil then
+        return nil, err
+    elseif type(M) ~= 'table' then
+        return nil, RegisterRoleError:new(
+            'Module %q must return a table, got %s', module_name, type(M)
+        )
     end
 
-    if mod.role_name == nil then
-        mod.role_name = module_name
+    local role = {
+        M = M,
+        deps = {},
+        role_name = M.role_name or module_name,
+        module_name = module_name,
+    }
+
+    if type(role.role_name) ~= 'string' then
+        return nil, RegisterRoleError:new(
+            'Module %q role_name must be a string, got %s',
+            module_name, type(role.role_name)
+        )
     end
 
-    if type(mod.role_name) ~= 'string' then
-        return nil, e('Module %q role_name must be a string', module_name)
-    end
-
-    if vars.known_roles[mod.role_name] ~= nil then
-        return nil, e('Role %q name clash', mod.role_name)
-    end
-
-    local dependencies = mod.dependencies or {}
+    local dependencies = M.dependencies or {}
     if type(dependencies) ~= 'table' then
-        return nil, e('Module %q dependencies must be a table', module_name)
+        return nil, RegisterRoleError:new(
+            'Module %q dependencies must be a table, got %s',
+            module_name, type(dependencies)
+        )
     end
 
-    vars.roles_dependencies[mod.role_name] = {}
-    vars.roles_dependants[mod.role_name] = {}
-    vars.known_roles[mod.role_name] = mod
+    if ctx.by_role_name[role.role_name] ~= nil then
+        return nil, RegisterRoleError:new(
+            'Role %q name clash between %s and %s',
+            role.role_name, module_name,
+            ctx.by_role_name[role.role_name].module_name
+        )
+    end
 
-    local function deps_append(tbl, deps)
-        for _, dep in pairs(deps) do
-            if not utils.table_find(tbl, dep) then
-                table.insert(tbl, dep)
+    ctx.by_package[module_name] = role
+    ctx.by_role_name[role.role_name] = role
+
+    for _, dep in ipairs(dependencies) do
+        local dep_role, err = register_role(ctx, dep)
+        if not dep_role then
+            return nil, err
+        end
+
+        if not utils.table_find(role.deps, dep_role) then
+            table.insert(role.deps, dep_role)
+        end
+
+        -- Inherit subdependencies
+        for _, subdep in ipairs(dep_role.deps) do
+            if not utils.table_find(role.deps, subdep) then
+                table.insert(role.deps, subdep)
             end
         end
     end
 
-    for _, dep_name in ipairs(dependencies) do
-        local dep_mod, err = register_role(dep_name)
-        if not dep_mod then
+    if utils.table_find(role.deps, role) then
+        return nil, RegisterRoleError:new(
+            'Module %q circular dependency prohibited', module_name
+        )
+    end
+
+    table.insert(ctx.by_number, role)
+    return role
+end
+utils.assert_upvalues(register_role, {
+    'RegisterRoleError',
+    'register_role',
+    'checks',
+    'utils'
+})
+
+local function cfg(roles)
+    checks('table')
+    local ctx = {
+        by_number = {},
+        by_package = {},
+        by_role_name = {},
+    }
+
+    local ok, err = register_role(ctx, 'cartridge.roles.coordinator')
+    if not ok then
+        return nil, err
+    end
+    for _, role in ipairs(roles or {}) do
+        local ok, err = register_role(ctx, role)
+        if not ok then
             return nil, err
         end
-
-        deps_append(
-            vars.roles_dependencies[mod.role_name],
-            {dep_mod.role_name}
-        )
-        deps_append(
-            vars.roles_dependencies[mod.role_name],
-            vars.roles_dependencies[dep_mod.role_name]
-        )
-
-        deps_append(
-            vars.roles_dependants[dep_mod.role_name],
-            {mod.role_name}
-        )
     end
 
-    if utils.table_find(vars.roles_dependencies[mod.role_name], mod.role_name) then
-        return nil, e('Module %q circular dependency not allowed', module_name)
-    end
-    topology.add_known_role(mod.role_name)
-    vars.known_roles[#vars.known_roles+1] = mod
-
-    return mod
+    vars.by_number = ctx.by_number
+    vars.by_package = ctx.by_package
+    vars.by_role_name = ctx.by_role_name
+    return true
 end
 
 local function get_role(role_name)
     checks('string')
-    return vars.known_roles[role_name]
+    return vars.by_role_name[role_name]
 end
 
 --- List all registered roles.
@@ -131,8 +155,8 @@ end
 local function get_all_roles()
     local ret = {}
 
-    for _, mod in ipairs(vars.known_roles) do
-        table.insert(ret, mod.role_name)
+    for _, role in ipairs(vars.by_number) do
+        table.insert(ret, role.role_name)
     end
 
     return ret
@@ -148,9 +172,11 @@ end
 local function get_known_roles()
     local ret = {}
 
-    for _, mod in ipairs(vars.known_roles) do
-        if not (mod.permanent or mod.hidden) then
-            table.insert(ret, mod.role_name)
+    for _, role in ipairs(vars.by_number) do
+        if not role.M.permanent
+        and not role.M.hidden
+        then
+            table.insert(ret, role.role_name)
         end
     end
 
@@ -175,9 +201,9 @@ local function get_enabled_roles(roles)
 
     local ret = {}
 
-    for _, mod in ipairs(vars.known_roles) do
-        if mod.permanent then
-            ret[mod.role_name] = true
+    for _, role in ipairs(vars.by_number) do
+        if role.M.permanent then
+            ret[role.role_name] = true
         end
     end
 
@@ -189,26 +215,21 @@ local function get_enabled_roles(roles)
             role_name, enabled = k, v
         end
 
-        repeat -- until true
-            if not enabled then
-                break
-            end
-
+        if enabled then
             ret[role_name] = true
-
-            local deps = vars.roles_dependencies[role_name]
-            if deps == nil then
-                break
+            local role = vars.by_role_name[role_name]
+            if role ~= nil then
+                for _, dep_role in ipairs(role.deps) do
+                    ret[dep_role.role_name] = true
+                end
             end
-
-            for _, dep_name in ipairs(deps) do
-                ret[dep_name] = true
-            end
-        until true
+        end
     end
 
     return ret
 end
+
+
 
 --- List role dependencies.
 -- Including sub-dependencies.
@@ -220,11 +241,10 @@ end
 local function get_role_dependencies(role_name)
     checks('?string')
     local ret = {}
-
-    for _, dep_name in ipairs(vars.roles_dependencies[role_name]) do
-        local mod = vars.known_roles[dep_name]
-        if not (mod.permanent or mod.hidden) then
-            table.insert(ret, mod.role_name)
+    local role = vars.by_role_name[role_name]
+    for _, dep_role in ipairs(role.deps) do
+        if not (dep_role.M.permanent or dep_role.M.hidden) then
+            table.insert(ret, dep_role.role_name)
         end
     end
 
@@ -252,15 +272,15 @@ local function validate_config(conf_new, conf_old)
         error(err, 2)
     end
 
-    for _, mod in ipairs(vars.known_roles) do
-        if type(mod.validate_config) == 'function' then
+    for _, role in ipairs(vars.by_number) do
+        if type(role.M.validate_config) == 'function' then
             local ok, err = ValidateConfigError:pcall(
-                mod.validate_config, conf_new, conf_old
+                role.M.validate_config, conf_new, conf_old
             )
             if not ok then
                 err = err or ValidateConfigError:new(
                     'Role %q method validate_config() returned %s',
-                    mod.role_name, ok
+                    role.role_name, ok
                 )
                 return nil, err
             end
@@ -293,15 +313,14 @@ local function apply_config(conf, opts)
 
     local err
     local enabled_roles = get_enabled_roles(my_replicaset.roles)
-    for _, mod in ipairs(vars.known_roles) do
-        local role_name = mod.role_name
-        if enabled_roles[role_name] then
+    for _, role in ipairs(vars.by_number) do
+        if enabled_roles[role.role_name] then
             -- Start the role
-            if (service_registry.get(role_name) == nil)
-            and (type(mod.init) == 'function')
+            if (service_registry.get(role.role_name) == nil)
+            and (type(role.M.init) == 'function')
             then
                 local _, _err = ApplyConfigError:pcall(
-                    mod.init, opts
+                    role.M.init, opts
                 )
                 if _err ~= nil then
                     if err == nil then
@@ -312,11 +331,11 @@ local function apply_config(conf, opts)
                 end
             end
 
-            service_registry.set(role_name, mod)
+            service_registry.set(role.role_name, role.M)
 
-            if type(mod.apply_config) == 'function' then
+            if type(role.M.apply_config) == 'function' then
                 local _, _err = ApplyConfigError:pcall(
-                    mod.apply_config, conf, opts
+                    role.M.apply_config, conf, opts
                 )
                 if _err ~= nil then
                     if err == nil then
@@ -327,11 +346,11 @@ local function apply_config(conf, opts)
             end
         else
             -- Stop the role
-            if (service_registry.get(role_name) ~= nil)
-            and (type(mod.stop) == 'function')
+            if (service_registry.get(role.role_name) ~= nil)
+            and (type(role.M.stop) == 'function')
             then
                 local _, _err = ApplyConfigError:pcall(
-                    mod.stop, opts
+                    role.M.stop, opts
                 )
                 if _err ~= nil then
                     if err == nil then
@@ -341,7 +360,7 @@ local function apply_config(conf, opts)
                 end
             end
 
-            service_registry.set(role_name, nil)
+            service_registry.set(role.role_name, nil)
         end
 
         ::continue::
@@ -356,7 +375,7 @@ end
 
 
 return {
-    register_role = register_role,
+    cfg = cfg,
     get_role = get_role,
     get_all_roles = get_all_roles,
     get_known_roles = get_known_roles,

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -10,15 +10,12 @@ local checks = require('checks')
 local errors = require('errors')
 local membership = require('membership')
 
-local vars = require('cartridge.vars').new('cartridge.topology')
 local pool = require('cartridge.pool')
+local roles = require('cartridge.roles')
 local utils = require('cartridge.utils')
 local label_utils = require('cartridge.label-utils')
 
 local e_config = errors.new_class('Invalid cluster topology config')
-vars:new('known_roles', {
-    -- [role_name] = true/false,
-})
 --[[ topology_cfg: {
     auth = false,
     failover = nil | boolean | {
@@ -643,7 +640,7 @@ local function validate_upgrade(topology_new, topology_old)
             local enabled_old = replicaset_old and replicaset_old.roles[role]
             if enabled_new and not enabled_old then
                 e_config:assert(
-                    vars.known_roles[role],
+                    roles.get_role(role),
                     'replicasets[%s] can not enable unknown role %q',
                     replicaset_uuid, tostring(role)
                 )
@@ -973,9 +970,6 @@ end
 return {
     validate = function(...)
         return e_config:pcall(validate, ...)
-    end,
-    add_known_role = function(role_name)
-        vars.known_roles[role_name] = true
     end,
 
     not_expelled = not_expelled,

--- a/test/unit/roledeps_test.lua
+++ b/test/unit/roledeps_test.lua
@@ -148,7 +148,7 @@ t.assert_equals(ok, true, err)
 
 local vars = require('cartridge.vars').new('cartridge.roles')
 local roles_order = {}
-for i, role in ipairs(vars.by_number) do
+for i, role in ipairs(vars.roles_by_number) do
     roles_order[i] = role.role_name
     log.info('%d) %s -> %s',
         i, role.role_name,

--- a/test/unit/rpc_candidates_test.lua
+++ b/test/unit/rpc_candidates_test.lua
@@ -21,6 +21,9 @@ function g.setup()
 
     g.server:start()
     helpers.retrying({}, t.Server.connect_net_box, g.server)
+    g.server.net_box:eval([[
+        _G.test = require('test.unit.rpc_candidates_test')
+    ]])
 end
 
 function g.teardown()
@@ -34,7 +37,10 @@ local function test_remotely(fn_name, fn)
     g[fn_name] = function()
         g.server.net_box:eval([[
             local test = require('test.unit.rpc_candidates_test')
-            test[...]()
+            local ok, err = pcall(test[...])
+            if not ok then
+                error(err.message, 0)
+            end
         ]], {fn_name})
     end
 end

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -97,8 +97,10 @@ function g.mock_package()
 end
 
 function g.before_all()
-    assert(roles.register_role('cartridge.roles.vshard-storage'))
-    assert(roles.register_role('cartridge.roles.vshard-router'))
+    assert(roles.cfg({
+      'cartridge.roles.vshard-storage',
+      'cartridge.roles.vshard-router',
+    }))
 
     rawset(_G, 'vshard', {
         storage = {


### PR DESCRIPTION
This is a pre-requisite for #1105.

* Consolidate registering all roles in a single `roles.cfg()` function instead of calling `register_role()` one by one.
* Reorganize internal access to registered roles: use clear variables `by_number`, `by_package`, `by_role_name` instead of single `known_roles`. Add a layer for role meta information.

I didn't forget about

- [x] Tests
- [x] Changelog (not a public feature)
- [x] Documentation (unnecessary)
