### PR TITLE
Fix ddl management issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,9 @@ Fixed
   ``UNIX_PATH_MAX`` limit.
 - Fix ``upstream.idle`` issue tolerance to avoid unnecessary warnings
   "Replication: long idle (1 > 1)".
+- Allow removing spaces from DDL schema for the sake of ``drop`` migrations.
+- Make DDL schema validation stricter. Forbid redundant keys in schema top-level
+  and make ``spaces`` mandatory.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,7 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
-    'ddl == 1.1.0-1',
+    'ddl == 1.3.0-1',
     'http == 1.1.0-1',
     'checks == 3.1.0-1',
     'lulpeg == 0.1.2-1',

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -733,7 +733,7 @@ return {
 
     --- Get clusterwide DDL schema.
     -- It's like **\_G.cartridge\_get\_schema**,
-    -- but isn't non-global variable.
+    -- but isn't a global variable.
     --
     -- (**Added** in v2.0.1-54)
     -- @function get_schema
@@ -744,7 +744,7 @@ return {
 
     --- Apply clusterwide DDL schema.
     -- It's like **\_G.cartridge\_set\_schema**,
-    -- but isn't non-global variable.
+    -- but isn't a global variable.
     --
     -- (**Added** in v2.0.1-54)
     -- @function set_schema

--- a/cartridge/webui/api-ddl.lua
+++ b/cartridge/webui/api-ddl.lua
@@ -1,4 +1,3 @@
-local yaml = require('yaml')
 local errors = require('errors')
 local netbox = require('net.box')
 
@@ -41,8 +40,8 @@ local function graphql_get_schema()
         )
     end
     local schema_yml = confapplier.get_readonly(_section_name)
-    if schema_yml == nil then
-        schema_yml = yaml.encode({spaces = {}})
+    if schema_yml == nil or schema_yml == '' then
+        schema_yml = ddl_manager._example_schema
     end
 
     return {

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -507,7 +507,9 @@ function g.test_operation_error()
     -- Real tho-phase commit fails on apply stage with artificial error
     local resp = g.cluster.main_server:graphql({
         query = [[
-            mutation { cluster { schema(as_yaml: "{}") {} } }
+            mutation{ cluster{ config(
+                sections: [{filename: "x.txt", content: "oops"}]
+            ){} }}
         ]],
         raise = false,
     })

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -586,9 +586,17 @@ add('test_issues', function(g)
     end)
 
     -- Trigger apply_config
-    g.cluster.main_server:graphql({query = [[
-        mutation { cluster { schema(as_yaml: "{}") {} } }
-    ]]})
+    g.cluster.main_server:graphql({
+        query = [[
+            mutation ($uuids: [String!]) {
+                cluster { config_force_reapply(uuids: $uuids) }
+            }
+        ]],
+        variables = {uuids = {
+            R1.instance_uuid,
+            S3.instance_uuid,
+        }}
+    })
 
     helpers.retrying({}, function()
         t.assert_equals(helpers.list_cluster_issues(S1), {})

--- a/webui/cypress/integration/schema-editor.spec.js
+++ b/webui/cypress/integration/schema-editor.spec.js
@@ -1,9 +1,8 @@
-
-
 describe('Schema section', () => {
 
   before(() => {
-    cy.task('tarantool', {code: `
+    cy.task('tarantool', {
+      code: `
       cleanup()
 
       _G.cluster = helpers.Cluster:new({
@@ -32,57 +31,62 @@ describe('Schema section', () => {
   });
 
   it('Open WebUI', () => {
-    cy.visit('/admin/cluster/schema')
+    cy.visit('/admin/cluster/schema');
   });
 
   it('Schema with bootstrap', () => {
     const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
     const defaultText = '---\nspaces: []\n...\n';
 
-    cy.get('.monaco-editor textarea').should('have.value', defaultText);
+    cy.get('.monaco-editor').contains('## Example:');
 
     ////////////////////////////////////////////////////////////////////
-    cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
-    cy.get('.monaco-editor textarea').type('spaces: incorrect-1');
-    cy.get('.monaco-editor textarea').should('have.value', 'spaces: incorrect-1');
+    cy.get('.monaco-editor').type(selectAllKeys + '{backspace}');
+    cy.get('.monaco-editor').type('spaces: incorrect-1');
+    cy.get('.monaco-editor').contains('spaces: incorrect-1');
 
     cy.get('button[type="button"]').contains('Validate').click();
-    cy.get('#root').contains('Schema.spaces must be a ?table, got string');
+    cy.get('span:contains(Schema validation) + span:contains(Schema is valid)').click();
+    cy.get('#root').contains('spaces: must be a table, got string');
 
     cy.get('button[type="button"]').contains('Reload').click();
-    cy.get('.monaco-editor textarea').should('have.value', defaultText);
+    cy.get('.monaco-editor').contains('## Example:');
 
-    cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
-    cy.get('.monaco-editor textarea').type('spaces: [] # Essentially the same');
+    cy.get('.monaco-editor').type(selectAllKeys + '{backspace}');
+    cy.get('.monaco-editor').type('spaces: [] # Essentially the same');
 
     cy.get('button[type="button"]').contains('Validate').click();
     cy.get('#root').contains('Bad argument #1 to ddl.check_schema').should('not.exist');
-    cy.get('#root').contains('Schema is valid');
+    cy.get('span:contains(Schema validation) + span:contains(Schema is valid)').click();
 
     cy.get('button[type="button"]').contains('Apply').click();
     cy.get('span:contains(Success) + span:contains(Schema successfully applied)').click();
 
     ////////////////////////////////////////////////////////////////////
-    cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
-    cy.get('.monaco-editor textarea').type('spaces: incorrect-2');
-    cy.get('.monaco-editor textarea').should('have.value', 'spaces: incorrect-2');
+    cy.get('.monaco-editor').type(selectAllKeys + '{backspace}');
+    cy.get('.monaco-editor').type('spaces: incorrect-2');
+    cy.get('.monaco-editor').contains('spaces: incorrect-2');
 
     cy.get('button[type="button"]').contains('Apply').click();
-    cy.get('#root').contains('Schema.spaces must be a ?table, got string');
+    cy.get('#root').contains('spaces: must be a table, got string');
 
     cy.get('button[type="button"]').contains('Reload').click();
-    cy.get('.monaco-editor textarea').should('have.value', 'spaces: [] # Essentially the same');
+    cy.get('.monaco-editor').contains('spaces: [] # Essentially the same');
 
-    cy.get('.monaco-editor textarea').type(selectAllKeys + '{backspace}');
-    cy.get('.monaco-editor textarea').type(defaultText);
-    cy.get('.monaco-editor textarea').should('have.value', defaultText);
+    cy.get('.monaco-editor').type(selectAllKeys + '{backspace}');
+    cy.get('.monaco-editor').type(defaultText);
+    cy.get('.monaco-editor').contains('---');
+    cy.get('.monaco-editor').contains('spaces: []');
+    cy.get('.monaco-editor').contains('...');
 
     cy.get('button[type="button"]').contains('Apply').click();
     cy.get('#root').contains('Bad argument #1 to ddl.check_schema').should('not.exist');
     cy.get('span:contains(Success) + span:contains(Schema successfully applied)').click();
 
     cy.get('button[type="button"]').contains('Reload').click();
-    cy.get('.monaco-editor textarea').should('have.value', defaultText);
+    cy.get('.monaco-editor').contains('---');
+    cy.get('.monaco-editor').contains('spaces: []');
+    cy.get('.monaco-editor').contains('...');
   })
 
   it('Tab title on Schema page', () => {


### PR DESCRIPTION
- Allow removing spaces from DDL schema for the sake of `drop`
  migrations.
- Make DDL schema validation stricter. Fordid redundant keys in schema top-level and make `spaces` mandatory.
- Add an example on Schema page in WebUI when it's empty.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1117
Close #1200 
