### PR TITLE
Cache frontend build intelligently

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -70,7 +70,8 @@ jobs:
 
       # Run tests
       - run: .rocks/bin/luacheck .
-      - run: |
+      - name: Run tarantoolctl rocks make
+        run: |
           . ./venv/bin/activate
           tarantoolctl rocks make
         env:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -9,7 +9,11 @@ env:
 
 jobs:
   webui-test:
-    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-18.04]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -18,17 +22,46 @@ jobs:
         with:
           tarantool-version: '1.10'
 
-      - name: Cache build dir
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-webui-rocks
+        with:
+          path: .rocks/
+          key: cache-webui-rocks-${{ matrix.runs-on }}
+      -
+        run: tarantoolctl rocks install luatest 0.5.2
+        if: steps.cache-webui-rocks.outputs.cache-hit != 'true'
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: webui/node_modules/
+          key: >
+            cache-node-modules-${{ hashFiles(
+            'webui/package-lock.json'
+            ) }}
+
+      - name: Cache webui bundle
         uses: actions/cache@v2
         with:
           path: |
-            .rocks/
-            build.luarocks/
-            webui/build/
-            webui/node_modules/
-          key: frontend-build
+            webui/build/bundle.lua
+            webui/build/bundle.md5
+          key: >
+            cache-webui-bundle-${{ hashFiles(
+            'webui/src/*',
+            'webui/config/*.prod.js',
+            'webui/flow-typed/*',
+            'webui/public/*',
+            'webui/.env',
+            'webui/.env.production',
+            'webui/.eslintrc',
+            'webui/.flowconfig',
+            'webui/codegen.yml',
+            'webui/scripts/build.js',
+            'webui/package-lock.json'
+            ) }}
 
-      - run: tarantoolctl rocks install luatest 0.5.2
       - run: tarantoolctl rocks make
 
       - name: Cache cypress

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,18 +51,11 @@ configure_file (
 
 ## Webui ######################################################################
 ###############################################################################
-add_custom_command(
-  OUTPUT ${WEB_ROOT}/node_modules
-  COMMAND NODE_ENV=production npm ci --prefix "${WEB_ROOT}"
-  DEPENDS "${WEB_ROOT}/package-lock.json"
-  COMMENT "Installing node_modules"
-)
 
 add_custom_command(
-  OUTPUT ${WEB_ROOT}/build/bundle.lua
-  COMMAND npm run build --prefix "${WEB_ROOT}"
-  DEPENDS ${WEB_ROOT}/node_modules ${FRONTEND_FILES}
-  COMMENT "Building web archive"
+  OUTPUT "${WEB_ROOT}/build/always-run-script"
+  COMMAND ${CMAKE_COMMAND} -P ${WEB_ROOT}/BuildFrontend.cmake
+  COMMENT "Building WebUI"
 )
 
 if(DEFINED ENV{CMAKE_DUMMY_WEBUI})
@@ -82,7 +75,7 @@ if(DUMMY_WEBUI)
   )
 else()
   add_custom_target(front-bundle ALL
-    DEPENDS "${WEB_ROOT}/build/bundle.lua"
+    DEPENDS "${WEB_ROOT}/build/always-run-script"
     COMMAND ${CMAKE_COMMAND} -E copy
       "${WEB_ROOT}/build/bundle.lua"
       "${CMAKE_CURRENT_BINARY_DIR}/front-bundle.lua"

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -25,7 +25,6 @@ external_dependencies = {
 build = {
     type = 'cmake',
     variables = {
-        version = 'scm-1',
         TARANTOOL_DIR = '$(TARANTOOL_DIR)',
         TARANTOOL_INSTALL_LIBDIR = '$(LIBDIR)',
         TARANTOOL_INSTALL_LUADIR = '$(LUADIR)',

--- a/webui/BuildFrontend.cmake
+++ b/webui/BuildFrontend.cmake
@@ -1,0 +1,83 @@
+## This is a cmake-based script which builds frontend bundle.
+# It's intelligent enough to avoid unnecesary rebuilds.
+# It calculates source hash (md5) and does nothing unless it changes.
+
+get_filename_component(BASE_DIR "${CMAKE_SCRIPT_MODE_FILE}" DIRECTORY)
+set(REBUILD 0)
+
+function(check_hash HASH_FILE FILES)
+    set(__digest "")
+
+    list(SORT FILES)
+    foreach(F ${FILES})
+        file(RELATIVE_PATH F_RELPATH ${BASE_DIR} ${F})
+        file(MD5 ${F} F_MD5)
+        list(APPEND __digest "${F_RELPATH};${F_MD5}")
+    endforeach()
+
+    string(MD5 MD5_ACTUAL "${__digest}")
+    if (NOT EXISTS ${HASH_FILE})
+        set(REBUILD 1)
+    else()
+        file(READ ${HASH_FILE} MD5_CACHED)
+        string(STRIP "${MD5_CACHED}" MD5_CACHED)
+        if (NOT MD5_CACHED STREQUAL MD5_ACTUAL)
+            set(REBUILD 1)
+        endif()
+    endif()
+
+    set(REBUILD ${REBUILD} PARENT_SCOPE)
+    set(MD5_CACHED ${MD5_CACHED} PARENT_SCOPE)
+    set(MD5_ACTUAL ${MD5_ACTUAL} PARENT_SCOPE)
+endfunction()
+
+## node_modules ###############################################################
+###############################################################################
+
+set(HASH_FILE "${BASE_DIR}/node_modules/package-lock.md5")
+check_hash(${HASH_FILE} "${BASE_DIR}/package-lock.json")
+
+if (REBUILD)
+    message(STATUS "Installing node_modules")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E
+            env NODE_ENV=production
+            npm ci  --no-audit --no-progress --prefer-offline
+        WORKING_DIRECTORY "${BASE_DIR}"
+    )
+    file(WRITE ${HASH_FILE} "${MD5_ACTUAL}")
+else()
+    message(STATUS "Skipping node_modules installation")
+endif()
+
+## bundle.lua #################################################################
+###############################################################################
+
+set(HASH_FILE "${BASE_DIR}/build/bundle.md5")
+file(GLOB_RECURSE FRONTEND_FILES
+    "${BASE_DIR}/src/*"
+    "${BASE_DIR}/config/*.prod.js"
+    "${BASE_DIR}/flow-typed/*"
+    "${BASE_DIR}/public/*"
+)
+list(APPEND FRONTEND_FILES
+    "${BASE_DIR}/.env"
+    "${BASE_DIR}/.env.production"
+    "${BASE_DIR}/.eslintrc"
+    "${BASE_DIR}/.flowconfig"
+    "${BASE_DIR}/codegen.yml"
+    "${BASE_DIR}/scripts/build.js"
+    "${BASE_DIR}/package-lock.json"
+)
+check_hash(${HASH_FILE} "${FRONTEND_FILES}")
+
+if (REBUILD)
+    message(STATUS "Building WebUI bundle")
+    execute_process(
+        COMMAND npm run build
+        WORKING_DIRECTORY "${BASE_DIR}"
+    )
+    file(WRITE ${HASH_FILE} "${MD5_ACTUAL}")
+else()
+    message(STATUS "Skipping WebUI bundle build")
+endif()


### PR DESCRIPTION
Nowadays, the WebUI bundle is built by CMake `custom_command` (`npm ci`, `npm run build`). CMake makes decisions about rebuild basing on file timestamps. Sometimes it causes unnecessary rebuilds, e.g. when switching git branches or in CI after restoring cache.

In this patch, the WebUI build process is refactored. Instead of running `npm` directly from `custom_command`, it's wrapped into the `BuildFrontend.cmake` script. This script is executed every time, but it doesn't always run the full build. Beforehand, it calculates the checksum of target dependencies and compares it to the one persisted near build results.

The build consists of two stages:

#### 1. `npm ci`

Produces
- webui/node_modules/*

Persists checksum in
- webui/node_modules/package-lock.md5

Depends on
- webui/package-lock.json

#### 2. `npm run build`

Produces
- webui/build/bundle.lua

Persists checksum in
- webui/build/bundle.md5

Depends on
- webui/src/*
- webui/config/*.prod.js
- webui/flow-typed/*
- webui/public/*
- webui/.env
- webui/.env.production
- webui/.eslintrc
- webui/.flowconfig
- webui/codegen.yml
- webui/scripts/build.js
- webui/package-lock.json

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (nothing changed for a user)
