### PR TITLE
Add zone field to the join_server API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Fixed
   The problem affected long-running clusters and resulted in flooding logs with
   the "Etcd cluster id mismatch" warnings.
 
+- Allow specifying server zone in ``join_server`` API.
+
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29
 -------------------------------------------------------------------------------

--- a/cartridge/lua-api/deprecated.lua
+++ b/cartridge/lua-api/deprecated.lua
@@ -39,6 +39,7 @@ local function join_server(args)
         replicaset_uuid = '?string',
         roles = '?table',
         timeout = '?number',
+        zone = '?string',
         labels = '?table',
         vshard_group = '?string',
         replicaset_alias = '?string',
@@ -71,6 +72,9 @@ local function join_server(args)
         args.replicaset_weight = nil
     end
 
+    if args.zone ~= nil and args.zone:strip() == '' then
+        args.zone = nil
+    end
 
     local topology, err = lua_api_topology.edit_topology({
         -- async = false,
@@ -83,6 +87,7 @@ local function join_server(args)
             join_servers = {{
                 uri = args.uri,
                 uuid = args.instance_uuid,
+                zone = args.zone,
                 labels = args.labels,
             }}
         }}

--- a/cartridge/lua-api/deprecated.lua
+++ b/cartridge/lua-api/deprecated.lua
@@ -25,6 +25,7 @@ local EditTopologyError = errors.new_class('Editing cluster topology failed')
 -- @tparam ?string args.replicaset_uuid
 -- @tparam ?{string,...} args.roles
 -- @tparam ?number args.timeout
+-- @tparam ?string args.zone (**Added** in v2.4.0-14)
 -- @tparam ?{[string]=string,...} args.labels
 -- @tparam ?string args.vshard_group
 -- @tparam ?string args.replicaset_alias

--- a/cartridge/lua-api/edit-topology.lua
+++ b/cartridge/lua-api/edit-topology.lua
@@ -28,6 +28,7 @@ local function __join_server(topology_cfg, params)
     checks(topology_cfg_checker, {
         uri = 'string',
         uuid = 'string',
+        zone = '?string',
         labels = '?table',
         replicaset_uuid = 'string',
     })
@@ -46,8 +47,13 @@ local function __join_server(topology_cfg, params)
     )
     table.insert(replicaset.master, params.uuid)
 
+    if params.zone ~= nil and params.zone:strip() == '' then
+        params.zone = nil
+    end
+
     local server = {
         uri = params.uri,
+        zone = params.zone,
         labels = params.labels,
         disabled = false,
         replicaset_uuid = params.replicaset_uuid,

--- a/cartridge/lua-api/edit-topology.lua
+++ b/cartridge/lua-api/edit-topology.lua
@@ -256,6 +256,7 @@ end
 --- Parameters required for joining a new server.
 -- @tfield string uri
 -- @tfield ?string uuid
+-- @tfield ?string zone (**Added** in v2.4.0-14)
 -- @tfield ?table labels
 -- @table JoinServerParams
 -- @within Editing topology

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -134,6 +134,7 @@ local gql_type_edit_replicaset_input = gql_types.inputObject {
                 fields = {
                     uri = gql_types.string.nonNull,
                     uuid = gql_types.string,
+                    zone = gql_types.string,
                     labels = gql_types.list(gql_type_label_input),
                 }
             })
@@ -344,6 +345,7 @@ local function init(graphql)
             replicaset_uuid = gql_types.string,
             roles = gql_types.list(gql_types.string.nonNull),
             timeout = gql_types.float,
+            zone = gql_types.string,
             labels = gql_types.list(gql_type_label_input),
             vshard_group = gql_types.string,
             replicaset_alias = gql_types.string,

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Jan 15 2021 17:13:53 GMT+0300 (Moscow Standard Time)
+# timestamp: Wed Jan 27 2021 15:01:55 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -172,6 +172,7 @@ type Issue {
 
 """Parameters for joining a new server"""
 input JoinServerInput {
+  zone: String
   uri: String!
   uuid: String
   labels: [LabelInput]
@@ -207,7 +208,7 @@ type Mutation {
   edit_replicaset(weight: Float, master: [String!], alias: String, roles: [String!], uuid: String!, all_rw: Boolean, vshard_group: String): Boolean
 
   """Deprecated. Use `cluster{edit_topology()}` instead."""
-  join_server(instance_uuid: String, timeout: Float, uri: String!, vshard_group: String, labels: [LabelInput], replicaset_alias: String, replicaset_weight: Float, roles: [String!], replicaset_uuid: String): Boolean
+  join_server(instance_uuid: String, timeout: Float, zone: String, uri: String!, vshard_group: String, labels: [LabelInput], replicaset_alias: String, replicaset_uuid: String, roles: [String!], replicaset_weight: Float): Boolean
   bootstrap_vshard: Boolean
 
   """Deprecated. Use `cluster{edit_topology()}` instead."""

--- a/test/integration/api_join_test.lua
+++ b/test/integration/api_join_test.lua
@@ -154,6 +154,7 @@ function g.test_join_server()
                 replicaset_uuid: "bbbbbbbb-0000-0000-0000-000000000000"
                 replicaset_alias: "spare-set"
                 roles: ["vshard-storage"]
+                zone: "z1"
             )
         }]]
     })
@@ -181,6 +182,7 @@ function g.test_join_server()
             servers {
                 uri
                 uuid
+                zone
                 status
                 replicaset { alias uuid status roles weight }
             }
@@ -196,6 +198,7 @@ function g.test_join_server()
         {
             uri = 'localhost:13302',
             uuid = g.server.instance_uuid,
+            zone = 'z1',
             status = 'healthy',
             replicaset = {
                 alias = 'spare-set',

--- a/test/integration/multiboot_test.lua
+++ b/test/integration/multiboot_test.lua
@@ -73,6 +73,7 @@ function g:test_bootstrap()
                             status
                             uuid
                             uri
+                            zone
                             labels {name value}
                             boxinfo { general {pid} }
                         }
@@ -87,6 +88,7 @@ function g:test_bootstrap()
                     join_servers = {{
                         uri = a1.advertise_uri,
                         uuid = a1.instance_uuid,
+                        zone = 'z1',
                         labels = {{name = 'addr', value = a1.advertise_uri}},
                     }},
                     failover_priority = {a1.instance_uuid},
@@ -124,6 +126,7 @@ function g:test_bootstrap()
         }
     })
     t.assert_equals(topology.servers[1].uuid, a1.instance_uuid)
+    t.assert_equals(topology.servers[1].zone, 'z1')
 
     local pids = {}
     for _, srv in pairs(topology.servers) do

--- a/test/integration/zones_test.lua
+++ b/test/integration/zones_test.lua
@@ -18,7 +18,6 @@ g.before_all(function()
     })
     g.cluster:start()
 
-
     g.A1 = g.cluster:server('A-1')
     g.A2 = g.cluster:server('A-2')
     g.A3 = g.cluster:server('A-3')

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -192,6 +192,7 @@ export type Issue = {|
 
 /** Parameters for joining a new server */
 export type JoinServerInput = {|
+  zone?: ?$ElementType<Scalars, 'String'>,
   uri: $ElementType<Scalars, 'String'>,
   uuid?: ?$ElementType<Scalars, 'String'>,
   labels?: ?Array<?LabelInput>,


### PR DESCRIPTION
Zone setting is now supported by `join_server` API

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1230 
