### PR TITLE
Weaken fencing params validation

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -604,11 +604,13 @@ local function cfg(clusterwide_config)
 
     if failover_cfg.mode == 'disabled' then
         log.info('Failover disabled')
+        vars.fencing_enabled = false
         vars.consistency_needed = false
         first_appointments = _get_appointments_disabled_mode(topology_cfg)
 
     elseif failover_cfg.mode == 'eventual' then
         log.info('Eventual failover enabled')
+        vars.fencing_enabled = false
         vars.consistency_needed = false
         first_appointments = _get_appointments_eventual_mode(topology_cfg)
 

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -390,8 +390,9 @@ local function validate_failover_schema(field, topology)
             )
         end
 
-
-        if topology.failover.fencing_enabled == true then
+        if topology.failover.mode == 'stateful'
+        and topology.failover.fencing_enabled == true
+        then
             e_config:assert(
                 topology.failover.failover_timeout ~= nil,
                 '%s.failover.failover_timeout must be specified'
@@ -831,7 +832,7 @@ local function get_failover_params(topology_cfg)
     end
 
     -- Enrich fencing params with defaults
-    if ret.fencing_enabled == nil then
+    if ret.mode ~= 'stateful' or ret.fencing_enabled == nil then
         ret.fencing_enabled = false
     end
 

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -242,7 +242,7 @@ failover:
     check_config('topology_new.failover.failover_timeout must be specified when fencing is enabled',
 [[---
 failover:
-  mode: disabled
+  mode: stateful
   fencing_enabled: true
   fencing_timeout: 1
 ...]])
@@ -250,7 +250,16 @@ failover:
     check_config('topology_new.failover.failover_timeout must be greater than fencing_timeout',
 [[---
 failover:
-  mode: disabled
+  mode: stateful
+  failover_timeout: 1
+  fencing_timeout: 1
+  fencing_enabled: true
+...]])
+
+    check_config('topology_new.failover.failover_timeout must be greater than fencing_timeout',
+[[---
+failover:
+  mode: stateful
   failover_timeout: 1
   fencing_timeout: 1
   fencing_enabled: true
@@ -940,6 +949,9 @@ replicasets:
 auth: false
 failover:
   mode: eventual
+  failover_timeout: 1
+  fencing_timeout: 2
+  fencing_enabled: true # but in eventual mode it doesn't matter
 servers:
   aaaaaaaa-aaaa-4000-b000-000000000001:
     replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001


### PR DESCRIPTION
The fencing feature is suitable in stateful mode only, but its config is always validated. One of the restrictions is `fencing_timeout < failover_timeout`. But in other failover modes, it doesn't help and disturbs a user. A user may switch from stateful failover to eventual and try to change failover timeout. In this case, any errors regarding fencing would be awkward.

I didn't forget about

- [x] Tests
- [x] Changelog (not that important)
- [x] Documentation (unnecessary)

