### PR TITLE
Return "Config didn't change" error instead of OK

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Changed
 - Default value of ``failover_timeout`` increased from 3 to 20 seconds.
 - RPC functions now consider ``suspect`` members as healthy to be in agreement
   with failover.
+- ``patch_clusterwide()`` now returns error ``Config didn't change`` error
+  instead of OK.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -334,8 +334,7 @@ local function _clusterwide(patch)
         clusterwide_config_new:get_plaintext(),
         clusterwide_config_old:get_plaintext()
     ) then
-        log.warn("Clusterwide config didn't change, skipping")
-        return true
+        return nil, PatchClusterwideError:new("Config didn't change")
     end
 
     local ok, err = topology.validate(topology_new, topology_old)

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -498,11 +498,18 @@ function g.test_operation_error()
     ]])
 
     -- Dummy mutation doesn't trigger two-phase commit
-    g.cluster.main_server:graphql({
-        query = [[
-            mutation { cluster { config(sections: []) {} } }
-        ]],
-    })
+    local dummy_mutation = function()
+        return g.cluster.main_server:graphql({
+            query = [[
+                mutation { cluster { config(sections: []) {} } }
+            ]],
+        }).cluster.config
+    end
+
+    t.assert_error_msg_contains(
+        "Config didn't change",
+        dummy_mutation
+    )
 
     -- Real tho-phase commit fails on apply stage with artificial error
     local resp = g.cluster.main_server:graphql({

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -71,8 +71,7 @@ end
 g.setup = function()
     g.cluster.main_server.net_box:eval([[
         local cartridge = require('cartridge')
-        local ok, err = cartridge.config_patch_clusterwide({users_acl = box.NULL})
-        assert(ok, err)
+        cartridge.config_patch_clusterwide({users_acl = box.NULL})
     ]])
 end
 
@@ -611,13 +610,9 @@ function g.test_set_params_graphql()
         get_lsid_max_age(resp)
     )
 
-    t.assert_equals(
-        set_auth_params(false)['enabled'],
-        false
-    )
-    t.assert_equals(
-        set_auth_params(nil)['enabled'],
-        false
+    t.assert_error_msg_contains(
+        "Config didn't change",
+        set_auth_params, false
     )
     t.assert_equals(
         get_auth_params(g.cluster:server('replica'))['enabled'],
@@ -627,10 +622,6 @@ function g.test_set_params_graphql()
         set_auth_params(true)['enabled'],
         true
     )
-    t.assert_equals(
-        set_auth_params(nil)['enabled'],
-        true
-    )
     t.assert_equals(get_auth_params(
         g.cluster:server('replica'))['enabled'],
         true
@@ -638,10 +629,6 @@ function g.test_set_params_graphql()
 
     t.assert_equals(
         set_auth_params(nil, 69)['cookie_max_age'],
-        69
-    )
-    t.assert_equals(
-        set_auth_params(nil, nil)['cookie_max_age'],
         69
     )
     t.assert_equals(

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -126,10 +126,9 @@ function g.test_luaapi()
 
     log.info('Reapplying valid schema...')
 
-    t.assert_equals(
-        call('cartridge_set_schema', {schema}),
-        schema
-    )
+    local ok, err = call('cartridge_set_schema', {schema})
+    t.assert_equals(ok, nil)
+    t.assert_equals(err, 'Config didn\'t change')
 
     t.assert_equals(
         call('cartridge_get_schema'),

--- a/test/integration/myrole_test.lua
+++ b/test/integration/myrole_test.lua
@@ -123,14 +123,14 @@ function g.test_rename()
     -- The test simulates a situation when the role is renamed in code,
     -- and the server is launced with old name in config.
 
-    g.cluster.main_server:graphql({query = [[
-        mutation {
-            edit_replicaset(
-                uuid: "aaaaaaaa-0000-0000-0000-000000000000"
-                roles: ["myrole"]
-            )
-        }
-    ]]})
+    -- g.cluster.main_server:graphql({query = [[
+    --     mutation {
+    --         edit_replicaset(
+    --             uuid: "aaaaaaaa-0000-0000-0000-000000000000"
+    --             roles: ["myrole"]
+    --         )
+    --     }
+    -- ]]})
 
     g.cluster:stop()
 

--- a/test/integration/zones_test.lua
+++ b/test/integration/zones_test.lua
@@ -177,7 +177,7 @@ function g.test_distances()
 end
 
 function g.test_validation()
-    t.assert_equals({set_distances()}, {true, nil})
+    set_distances()
     t.assert_equals({set_distances(box.NULL)}, {true, nil})
 
     local ok, err = set_distances('foo')


### PR DESCRIPTION
 `patch_clusterwide()` now returns error "Config didn't change" error instead of OK.

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation

Close #1046 
