### PR TITLE
Fix x-etcd-index updates during longpolling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,14 @@ Added
   heal the cluster in case of config errors like ``Configuration checksum mismatch``,
   ``Configuration is prepared and locked``, and sometimes ``OperationError``.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Properly handle etcd index updates while polling stateful failover updates.
+  The problem affected long-running clusters and resulted in flooding logs with
+  the "Etcd cluster id mismatch" warnings.
+
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29
 -------------------------------------------------------------------------------

--- a/cartridge/etcd2-client.lua
+++ b/cartridge/etcd2-client.lua
@@ -100,7 +100,8 @@ local function set_leaders(session, updates)
     local old_leaders = session.leaders
     local new_leaders = {}
     for _, leader in ipairs(updates) do
-        local replicaset_uuid, instance_uuid = unpack(leader)
+        local replicaset_uuid = leader[1]
+        local instance_uuid = leader[2]
         if new_leaders[replicaset_uuid] ~= nil then
             return nil, SessionError:new('Duplicate key in updates')
         end

--- a/cartridge/etcd2.lua
+++ b/cartridge/etcd2.lua
@@ -97,6 +97,7 @@ local function request(connection, method, path, args, opts)
             err.etcd_index = data.index
             return nil, err
         else
+            data.etcd_index = resp.headers['x-etcd-index']
             return data
         end
 

--- a/test/integration/etcd2_client_test.lua
+++ b/test/integration/etcd2_client_test.lua
@@ -194,53 +194,61 @@ function g.test_longpolling()
 end
 
 function g.test_event_cleared()
-    local vclockkeeper = create_client():get_session()
-    -- local c2 = create_client():get_session()
-
-    local etcd2_connection = etcd2.connect(
-        {URI},
-        {
-            prefix = 'etcd2_client_test',
-            request_timeout = 1,
-            username = '',
-            password = ''
-        }
-    )
-
-    t.assert_equals(
-        vclockkeeper:acquire_lock({uuid = 'a1', uri = 'localhost:9'}),
-        true
-    )
-    vclockkeeper:set_leaders({{'A', 'a1'}, {'B', 'b1'}})
+    local httpc = httpc.new({max_connections = 100})
+    local function set_leaders(leaders)
+        local resp = httpc:put(
+            URI .. '/v2/keys/etcd2_client_test/leaders',
+            'value=' .. json.encode(leaders)
+        )
+        t.assert_covers(resp, {reason = "Ok"})
+    end
 
     local client1 = create_client()
     local client2 = create_client()
-    t.assert_equals(client1:longpoll(0), {A = 'a1', B = 'b1'})
-    t.assert_equals(client2:longpoll(0), {A = 'a1', B = 'b1'})
 
+    set_leaders({A = 'a1'})
+    t.assert_equals(client1:longpoll(0.2), {A = 'a1'})
+    t.assert_equals(client2:longpoll(0.2), {A = 'a1'})
+
+    -- Cause the error "The event in requested index is outdated and
+    -- cleared" by inserting 1000 values. The number 1000 is hardcoded
+    -- in the etcd source code:
+    -- https://github.com/etcd-io/etcd/blob/master/server/etcdserver/api/v2store/store.go#L101
+    -- See also: https://github.com/etcd-io/etcd/issues/925#issuecomment-51722404
     local fiber_map = {}
-    for i = 0, 1000 do
+    for i = 1, 100 do
         local fiber_object = fiber.new(function()
-            etcd2_connection:request('PUT', 'foo', {value = i})
+            for _ = 1, 11 do
+                httpc:put(URI .. '/v2/keys/foo?value=bar')
+            end
         end)
         fiber_object:set_joinable(true)
-        table.insert(fiber_map, fiber_object)
+        fiber_map[i] = fiber_object
     end
 
     for _, fiber_object in ipairs(fiber_map) do
         fiber_object:join()
     end
 
+    -- Self-test. We check the behavior of
+    local resp = httpc:get(URI .. '/v2/keys/foo' ..
+        '?wait=true&waitIndex=' .. (client1.session.longpoll_index + 1)
+    )
+    t.assert_covers(resp, {status = 400})
+    t.assert_covers(json.decode(resp.body),
+        {errorCode = etcd2.EcodeEventIndexCleared}
+    )
+
     --  ----s---|-------
     --       ^         ^
     -- In case of cleared history long-polling algorithm will return
     -- old leaders even if they haven't changed
-    t.assert_equals(client1:longpoll(0.1), {A = 'a1', B = 'b1'})
+    t.assert_equals(client1:longpoll(0.1), {A = 'a1'})
 
     --  ----s---|----x--
     --       ^         ^
-    vclockkeeper:set_leaders({{'A', 'a2'}, {'B', 'b1'}})
-    t.assert_equals(client2:longpoll(0.1), {A = "a2", B = "b1"})
+    set_leaders({A = 'a2'})
+    t.assert_equals(client2:longpoll(0.1), {A = 'a2'})
 end
 
 function g.test_client_drop_session()

--- a/test/integration/etcd2_client_test.lua
+++ b/test/integration/etcd2_client_test.lua
@@ -249,6 +249,12 @@ function g.test_event_cleared()
     --       ^         ^
     set_leaders({A = 'a2'})
     t.assert_equals(client2:longpoll(0.1), {A = 'a2'})
+
+    -- Check that longpoll_index is updated despite leaders aren't modified
+    local old_index = client2.session.longpoll_index
+    httpc:put(URI .. '/v2/keys/foo?value=buzz')
+    t.assert_equals(client2:longpoll(0.1), {})
+    t.assert_equals(client2.session.longpoll_index, old_index + 1)
 end
 
 function g.test_client_drop_session()


### PR DESCRIPTION
The long-polling algorithm has a bug:

1. Every instance does HTTP GET `/v2/keys/leaders?waitIndex=N&wait=true`.
2. Since there're no updates, it queries the same `waitIndex=N` all the time.
3. Meanwhile, the failover coordinator from time to time refreshes the lock and updates the `etcd-index`.
4. After 1000 changes, etcd clears the history, and the next HTTP GET results in error 400 "The event in requested index is outdated and cleared".
5. An instance retries it several times, and finally makes another request with `{timeout = 0}` option. This time the response turns out to be `{"status": 408, "reason": "Timeout was reached"}` with no headers.
6. The etcd client reconnects and it starts over.

This patch fixes the long-polling algorithm:

- In case there're no updates the `waitIndex` is bumped with the current `etcd-index` value.
- Encountering the queue clear error becomes very unlikely, but even if it occurs, etcd client handles it properly and resets the `waitIndex` without actual reconnect.

See also:
- https://github.com/etcd-io/etcd/blob/master/server/etcdserver/api/v2store/store.go#L101
- https://github.com/etcd-io/etcd/issues/925#issuecomment-51722404

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1205 
