### PR TITLE
Suggestion API to force-apply config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ and this project adheres to
 [Unreleased]
 -------------------------------------------------------------------------------
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Added
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- New GraphQL API: ``{cluster {suggestions {force_apply {uuid reasons}}}}`` to
+  heal the cluster in case of config errors like ``Configuration checksum mismatch``,
+  ``Configuration is prepared and locked``, and sometimes ``OperationError``.
+
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29
 -------------------------------------------------------------------------------

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -285,7 +285,7 @@ local function list_on_instance(opts)
 
         table.insert(ret, {
             level = 'warning',
-            topic = 'configuration',
+            topic = 'config_mismatch',
             instance_uuid = instance_uuid,
             replicaset_uuid = replicaset_uuid,
             message = string.format(
@@ -302,7 +302,7 @@ local function list_on_instance(opts)
     and fio.path.exists(path_prepare) then
         table.insert(ret, {
             level = 'warning',
-            topic = 'configuration',
+            topic = 'config_locked',
             instance_uuid = instance_uuid,
             replicaset_uuid = replicaset_uuid,
             message = string.format(

--- a/cartridge/webui/api-issues.lua
+++ b/cartridge/webui/api-issues.lua
@@ -1,4 +1,6 @@
-local _ = require('cartridge.issues')
+local module_name = 'cartridge.webui.api-issues'
+
+local issues = require('cartridge.issues')
 local gql_types = require('cartridge.graphql.types')
 
 local gql_type_warning = gql_types.object({
@@ -12,6 +14,16 @@ local gql_type_warning = gql_types.object({
     }
 })
 
+local function get_issues(_, _, info)
+    local cache = info.context.request_cache
+    if cache.issues ~= nil then
+        return cache.issues
+    end
+
+    cache.issues = issues.list_on_cluster()
+    return cache.issues
+end
+
 local function init(graphql)
     graphql.add_callback({
         prefix = 'cluster',
@@ -19,10 +31,11 @@ local function init(graphql)
         doc = 'List issues in cluster',
         args = {},
         kind = gql_types.list(gql_type_warning.nonNull),
-        callback = 'cartridge.issues.list_on_cluster',
+        callback = module_name .. '.get_issues',
     })
 end
 
 return {
     init = init,
+    get_issues = get_issues,
 }

--- a/cartridge/webui/api-suggestions.lua
+++ b/cartridge/webui/api-suggestions.lua
@@ -1,16 +1,18 @@
 local module_name = 'cartridge.webui.api-suggestions'
 
 local fun = require('fun')
+local membership = require('membership')
 local issues = require('cartridge.issues')
 local topology = require('cartridge.topology')
 local confapplier = require('cartridge.confapplier')
-local lua_api_get_topology = require('cartridge.lua-api.get-topology')
 
 local gql_types = require('cartridge.graphql.types')
 
 local refine_uri_suggestion = gql_types.object({
     name = 'RefineUriSuggestion',
-    description = 'A suggestion to reconfigure cluster topology',
+    description =
+        'A suggestion to reconfigure cluster topology because ' ..
+        ' one or more servers were restarted with a new advertise uri',
     fields = {
         uuid = gql_types.string.nonNull,
         uri_old = gql_types.string.nonNull,
@@ -20,10 +22,17 @@ local refine_uri_suggestion = gql_types.object({
 
 local force_apply_suggestion = gql_types.object({
     name = 'ForceApplySuggestion',
-    description = 'A suggestion to force apply config on the specified instance',
+    description =
+        'A suggestion to reapply configuration forcefully.' ..
+        ' There may be several reasons to do that:' ..
+        ' configuration checksum mismatch (config_mismatch);' ..
+        ' the locking of tho-phase commit (config_locked);' ..
+        ' an error during previous config update (operation_error).',
     fields = {
         uuid = gql_types.string.nonNull,
-        reasons = gql_types.list(gql_types.string.nonNull).nonNull
+        config_locked = gql_types.boolean.nonNull,
+        config_mismatch = gql_types.boolean.nonNull,
+        operation_error = gql_types.boolean.nonNull,
     }
 })
 
@@ -53,48 +62,50 @@ local function refine_uri()
     return ret
 end
 
-local function parse_issues(issues)
-    local reasons_list = {}
+local function force_apply(_, _, info)
+    local topology_cfg = confapplier.get_readonly('topology')
+    if topology_cfg == nil then
+        return nil
+    end
 
-    for _, issue in ipairs(issues) do
+    local cache = info.context.request_cache
+    if cache.issues == nil then
+        cache.issues = issues.list_on_cluster()
+    end
+
+    local reasons_map = {}
+
+    for _, issue in ipairs(cache.issues) do
+        local uuid = issue.instance_uuid
+
         if issue.topic == 'config_mismatch'
-        or issue.topic == 'config_locked' then
-            if reasons_list[issue.instance_uuid] == nil then
-                reasons_list[issue.instance_uuid] = {}
-            end
-
-            if issue.topic == 'config_mismatch' then
-                table.insert(
-                    reasons_list[issue.instance_uuid],
-                    'Configuration checksum mismatch'
-                )
-            end
-
-            if issue.topic == 'config_locked' then
-                table.insert(
-                    reasons_list[issue.instance_uuid],
-                    'Configuration is prepared and locked'
-                )
-            end
+        or issue.topic == 'config_locked'
+        then
+            reasons_map[uuid] = reasons_map[uuid] or {}
+            reasons_map[uuid][issue.topic] = true
         end
     end
 
-    local servers = lua_api_get_topology.get_topology().servers
-    for uuid, srv in pairs(servers) do
-        if srv.message == 'OperationError' then
-            if reasons_list[uuid] == nil then
-                reasons_list[uuid] = {}
-            end
+    local refined_uri_list = topology.refine_servers_uri(topology_cfg)
+    for _, uuid, _ in fun.filter(topology.not_disabled, topology_cfg.servers) do
+        local member = membership.get_member(refined_uri_list[uuid])
 
-            table.insert(reasons_list[uuid], 'Operation Error')
+        if member ~= nil
+        and (member.status == 'alive' or member.status == 'suspect')
+        and member.payload.state == 'OperationError'
+        then
+            reasons_map[uuid] = reasons_map[uuid] or {}
+            reasons_map[uuid]['operation_error'] = true
         end
     end
 
     local ret = {}
-    for uuid, reasons in pairs(reasons_list) do
+    for uuid, reasons in pairs(reasons_map) do
         table.insert(ret, {
             uuid = uuid,
-            reasons = reasons
+            config_locked = reasons.config_locked or false,
+            config_mismatch = reasons.config_mismatch or false,
+            operation_error = reasons.operation_error or false,
         })
     end
 
@@ -103,16 +114,6 @@ local function parse_issues(issues)
     end
 
     return ret
-end
-
-local function force_apply(_, _, info)
-    local cache = info.context.request_cache
-    if cache.issues ~= nil then
-        return parse_issues(cache.issues)
-    end
-
-    cache.issues = issues.list_on_cluster()
-    return parse_issues(cache.issues)
 end
 
 local function get_suggestions(_, _, info)

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Tue Jan 12 2021 16:14:02 GMT+0300 (Moscow Standard Time)
+# timestamp: Fri Jan 15 2021 13:06:04 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -147,6 +147,12 @@ input FailoverStateProviderCfgInputTarantool {
 type FailoverStateProviderCfgTarantool {
   uri: String!
   password: String!
+}
+
+"""A suggestion to force apply config on the specified instance"""
+type ForceApplySuggestion {
+  uuid: String!
+  reasons: [String!]!
 }
 
 type Issue {
@@ -513,6 +519,7 @@ type ServerStat {
 
 type Suggestions {
   refine_uri: [RefineUriSuggestion!]
+  force_apply: [ForceApplySuggestion!]
 }
 
 """A single user account information"""

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Jan 15 2021 13:06:04 GMT+0300 (Moscow Standard Time)
+# timestamp: Fri Jan 15 2021 17:13:53 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -149,10 +149,17 @@ type FailoverStateProviderCfgTarantool {
   password: String!
 }
 
-"""A suggestion to force apply config on the specified instance"""
+"""
+A suggestion to reapply configuration forcefully. There may be several reasons
+to do that: configuration checksum mismatch (config_mismatch); the locking of
+tho-phase commit (config_locked); an error during previous config update
+(operation_error).
+"""
 type ForceApplySuggestion {
+  config_mismatch: Boolean!
+  config_locked: Boolean!
   uuid: String!
-  reasons: [String!]!
+  operation_error: Boolean!
 }
 
 type Issue {
@@ -257,7 +264,9 @@ type Query {
   replicasets(uuid: String): [Replicaset]
 }
 
-"""A suggestion to reconfigure cluster topology"""
+"""
+A suggestion to reconfigure cluster topology because  one or more servers were restarted with a new advertise uri
+"""
 type RefineUriSuggestion {
   uri_new: String!
   uuid: String!

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -58,6 +58,12 @@ function helpers.get_suggestions(server)
                     uri_old
                     uri_new
                 }
+                force_apply {
+                    uuid
+                    config_locked
+                    config_mismatch
+                    operation_error
+                }
             }}
         }]]
     }).data.cluster.suggestions

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -144,7 +144,10 @@ function g.test_2pc()
         }},
     })
 
-    t.assert_equals(helpers.get_suggestions(g.A1), {refine_uri = box.NULL})
+    t.assert_equals(helpers.get_suggestions(g.A1), {
+        refine_uri = box.NULL,
+        force_apply = box.NULL,
+    })
     helpers.retrying({}, function()
         -- Replication takes time to re-establish
         t.assert_equals(helpers.list_cluster_issues(g.A1), {})

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -167,12 +167,14 @@ function g.test_suggestions()
         query = [[{
             cluster { suggestions {
                 refine_uri {}
+                force_apply {}
             }}
         }]]
     }).data.cluster.suggestions
 
     t.assert_equals(suggestions, {
         refine_uri = box.NULL,
+        force_apply = box.NULL,
     })
 end
 

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -49,6 +49,7 @@ function g.test_uninitialized()
                     }
                     suggestions {
                         refine_uri {}
+                        force_apply {}
                     }
                     can_bootstrap_vshard
                     vshard_bucket_count
@@ -81,6 +82,7 @@ function g.test_uninitialized()
 
     t.assert_equals(resp['data']['cluster']['suggestions'], {
         refine_uri = box.NULL,
+        force_apply = box.NULL,
     })
 
     t.assert_equals(resp['data']['cluster']['can_bootstrap_vshard'], false)

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -146,7 +146,7 @@ function g.test_config_mismatch()
         helpers.list_cluster_issues(master),
         {{
             level = 'warning',
-            topic = 'configuration',
+            topic = 'config_mismatch',
             instance_uuid = helpers.uuid('a', 'a', 3),
             replicaset_uuid = helpers.uuid('a'),
             message = 'Configuration checksum mismatch' ..
@@ -193,7 +193,7 @@ function g.test_twophase_config_locked()
     -- But it's an issue from replicas point of view
     t.assert_items_include(helpers.list_cluster_issues(replica1), {{
         level = 'warning',
-        topic = 'configuration',
+        topic = 'config_locked',
         instance_uuid = master.instance_uuid,
         replicaset_uuid = master.replicaset_uuid,
         message = 'Configuration is prepared and locked'..

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -167,6 +167,20 @@ export type FailoverStateProviderCfgTarantool = {|
   password: $ElementType<Scalars, 'String'>,
 |};
 
+/**
+ * A suggestion to reapply configuration forcefully. There may be several reasons
+ * to do that: configuration checksum mismatch (config_mismatch); the locking of
+ * tho-phase commit (config_locked); an error during previous config update
+ * (operation_error).
+ */
+export type ForceApplySuggestion = {|
+  __typename?: 'ForceApplySuggestion',
+  config_mismatch: $ElementType<Scalars, 'Boolean'>,
+  config_locked: $ElementType<Scalars, 'Boolean'>,
+  uuid: $ElementType<Scalars, 'String'>,
+  operation_error: $ElementType<Scalars, 'Boolean'>,
+|};
+
 export type Issue = {|
   __typename?: 'Issue',
   level: $ElementType<Scalars, 'String'>,
@@ -410,7 +424,7 @@ export type QueryReplicasetsArgs = {|
   uuid?: ?$ElementType<Scalars, 'String'>,
 |};
 
-/** A suggestion to reconfigure cluster topology */
+/** A suggestion to reconfigure cluster topology because  one or more servers were restarted with a new advertise uri */
 export type RefineUriSuggestion = {|
   __typename?: 'RefineUriSuggestion',
   uri_new: $ElementType<Scalars, 'String'>,
@@ -629,6 +643,7 @@ export type ServerStat = {|
 export type Suggestions = {|
   __typename?: 'Suggestions',
   refine_uri?: ?Array<RefineUriSuggestion>,
+  force_apply?: ?Array<ForceApplySuggestion>,
 |};
 
 /** A single user account information */


### PR DESCRIPTION
Implemented GraphQL API that provides a user with suggestions to force-apply config on specified instances. It is a part of the suggestions API that is used for `refine_uri` stuff. Besides instance's UUID suggestions contain reasons:

```GraphQL
{
  cluster {
    suggestions {
      force_apply {
        uuid
        config_locked
        config_mismatch
        operation_error
      }
    } 
  }
}
```

Example output:

```json
{
  "data": {
    "cluster": {
      "suggestions": {
        "force_apply": [
          {
            "uuid": "451a1c78-e71e-47b5-b7f1-706143f6f205",
            "config_locked": false,
            "config_mismatch": false,
            "operation_error": true
          },
          {
            "uuid": "285c300d-7082-4e78-a880-63ed55066dc0",
            "config_locked": true,
            "config_mismatch": true,
            "operation_error": false
          }
        ]
      }
    }
  }
}
```


I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1187 
