### PR TITLE
test: failure for non-default buckets count

### DIFF
--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -94,6 +94,7 @@ local function stop()
 
     for router_name, router in pairs(vars.routers) do
         router:cfg({
+            bucket_count = router.total_bucket_count,
             sharding = {[replicaset_uuid] = {
                 replicas = {[instance_uuid] = {
                     uri = pool.format_uri(advertise_uri),

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -48,6 +48,7 @@ local function stop()
         listen = box.cfg.listen,
         read_only = box.cfg.read_only,
         replication = box.cfg.replication,
+        bucket_count = vars.vshard_cfg.bucket_count,
         sharding = {[replicaset_uuid] = {
             replicas = {[instance_uuid] = {
                 uri = pool.format_uri(advertise_uri),


### PR DESCRIPTION
It looks like vshard bug but if we don't specify "bucket_count"
explicitly we get "Non-dynamic option bucket_count cannot be reconfigured"
error. Anyway currently we should handle it on cartridge side.

Closes #1156