### PR TITLE
Add stateboard defaults

### DIFF
--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -797,6 +797,19 @@ local function get_failover_params(topology_cfg)
         -- because stateful failover itself wasn't implemented yet
     end
 
+    -- Enrich tarantool params with defaults
+    if ret.tarantool_params == nil then
+        ret.tarantool_params = {}
+    end
+
+    if ret.tarantool_params.uri == nil then
+        ret.tarantool_params.uri = 'tcp://localhost:4401'
+    end
+
+    if ret.tarantool_params.password == nil then
+        ret.tarantool_params.password = ''
+    end
+
     -- Enrich etcd2 params with defaults
     if ret.etcd2_params == nil then
         ret.etcd2_params = {}

--- a/instances.yml
+++ b/instances.yml
@@ -29,5 +29,5 @@ cartridge.srv-5:
 
 cartridge-stateboard:
     workdir: ./dev/stateboard
-    password: qwerty
+    password: ''
     listen: 4401

--- a/test/compatibility/config_test.lua
+++ b/test/compatibility/config_test.lua
@@ -72,13 +72,15 @@ function g.test_failover_2_0_1_78()
             mode
             state_provider
             tarantool_params {}
+            etcd2_params {}
         }}
     }]]}).data.cluster.failover_params
 
     t.assert_equals(failover_params, {
         mode = 'eventual',
         state_provider = box.NULL,
-        tarantool_params = box.NULL,
+        tarantool_params = {},
+        etcd2_params = {},
     })
 end
 
@@ -133,12 +135,14 @@ function g.test_failover_2_0_1_95()
             mode
             state_provider
             tarantool_params {}
+            etcd2_params {}
         }}
     }]]}).data.cluster.failover_params
 
     t.assert_equals(failover_params, {
         mode = 'eventual',
         state_provider = box.NULL,
-        tarantool_params = box.NULL,
+        tarantool_params = {},
+        etcd2_params = {},
     })
 end

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -363,6 +363,11 @@ g.test_api_failover = function()
         set_failover_params, {etcd2_params = {endpoints = {'%^&*'}}}
     )
 
+    local tarantool_defaults = {
+        uri = 'tcp://localhost:4401',
+        password = '',
+    }
+
     local etcd2_params = {
         prefix = '/',
         lock_delay = 10,
@@ -376,6 +381,7 @@ g.test_api_failover = function()
         }), {
             mode = 'eventual',
             failover_timeout = 0,
+            tarantool_params = tarantool_defaults,
             etcd2_params = {
                 prefix = 'kv',
                 lock_delay = 36.6,
@@ -397,6 +403,7 @@ g.test_api_failover = function()
         }), {
             mode = 'eventual',
             failover_timeout = 0,
+            tarantool_params = tarantool_defaults,
             etcd2_params = {
                 prefix = '/',
                 lock_delay = 10,
@@ -415,6 +422,7 @@ g.test_api_failover = function()
         {
             mode = 'eventual',
             failover_timeout = 0,
+            tarantool_params = tarantool_defaults,
             etcd2_params = etcd2_params,
             fencing_enabled = false,
             fencing_timeout = 4,
@@ -514,8 +522,8 @@ g.test_api_failover = function()
             mode = 'disabled',
             state_provider = 'tarantool',
             failover_timeout = 3,
-            tarantool_params = tarantool_params,
             etcd2_params = etcd2_defaults,
+            tarantool_params = tarantool_params,
             fencing_enabled = false,
             fencing_timeout = 4,
             fencing_pause = 2,

--- a/webui/cypress/integration/failover.spec.js
+++ b/webui/cypress/integration/failover.spec.js
@@ -154,7 +154,7 @@ describe('Failover', () => {
     cy.get('button[label="State provider"]').contains('Tarantool (stateboard)').click();
     cy.get('.meta-test__StateProvider__Dropdown *:contains(Tarantool (stateboard))');
     cy.get('.meta-test__StateProvider__Dropdown *:contains(Etcd)');
-    cy.get('.meta-test__stateboardURI input').should('have.value', '');
+    cy.get('.meta-test__stateboardURI input').should('have.value', 'tcp://localhost:4401');
     cy.get('.meta-test__stateboardPassword input').should('have.value', '');
     //error failover_timeout must be greater than fencing_timeout
     cy.get('.meta-test__SubmitButton').click();
@@ -162,6 +162,7 @@ describe('Failover', () => {
       'topology_new.failover.failover_timeout must be greater than fencing_timeout'
     );
     //error Invalid URI ""
+    cy.get('.meta-test__stateboardURI input').type('{selectAll}{del}');
     cy.get('.meta-test__fencingTimeout input').type('{selectAll}{del}4');
     cy.get('.meta-test__SubmitButton').click();
     cy.get('.meta-test__inlineError span').should('have.text',


### PR DESCRIPTION
Stateboard defaults have been added to the `failover_params` query:

```json
{
  "tarantool_params": {
    "uri": "tcp://localhost:4401",
    "password": ""
  }
}
```


I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Close #1189 
