### PR TITLE
API to force-apply current config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,18 @@ Added
 - New argparse options support for tarantool 2.5+: ``replication_synchro_quorum``,
   ``replication_synchro_timeout``, ``memtx_use_mvcc_engine``.
 - Fencing parameters ``fencing_enabled``, ``fencing_pause``, ``fencing_timeout``
-  are available for customization via Lua API and GraphQL API.
+  are available for customization via Lua and GraphQL API.
+
+- New API ``cartridge.config_force_reapply()`` to heal several operational
+  errors:
+
+  - "Prepare2pcError: Two-phase commit is locked";
+  - "SaveConfigError: .../config.prepare: Directory not empty";
+  - "Configuration is prepared and locked on ..." (an issue);
+  - "Configuration checksum mismatch on ..." (an issue).
+
+  It'll unlock two-phase commit (remove ``config.prepare`` lock), upload the
+  active config from the current instance and reconfigure all roles.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -869,6 +869,11 @@ return {
     -- @function config_patch_clusterwide
     config_patch_clusterwide = twophase.patch_clusterwide,
 
+    --- .
+    -- @refer cartridge.twophase.force_reapply
+    -- @function config_force_reapply
+    config_force_reapply = twophase.force_reapply,
+
 --- Inter-role interaction.
 -- @refer cartridge.service-registry
 -- @section service_registry

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -59,9 +59,7 @@ local function prepare_2pc(data)
     local workdir = confapplier.get_workdir()
     local path_prepare = fio.pathjoin(workdir, 'config.prepare')
 
-    if vars.prepared_config ~= nil
-    or fio.path.exists(path_prepare)
-    then
+    if vars.prepared_config ~= nil then
         local err = Prepare2pcError:new('Two-phase commit is locked')
         log.warn('%s', err)
         return nil, err
@@ -81,6 +79,10 @@ local function prepare_2pc(data)
     end
 
     local ok, err = ClusterwideConfig.save(clusterwide_config, path_prepare)
+    if not ok and fio.path.exists(path_prepare) then
+        err = Prepare2pcError:new('Two-phase commit is locked')
+    end
+
     if not ok then
         log.warn('%s', err)
         return nil, err

--- a/test/integration/bootstrap_test.lua
+++ b/test/integration/bootstrap_test.lua
@@ -102,7 +102,7 @@ end
 function g.test_workdir_collision()
     -- We create a single-instance cluster
     -- and another instance in the same workdir
-    -- Test checks that attempt to join it boesn't break anything
+    -- Test checks that attempt to join it doesn't break anything
 
     g.tempdir = fio.tempdir()
     g.cluster = helpers.Cluster:new({
@@ -135,7 +135,7 @@ function g.test_workdir_collision()
     g.cluster:start()
 
     t.assert_error_msg_contains(
-        g.tempdir .. '/config.prepare: ',
+        'Two-phase commit is locked',
         helpers.Cluster.join_server, g.cluster, g.server
     )
     g.cluster:wait_until_healthy()

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -1,0 +1,88 @@
+local t = require('luatest')
+local g = t.group()
+
+local fio = require('fio')
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = require('digest').urandom(6):hex(),
+        replicasets = {{
+            uuid = helpers.uuid('a'),
+            roles = {},
+            servers = {{
+                alias = 'master',
+                instance_uuid = helpers.uuid('a', 'a', 1)
+            }, {
+                alias = 'replica1',
+                instance_uuid = helpers.uuid('a', 'a', 2)
+            }, {
+                alias = 'replica2',
+                instance_uuid = helpers.uuid('a', 'a', 3)
+            }},
+        }},
+        env = {}
+    })
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+
+function g.test_twophase_config_locked()
+    local master = g.cluster.main_server
+    local replica1 = g.cluster:server('replica1')
+
+    -- Make validate_config hang on replica2
+    local config = master.net_box:eval(
+            'return require(\'cartridge.confapplier\').'..
+            'get_active_config():get_plaintext()'
+    )
+
+    config['hey.yml'] = 'that is new'
+
+    -- let's put a spoke in two-phase's wheel
+    replica1.net_box:call(
+        '_G.__cartridge_clusterwide_config_prepare_2pc',
+        {config}
+    )
+
+    t.helpers.retrying({}, function()
+        t.assert_equals(fio.path.exists(replica1.workdir .. '/config.prepare'), true)
+    end)
+
+    local status, err = master.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide',
+        {config}
+    )
+
+    -- Eventually commit is locked
+    t.assert_equals(status, nil)
+    t.assert_covers(err, {err = "Two-phase commit is locked"})
+
+    -- But force reapply comes to the rescue!
+    master.net_box:call(
+        'package.loaded.cartridge.config_force_reapply',
+        {{replica1.instance_uuid}}
+    )
+
+    -- Lock is gone
+    t.helpers.retrying({}, function()
+        t.assert_equals(fio.path.exists(replica1.workdir .. '/config.prepare'), false)
+    end)
+
+    local status, err = master.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide',
+        {config}
+    )
+
+    -- And patch_clusterwide has succeed
+    t.assert_equals(status, true)
+    t.assert_equals(err, nil)
+end

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -32,7 +32,7 @@ end)
 
 
 function g.test_twophase_config_locked()
-    -- Let's put a spoke in two-phase's wheel
+    -- Let's put a spoke in two-phases wheel
     local config = g.A1.net_box:eval([[
         local confapplier = require('cartridge.confapplier')
         return confapplier.get_active_config():get_plaintext()
@@ -54,10 +54,10 @@ function g.test_twophase_config_locked()
             ' on localhost:13302 (A-2)',
     }})
 
-    -- Eventually commit is locked
+    -- Obviously, 2pc is locked
     local ok, err = g.A1.net_box:call(
         'package.loaded.cartridge.config_patch_clusterwide',
-        {{['bye.txt'] = 'Googbye, locks'}}
+        {{['bye.txt'] = 'Goodbye, locks'}}
     )
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
@@ -78,13 +78,13 @@ function g.test_twophase_config_locked()
     -- And patch_clusterwide succeeds
     local ok, err = g.A1.net_box:call(
         'package.loaded.cartridge.config_patch_clusterwide',
-        {{['bye.txt'] = 'Googbye, locks'}}
+        {{['bye.txt'] = 'Goodbye, locks'}}
     )
     t.assert_equals({ok, err}, {true, nil})
 
     t.assert_equals(helpers.list_cluster_issues(g.A1), {})
     t.assert_equals(
         g.cluster:download_config(),
-        {['bye.txt'] = 'Googbye, locks'}
+        {['bye.txt'] = 'Goodbye, locks'}
     )
 end


### PR DESCRIPTION
The function performs the following actions:
 - Abort two-phase commit (remove `config.prepare` lock)
-  Apply config taken from the server which handles the request

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Part of #1144
