### PR TITLE
Add graphql API for force_reapply

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Added
 
   It'll unlock two-phase commit (remove ``config.prepare`` lock), upload the
   active config from the current instance and reconfigure all roles.
+- New GraphQL API: ``mutation {cluster {force_reapply (uuids: [])}}`` to
+  supplement ``cartridge.config_force_reapply()`` API.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
 
 - New GraphQL API: ``{cluster {suggestions {refine_uri {}}}}`` to heal the
   cluster after relocation of servers ``advertise_uri``.
-- New `cartridge.cfg` option `swim_broadcast` (default true) to disable
+- New ``cartridge.cfg`` option ``swim_broadcast`` (default true) to disable
   instances discovery on start.
 - Add support of replica weights and zones via a clusterwide config new section
   ``zone_distances`` and a server parameter ``zone``.
@@ -33,8 +33,8 @@ Added
 - Fencing parameters ``fencing_enabled``, ``fencing_pause``, ``fencing_timeout``
   are available for customization via Lua and GraphQL API.
 
-- New API ``cartridge.config_force_reapply()`` to heal several operational
-  errors:
+- New Lua API ``cartridge.config_force_reapply()`` and similar GraphQL mutation
+  ``cluster { config_force_reapply() }`` to heal several operational errors:
 
   - "Prepare2pcError: Two-phase commit is locked";
   - "SaveConfigError: .../config.prepare: Directory not empty";
@@ -43,8 +43,6 @@ Added
 
   It'll unlock two-phase commit (remove ``config.prepare`` lock), upload the
   active config from the current instance and reconfigure all roles.
-- New GraphQL API: ``mutation {cluster {force_reapply (uuids: [])}}`` to
-  supplement ``cartridge.config_force_reapply()`` API.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -503,12 +503,25 @@ local function _force_reapply(uuids)
 
     local _reapply_error
 
+    local prepared_uuid = {}
+    for _, uuid in ipairs(uuids) do
+        prepared_uuid[uuid] = true
+    end
+
     -- Prepare a server group to be configured
     local uri_list = {}
     local refined_uri_list = topology.refine_servers_uri(current_topology)
     for _, uuid, _ in fun.filter(topology.not_disabled, current_topology.servers) do
         if prepared_uuid[uuid] then
             table.insert(uri_list, refined_uri_list[uuid])
+            prepared_uuid[uuid] = nil
+        end
+    end
+
+    -- Check if all uuids are valid
+    for uuid, _ in pairs(prepared_uuid) do
+        if prepared_uuid[uuid] then
+            return nil, ForceReapplyError:new("Server \'%s\' is not in topology", uuid)
         end
     end
 

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -507,7 +507,7 @@ local function _force_reapply(uuids)
     local uri_list = {}
     local refined_uri_list = topology.refine_servers_uri(current_topology)
     for _, uuid, _ in fun.filter(topology.not_disabled, current_topology.servers) do
-        if utils.table_find(uuids, uuid) then
+        if prepared_uuid[uuid] then
             table.insert(uri_list, refined_uri_list[uuid])
         end
     end

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Wed Nov 25 2020 19:56:51 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Dec 14 2020 18:56:50 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -203,8 +203,8 @@ type Mutation {
 
 """Cluster management"""
 type MutationApicluster {
-  """Applies DDL schema on cluster"""
-  schema(as_yaml: String!): DDLSchema!
+  """Remove user"""
+  remove_user(username: String!): User
 
   """
   Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.2-2)
@@ -214,18 +214,21 @@ type MutationApicluster {
   """Configure automatic failover."""
   failover_params(fencing_enabled: Boolean, fencing_timeout: Float, failover_timeout: Float, mode: String, state_provider: String, tarantool_params: FailoverStateProviderCfgInputTarantool, fencing_pause: Float, etcd2_params: FailoverStateProviderCfgInputEtcd2): FailoverAPI!
 
-  """Checks that schema can be applied on cluster"""
-  check_schema(as_yaml: String!): DDLCheckResult!
-
   """Applies updated config on cluster"""
   config(sections: [ConfigSectionInput]): [ConfigSection]!
 
-  """Edit cluster topology"""
-  edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
-  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
+  """Checks that schema can be applied on cluster"""
+  check_schema(as_yaml: String!): DDLCheckResult!
 
   """Create a new user"""
   add_user(password: String!, username: String!, fullname: String, email: String): User
+
+  """Reapplies config on the specified nodes"""
+  config_force_reapply(uuids: [String]): Boolean!
+  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
+
+  """Edit cluster topology"""
+  edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
 
   """Edit an existing user"""
   edit_user(password: String, username: String!, fullname: String, email: String): User
@@ -234,8 +237,8 @@ type MutationApicluster {
   """Promote the instance to the leader of replicaset"""
   failover_promote(force_inconsistency: Boolean, replicaset_uuid: String!, instance_uuid: String!): Boolean!
 
-  """Remove user"""
-  remove_user(username: String!): User
+  """Applies DDL schema on cluster"""
+  schema(as_yaml: String!): DDLSchema!
 
   """Disable listed servers by uuid"""
   disable_servers(uuids: [String!]): [Server]

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -112,6 +112,11 @@ local q_set_myrole_counter = [[
 local q_get_counter = [[ return _G.counter ]]
 
 function g.test_graphql_api()
+    t.assert_error_msg_contains(
+        'Server \'alien\' is not in topology',
+        force_reapply, {'alien'}
+    )
+
     for _, srv in pairs(g.cluster.servers) do
         srv.net_box:eval(q_set_myrole_counter)
     end

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -12,7 +12,7 @@ g.before_all(function()
         cookie = require('digest').urandom(6):hex(),
         replicasets = {{
             alias = 'A',
-            roles = {},
+            roles = {'myrole-permanent'},
             servers = 3,
         }},
     })
@@ -87,4 +87,40 @@ function g.test_twophase_config_locked()
         g.cluster:download_config(),
         {['bye.txt'] = 'Goodbye, locks'}
     )
+end
+
+local function force_reapply(uuids)
+    return g.cluster.main_server:graphql({
+        query = [[
+            mutation($uuids: [String]) {
+                cluster { config_force_reapply(uuids: $uuids) }
+            }
+        ]],
+        variables = {uuids = uuids}
+    }).data.cluster.config_force_reapply
+end
+
+local q_set_myrole_counter = [[
+    local vars = require('cartridge.vars').new('cartridge.service-registry')
+
+    vars.registry['myrole-permanent'].apply_config = function()
+        _G.counter = _G.counter + 1
+    end
+    _G.counter = 0
+]]
+
+local q_get_counter = [[ return _G.counter ]]
+
+function g.test_graphql_api()
+    for _, srv in pairs(g.cluster.servers) do
+        srv.net_box:eval(q_set_myrole_counter)
+    end
+
+    t.assert(force_reapply({g.A1.instance_uuid}))
+    t.assert(force_reapply({g.A1.instance_uuid, g.A2.instance_uuid}))
+    t.assert(force_reapply({g.A1.instance_uuid, g.A2.instance_uuid, g.A3.instance_uuid}))
+
+    t.assert_equals(g.A1.net_box:eval(q_get_counter), 3)
+    t.assert_equals(g.A2.net_box:eval(q_get_counter), 2)
+    t.assert_equals(g.A3.net_box:eval(q_get_counter), 1)
 end


### PR DESCRIPTION
GraphQL mutation which reapplies the current config forcefully on specified instances.

```
mutation {
  cluster {
    config(force_reapply: ["uuid1", "uuid2"]) {}
  }
}
```

Config mutation is already a part of cartridge API. It's used on the "Code" page to modify sections of a config. The `force_reapply` param will conflict with `sections` and whey can't be used together.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1144 
