### PR TITLE
Make console_sock error more clear

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Fixed
 - Allow applying config when instance is in ``OperationError``. It doesn't cause
   loss of quorum anymore.
 - Stop vshard fibers when the corresponding role is disabled.
+- Make ``console.listen`` error more clear when ``console_sock`` exceeds
+  ``UNIX_PATH_MAX`` limit.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -245,22 +245,11 @@ g.test_console_sock = function()
     })
 
     t.assert_not(ok)
-    t.assert_covers(err, {class_name = 'CartridgeCfgError'})
+    t.assert_covers(err, {
+        class_name = 'CartridgeCfgError',
+        err = 'Too long console_sock exceeds UNIX_PATH_MAX limit',
+    })
     t.assert_equals(fio.listdir(sock_dir), {})
-
-    -- Tarantool < 2.3.2
-    local e1 = 'Too long console_sock exceeds UNIX_PATH_MAX limit'
-    -- The message differs in 2.3.2+
-    local e2 = 'failed to create server unix/:' .. sock_name ..
-        ': ' .. errno.strerror(errno.ENOBUFS)
-    if err.err ~= e1 and not err.err:endswith(e2) then
-        error(
-            'Unexpected error message:\n' ..
-            'expected: ' .. e1 .. '\n' ..
-            '      or: ' .. e2 .. '\n' ..
-            '  actual: ' .. tostring(err)
-        )
-    end
 end
 
 -- resolve_dns ----------------------------------------------------------------


### PR DESCRIPTION
A common problem with console_sock is UNIX_PATH_MAX limit.
In case it's exceeded, modern tarantool returns an ambiguous error:

```
CartridgeCfgError: builtin/box/console.lua:865: failed to create server
  unix/:/very/long/path: No buffer space available
```

After this patch the massage will be:

```
CartridgeCfgError: Too long console_sock exceeds UNIX_PATH_MAX limit
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1161 
