### PR TITLE
gh-1520 reference to config section

### DIFF
--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -1232,6 +1232,9 @@ The options are:
 ``--cfg FILE``
         Cartridge instances YAML configuration file.
         Defaults to ``TARANTOOL_CFG`` or ``./instances.yml``.
+        The ``instances.yml`` file contains ``cartridge.cfg()``
+        parameters described in the :ref:`configuration section <cartridge-config-basic>`
+        of this guide.
 
 ``--foreground``
         Do not daemonize.


### PR DESCRIPTION
Documentation update: referencing ``start --cfg`` option to the config parameters section. 

Part of tarantool/doc#1520