### PR TITLE
Speedup Github Actions

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -4,60 +4,97 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  # Skip building frontend in tarantoolctl rocks make
+  CMAKE_DUMMY_WEBUI: true
+  # Prerequisite for some etcd-related tests
+  ETCD_PATH: etcd-v2.3.8/etcd
+  # Prerequisite for compatibility.cartridge_upgrade_test
+  CARTRIDGE_OLDER_PATH: cartridge-1.2.0
+  CARTRIDGE_OLDER_VERSION: 1.2.0-1
+
 jobs:
   misc:
-    runs-on: ubuntu-latest
-    env:
-      CMAKE_DUMMY_WEBUI: true
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-18.04]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - uses: actions/setup-python@v2
-      - run: python -m pip install -r rst/requirements.txt
 
-      - name: Install tarantool
+      # Setup sphinx
+      - name: Cache pip packages
+        uses: actions/cache@v1
+        id: cache-misc-venv
+        with:
+          path: ./venv
+          key: cache-misc-venv-${{ matrix.runs-on }}
+      -
         run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=1.10 bash
+          python -m venv ./venv && . ./venv/bin/activate
+          pip install -r rst/requirements.txt
+        if: steps.cache-misc-venv.outputs.cache-hit != 'true'
 
-      - name: Install ldoc
-        run: >
-          tarantoolctl rocks install --server=http://rocks.moonscript.org
-          https://raw.githubusercontent.com/tarantool/ldoc/tarantool/ldoc-scm-2.rockspec
+      # Setup tarantool
+      - uses: rosik/setup-tarantool@v1
+        with:
+          tarantool-version: '1.10'
 
-      - name: Build cartridge
+      # Setup luacheck and ldoc
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-misc-rocks
+        with:
+          path: .rocks/
+          key: cache-misc-rocks-${{ matrix.runs-on }}
+      -
+        run: tarantoolctl rocks install luacheck
+        if: steps.cache-misc-rocks.outputs.cache-hit != 'true'
+      -
+        run: tarantoolctl rocks install ldoc --server=https://tarantool.github.io/LDoc/
+        if: steps.cache-misc-rocks.outputs.cache-hit != 'true'
+
+      # Setup graphql cli
+      - name: Cache npm
+        uses: actions/cache@v2
+        id: cache-misc-npm
+        with:
+          path: node_modules
+          key: cache-misc-npm-01
+      -
+        run: npm install graphql-cli@3.0.14
+        if: steps.cache-misc-npm.outputs.cache-hit != 'true'
+
+      # Run tests
+      - run: .rocks/bin/luacheck .
+      - run: |
+          . ./venv/bin/activate
+          tarantoolctl rocks make
         env:
           CMAKE_LDOC_FIND_REQUIRED: 'YES'
           CMAKE_SPHINX_FIND_REQUIRED: 'YES'
-        run: |
-          tarantoolctl rocks make
+      - run: ./fetch-schema.sh
 
-      - name: Lint
-        run: |
-          tarantoolctl rocks install luacheck
-          .rocks/bin/luacheck .
-
-      - name: Check schema
-        run: |
-          npm install graphql-cli@3.0.14
-          ./fetch-schema.sh
+      # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge
 
   luatest:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-18.04]
         tarantool: ['1.10']
     runs-on: ${{ matrix.runs-on }}
-    env:
-      CMAKE_DUMMY_WEBUI: true
     steps:
       - uses: actions/checkout@v2
+      - uses: rosik/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
 
-      - name: Install tarantool
-        run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=${{ matrix.tarantool }} bash
-          tarantoolctl rocks install luatest 0.5.2
-
+      # Setup etcd
       - name: Install etcd
         uses: ./.github/actions/setup-etcd
         if: runner.os == 'Linux'
@@ -65,31 +102,34 @@ jobs:
           etcd-version: v2.3.8
           install-prefix: etcd-v2.3.8
 
-      - name: Cache build dir
+      # Setup older cartridge for compatibility.cartridge_upgrade_test
+      - name: Cache ${{ env.CARTRIDGE_OLDER_PATH }}
+        id: cache-older-cartridge
         uses: actions/cache@v2
         with:
-          path: |
-            .rocks/
-            build.luarocks/
-          key: backend-build-${{ runner.os }}
-
-      - name: Build cartridge
+          path: ${{ env.CARTRIDGE_OLDER_PATH }}
+          key: cache-${{ env.CARTRIDGE_OLDER_PATH }}-${{ matrix.runs-on }}
+      - name: Install ${{ env.CARTRIDGE_OLDER_PATH }}
+        if: steps.cache-older-cartridge.outputs.cache-hit != 'true'
         run: |
-          tarantoolctl rocks make
-
-      - name: Run tests
-        env:
-          ETCD_PATH: etcd-v2.3.8/etcd
-          CARTRIDGE_OLDER_PATH: cartridge-1.2.0
-        run: |
-          mkdir -p $CARTRIDGE_OLDER_PATH
-          pushd $CARTRIDGE_OLDER_PATH
-          # Prerequisite for compatibility.cartridge_upgrade_test
-          tarantoolctl rocks install cartridge 1.2.0-1
+          mkdir -p ${{ env.CARTRIDGE_OLDER_PATH }}
+          pushd ${{ env.CARTRIDGE_OLDER_PATH }}
+          tarantoolctl rocks install cartridge ${{ env.CARTRIDGE_OLDER_VERSION }}
           popd
 
-          .rocks/bin/luatest -v
+      # Setup luatest
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-luatest-rocks
+        with:
+          path: .rocks/
+          key: cache-luatest-rocks-${{ matrix.runs-on }}
+      -
+        run: tarantoolctl rocks install luatest 0.5.2
+        if: steps.cache-luatest-rocks.outputs.cache-hit != 'true'
 
-      - name: Cleanup cached paths
-        run: |
-          tarantoolctl rocks remove cartridge
+      - run: tarantoolctl rocks make
+      - run: .rocks/bin/luatest -v
+
+      # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -4,19 +4,19 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  CMAKE_DUMMY_WEBUI: false
+
 jobs:
   webui-test:
-    runs-on: ubuntu-latest
-    env:
-      CMAKE_DUMMY_WEBUI: false
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
 
-      - name: Install tarantool
-        run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=1.10 bash
-          tarantoolctl rocks install luatest 0.5.2
+      - uses: rosik/setup-tarantool@v1
+        with:
+          tarantool-version: '1.10'
 
       - name: Cache build dir
         uses: actions/cache@v2
@@ -28,8 +28,8 @@ jobs:
             webui/node_modules/
           key: frontend-build
 
-      - name: Build cartridge
-        run: tarantoolctl rocks make
+      - run: tarantoolctl rocks install luatest 0.5.2
+      - run: tarantoolctl rocks make
 
       - name: Cache cypress
         id: cache-cypress
@@ -38,16 +38,11 @@ jobs:
           path: ~/.cache/Cypress
           key: cypress-cache-${{ runner.os }}
 
-      - name: Setup cypress
-        run: |
-          npm install cypress@4.12.1
-          npx cypress cache list
+      - run: npm install cypress@4.12.1
+      - run: npx cypress cache list
 
-      - name: Run tests
-        run: |
-          ./cypress-test.sh
-          ./frontend-test.sh
+      - run: ./cypress-test.sh
+      - run: ./frontend-test.sh
 
-      - name: Cleanup cached paths
-        run: |
-          tarantoolctl rocks remove cartridge
+      # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge


### PR DESCRIPTION
- Make use of rosik/setup-tarantool which caches apt packages
- Cache cartridge-1.2.0 dir used for tests
- Elimitate warning "Ubuntu-latest workflows will use Ubuntu-20.04 soon"

This makes backend tests ~1.5 minutes faster.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

