### PR TITLE
Add implies_storage, implies_router attributes to cluster.known_roles GraphQL

### DIFF
--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -239,6 +239,8 @@ end
 
 return {
     role_name = 'vshard-router',
+    implies_router = true,
+
     validate_config = vshard_utils.validate_config,
     apply_config = apply_config,
     stop = stop,

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -74,6 +74,8 @@ end
 
 return {
     role_name = 'vshard-storage',
+    implies_storage = true,
+
     apply_config = apply_config,
     init = init,
     stop = stop,

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -175,6 +175,8 @@ local gql_type_role = gql_types.object {
     name = 'Role',
     fields = {
         name = gql_types.string.nonNull,
+        implies_router = gql_types.boolean.nonNull,
+        implies_storage = gql_types.boolean.nonNull,
         dependencies = gql_types.list(gql_types.string.nonNull),
     }
 }
@@ -291,12 +293,14 @@ end
 local function get_known_roles(_, _)
     local ret = {}
     for _, role_name in ipairs(roles.get_known_roles()) do
-        local role = {
-            name = role_name,
-            dependencies = roles.get_role_dependencies(role_name),
-        }
+        local role = roles.get_role(role_name)
 
-        table.insert(ret, role)
+        table.insert(ret, {
+            name = role_name,
+            implies_router = role.implies_router or false,
+            implies_storage = role.implies_storage or false,
+            dependencies = roles.get_role_dependencies(role_name),
+        })
     end
 
     return ret

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Mon Dec 14 2020 18:56:50 GMT+0300 (Moscow Standard Time)
+# timestamp: Tue Jan 12 2021 16:14:02 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -314,8 +314,10 @@ type ReplicaStatus {
 }
 
 type Role {
-  name: String!
   dependencies: [String!]
+  implies_storage: Boolean!
+  name: String!
+  implies_router: Boolean!
 }
 
 """A server participating in tarantool cluster"""

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -58,6 +58,8 @@ package.preload['mymodule'] = function()
 
     return {
         role_name = 'myrole',
+        implies_router = true,
+        implies_storage = true,
         dependencies = {
             'mymodule-dependency',
             'mymodule-hidden',

--- a/test/integration/myrole_test.lua
+++ b/test/integration/myrole_test.lua
@@ -38,17 +38,32 @@ end
 function g.test_api()
     local res = g.cluster.main_server:graphql({query = [[{
             cluster {
-                known_roles { name dependencies }
+                known_roles { name dependencies implies_router implies_storage }
             }
         }]]
     })
 
     t.assert_equals(res['data']['cluster']['known_roles'], {
-        {['name'] = 'failover-coordinator', ['dependencies'] = {}},
-        {['name'] = 'vshard-storage', ['dependencies'] = {}},
-        {['name'] = 'vshard-router', ['dependencies'] = {}},
-        {['name'] = 'myrole-dependency', ['dependencies'] = {}},
-        {['name'] = 'myrole', ['dependencies'] = {'myrole-dependency'}}
+        {
+            name = 'failover-coordinator', dependencies = {},
+            implies_router = false, implies_storage = false,
+        },
+        {
+            name = 'vshard-storage', dependencies = {},
+            implies_router = false, implies_storage = true,
+        },
+        {
+            name = 'vshard-router', dependencies = {},
+            implies_router = true, implies_storage = false,
+        },
+        {
+            name = 'myrole-dependency', dependencies = {},
+            implies_router = false, implies_storage = false,
+        },
+        {
+            name = 'myrole', dependencies = { 'myrole-dependency' },
+            implies_router = true, implies_storage = true,
+        },
     })
 end
 

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -460,8 +460,10 @@ export type ReplicaStatus = {|
 
 export type Role = {|
   __typename?: 'Role',
-  name: $ElementType<Scalars, 'String'>,
   dependencies?: ?Array<$ElementType<Scalars, 'String'>>,
+  implies_storage: $ElementType<Scalars, 'Boolean'>,
+  name: $ElementType<Scalars, 'String'>,
+  implies_router: $ElementType<Scalars, 'Boolean'>,
 |};
 
 /** A server participating in tarantool cluster */


### PR DESCRIPTION
Closes #1071

TDG explicitly marks vshard-storage role as hidden in favor of simple "storage". WebUI is unable to determine when vshard could be bootstrapped.

WebUI renders "Edit replicaset" dialog using the following query:
```graphql
{
  cluster {
    known_roles {
      name dependencies
    }
  }
}
```

Let's extend with `implies_storage`, `implies_router` attributes (both boolean). It may seem that `implies_router` is a new concept, but it's not. It's already used on the frontend implicitly. It's tied on a hardcoded name of the `vshard-router` role. Using this option makes it possible to eliminate implicit relations.