### PR TITLE
Fix upstream.idle issue tolerance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,8 @@ Fixed
 - Stop vshard fibers when the corresponding role is disabled.
 - Make ``console.listen`` error more clear when ``console_sock`` exceeds
   ``UNIX_PATH_MAX`` limit.
+- Fix ``upstream.idle`` issue tolerance to avoid unnecessary warnings
+  "Replication: long idle (1 > 1)".
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI


### PR DESCRIPTION
When there's no workload on a cluster, the cartridge usually shows an issue:
"Replication from ... to ...: long idle (1 > 1)".  If the master has no
updates to send to the replicas, it sends heartbeat messages every
`replication_timeout` seconds and the issue is shown when
`upstream.idle > box.cfg.replication_timeout`.

This patch adds the 2x threshold to avoid unnecessary warnings.

I didn't forget about

- [x] Tests (not covered, hard to simulate)
- [x] Changelog
- [x] Documentation

Close #1173 
