### PR TITLE
Make console_sock error more clear

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Fixed
 - Allow applying config when instance is in ``OperationError``. It doesn't cause
   loss of quorum anymore.
 - Stop vshard fibers when the corresponding role is disabled.
+- Make ``console.listen`` error more clear when ``console_sock`` exceeds
+  ``UNIX_PATH_MAX`` limit.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI


### PR DESCRIPTION
A common problem with console_sock is UNIX_PATH_MAX limit.
In case it's exceeded, modern tarantool returns an ambiguous error:

```
CartridgeCfgError: builtin/box/console.lua:865: failed to create server
  unix/:/very/long/path: No buffer space available
```

After this patch the massage will be:

```
ConsoleListenError:
  unix/:/very/long/path: Too long console_sock exceeds UNIX_PATH_MAX limit
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1161
