### PR TITLE
Add issue for a long ConfiguringRoles state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Added
 - New GraphQL API: ``{cluster {suggestions {force_apply {uuid reasons}}}}`` to
   heal the cluster in case of config errors like ``Configuration checksum mismatch``,
   ``Configuration is prepared and locked``, and sometimes ``OperationError``.
+- New issue ``state_stuck`` that is triggered when instance is hanging in
+  ``ConfiguringRoles`` state for more than 5s.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,7 @@ Added
 - New GraphQL API: ``{cluster {suggestions {force_apply {uuid reasons}}}}`` to
   heal the cluster in case of config errors like ``Configuration checksum mismatch``,
   ``Configuration is prepared and locked``, and sometimes ``OperationError``.
-- New issue ``state_stuck`` that is triggered when instance is hanging in
-  ``ConfiguringRoles`` state for more than 5s.
+- Show an issue when ``ConfiguringRoles`` state stucks for more than 5s.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -38,6 +38,7 @@ local OperationError = errors.new_class('OperationError')
 
 vars:new('state', '')
 vars:new('error')
+vars:new('timestamp') -- used for issues
 vars:new('state_notification', fiber.cond())
 vars:new('state_notification_timeout', 5)
 vars:new('clusterwide_config')
@@ -140,6 +141,7 @@ local function set_state(new_state, err)
     membership.set_payload('state', new_state)
     vars.state = new_state
     vars.error = err
+    vars.timestamp = fiber.time()
     vars.state_notification:broadcast()
 end
 

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -38,9 +38,9 @@ local OperationError = errors.new_class('OperationError')
 
 vars:new('state', '')
 vars:new('error')
-vars:new('timestamp') -- used for issues
 vars:new('state_notification', fiber.cond())
 vars:new('state_notification_timeout', 5)
+vars:new('state_timestamp', 0) -- last time the state was set
 vars:new('clusterwide_config')
 
 vars:new('workdir')
@@ -141,7 +141,7 @@ local function set_state(new_state, err)
     membership.set_payload('state', new_state)
     vars.state = new_state
     vars.error = err
-    vars.timestamp = fiber.time()
+    vars.state_timestamp = fiber.clock()
     vars.state_notification:broadcast()
 end
 

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -36,13 +36,14 @@
 --   `box.slab.info()` exceed `limits.fragmentation_threshold_critical`;
 -- * "Memory is highly fragmented on ..." - when
 --   `items_used_ratio > limits.fragmentation_threshold_warning` and
---   both `arena_used_ratio`, `quota_used_ratio` exceed critical limit.
+--   both `arena_used_ratio`, `quota_used_ratio` exceed critical limit;
 --
 -- Configuration:
 --
--- * "Configuration checksum mismatch on ...".
--- * "Advertise URI (...) differs from clusterwide config (...)".
--- * "Configuration is prepared and locked on ..."
+-- * "Configuration checksum mismatch on ...";
+-- * "Configuration is prepared and locked on ...";
+-- * "Advertise URI (...) differs from clusterwide config (...)";
+-- * "Configuring roles is stuck on ... and hangs for ... so far";
 --
 -- @module cartridge.issues
 -- @local
@@ -313,21 +314,23 @@ local function list_on_instance(opts)
         })
     end
 
-    local conf_vars = require('cartridge.vars').new('cartridge.confapplier')
-    local timeout = conf_vars.state_notification_timeout
-    local deadline = conf_vars.timestamp + timeout
-    if conf_vars.state == 'ConfiguringRoles'
-    and deadline < fiber.time() then
-        table.insert(ret, {
-            level = 'warning',
-            topic = 'state_stuck',
-            instance_uuid = instance_uuid,
-            replicaset_uuid = replicaset_uuid,
-            message = string.format(
-                'ConfiguringRoles state hangs on %s',
-                describe(self_uri)
-            ),
-        })
+    if confapplier.get_state() == 'ConfiguringRoles' then
+        local confapplier_vars = require('cartridge.vars').new('cartridge.confapplier')
+        local elapsed = fiber.clock() - confapplier_vars.state_timestamp
+        local timeout = confapplier_vars.state_notification_timeout
+        if elapsed > timeout then
+            table.insert(ret, {
+                level = 'warning',
+                topic = 'state_stuck',
+                instance_uuid = instance_uuid,
+                replicaset_uuid = replicaset_uuid,
+                message = string.format(
+                    'Configuring roles is stuck on %s' ..
+                    ' and hangs for %ds so far',
+                    describe(self_uri), elapsed
+                ),
+            })
+        end
     end
 
     return ret

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -252,10 +252,10 @@ function g.test_state_hangs()
     -- When instance passes ConfiguringRoles issue is gone
     t.assert_items_include(helpers.list_cluster_issues(replica1), {})
 
-    replica1.net_box:eval(string.format([[
+    replica1.net_box:eval([[
         local conf_vars = require('cartridge.vars').new('cartridge.confapplier')
-        conf_vars.state_notification_timeout = %d
+        conf_vars.state_notification_timeout = ...
 
         package.loaded['mymodule-permanent'].apply_config = nil
-    ]], old_timeout))
+    ]], {old_timeout})
 end

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -2,6 +2,7 @@ local t = require('luatest')
 local g = t.group()
 
 local fio = require('fio')
+local fiber = require('fiber')
 local helpers = require('test.helper')
 
 g.before_all(function()
@@ -12,7 +13,7 @@ g.before_all(function()
         cookie = require('digest').urandom(6):hex(),
         replicasets = {{
             uuid = helpers.uuid('a'),
-            roles = {},
+            roles = {'myrole-permanent'},
             servers = {{
                 alias = 'master',
                 instance_uuid = helpers.uuid('a', 'a', 1)
@@ -207,4 +208,54 @@ function g.test_twophase_config_locked()
     t.helpers.retrying({}, function()
         t.assert_equals(helpers.list_cluster_issues(master), {})
     end)
+end
+
+function g.test_state_hangs()
+    local master = g.cluster.main_server
+    local replica1 = g.cluster:server('replica1')
+
+    t.assert_equals(helpers.list_cluster_issues(master), {})
+
+    local old_timeout = replica1.net_box:eval([[
+        local conf_vars = require('cartridge.vars').new('cartridge.confapplier')
+        local old_timeout = conf_vars.state_notification_timeout
+        conf_vars.state_notification_timeout = 0.1
+
+        package.loaded['mymodule-permanent'].apply_config = function()
+            -- instance will stop hanging in ConfiguringRoles after 0.3s
+            require('fiber').sleep(0.3)
+        end
+
+        return old_timeout
+    ]])
+
+    fiber.new(function()
+        master:graphql({
+            query = [[mutation($uuids: [String]) {
+                cluster { config_force_reapply(uuids: $uuids) }
+            }]],
+            variables = {uuids = {replica1.instance_uuid}}
+        })
+    end)
+
+    t.assert_equals(helpers.list_cluster_issues(replica1), {})
+    fiber.sleep(0.1)
+    t.assert_items_include(helpers.list_cluster_issues(replica1), {{
+        level = 'warning',
+        topic = 'state_stuck',
+        instance_uuid = replica1.instance_uuid,
+        replicaset_uuid = replica1.replicaset_uuid,
+        message = 'ConfiguringRoles state hangs'..
+            ' on localhost:13302 (replica1)',
+    }})
+    fiber.sleep(0.3)
+    -- When instance passes ConfiguringRoles issue is gone
+    t.assert_items_include(helpers.list_cluster_issues(replica1), {})
+
+    replica1.net_box:eval(string.format([[
+        local conf_vars = require('cartridge.vars').new('cartridge.confapplier')
+        conf_vars.state_notification_timeout = %d
+
+        package.loaded['mymodule-permanent'].apply_config = nil
+    ]], old_timeout))
 end


### PR DESCRIPTION
New issue `state_stuck` that is triggered when instance is hanging in `ConfiguringRoles` state for more than 5s (`state_notification_timeout`).

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1172 
