### PR TITLE
Change RPC is_healthy predicate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Default value of ``failover_timeout`` increased from 3 to 20 seconds.
+- RPC functions now consider ``suspect`` members as healthy to be in agreement
+  with failover.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -42,7 +42,7 @@ local function member_is_healthy(uri, instance_uuid)
     local member = membership.get_member(uri)
     return (
         (member ~= nil)
-        and (member.status == 'alive')
+        and (member.status == 'alive' or member.status == 'suspect')
         and (member.payload.uuid == instance_uuid)
         and (
             member.payload.state == 'ConfiguringRoles' or
@@ -62,7 +62,9 @@ end
 --   Filter instances which are leaders now.
 --   (default: **false**)
 -- @tparam ?boolean opts.healthy_only
---   Filter instances which have membership status healthy.
+--   The member is considered healthy if
+--   it reports either `ConfiguringRoles` or `RolesConfigured` state
+--   and its SWIM status is either `alive` or `suspect`
 --   (added in v1.1.0-11, default: **true**)
 --
 -- @treturn[1] {string,...} URIs

--- a/test/unit/rpc_candidates_test.lua
+++ b/test/unit/rpc_candidates_test.lua
@@ -185,6 +185,20 @@ test_candidates('+leader',
 )
 
 -------------------------------------------------------------------------------
+draft[1][1].status = 'suspect'
+log.info('a1 leader suspect')
+
+test_candidates('-leader +healthy',
+    draft, {'target-role'},
+    {'a1', 'a2'}
+)
+
+test_candidates('+leader +healthy',
+    draft, {'target-role', {leader_only = true}},
+    {'a1'}
+)
+
+-------------------------------------------------------------------------------
 draft[1][1].status = 'dead'
 log.info('a1 leader died')
 


### PR DESCRIPTION
Neither eventual nor stateful failover isn't triggered until a `suspect`
member becomes dead, but RPC already considers it as unhealthy. As a
result, `get_active_leaders` may return a suspect leader and the RPC call
would return an error "No remotes with role %q available" preliminary.

Starting with this patch, prc will consider suspects as healthy.

What has been done? Why? What problem is being solved?

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Part of #1139 
