### PR TITLE
Never skip two-phase commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,9 @@ Fixed
 
 - Allow specifying server zone in ``join_server`` API.
 
-- Querying zone names for dead servers.
+- Fix corner cases when querying server zones.
+
+- Don't skip config apply even if it didn't change.
 
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -330,14 +330,6 @@ local function _clusterwide(patch)
 
     topology.probe_missing_members(topology_new.servers)
 
-    if utils.deepcmp(
-        clusterwide_config_new:get_plaintext(),
-        clusterwide_config_old:get_plaintext()
-    ) then
-        log.warn("Clusterwide config didn't change, skipping")
-        return true
-    end
-
     local ok, err = topology.validate(topology_new, topology_old)
     if not ok then
         log.error('%s', err)

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -499,19 +499,11 @@ function g.test_operation_error()
         end
     ]])
 
-    -- Dummy mutation doesn't trigger two-phase commit
-    g.cluster.main_server:graphql({
-        query = [[
-            mutation { cluster { config(sections: []) {} } }
-        ]],
-    })
-
-    -- Real tho-phase commit fails on apply stage with artificial error
+    -- Since v2.4.0-17 two-phase commit is never skipped
+    -- Tho-phase commit fails on apply stage with artificial error
     local resp = g.cluster.main_server:graphql({
         query = [[
-            mutation{ cluster{ config(
-                sections: [{filename: "x.txt", content: "oops"}]
-            ){} }}
+            mutation { cluster { config(sections: []) {} } }
         ]],
         raise = false,
     })


### PR DESCRIPTION
Commit f0b83825 introduced skipping two-phase commit if it didn't change. Back in those days, new instances used to poll the config from already bootstrapped ones, and there were lots of restrictions connected to the membership status validation. Occasionally, an attempt to apply the same config resulted in an unexpected error "Server is unreachable with status dead" despite everything was ok.

In Cartridge v2.0 everything changed. Today the bootstrap is called over remote-control, membership status checks eliminated, and updating config doesn't produce false errors anymore.

But today, we've got situations when the config is inconsistent across instances and uploading it says "ok" but does nothing.

This patch simply eliminates the skipping. It does more harm than good today.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1046 
Close #1056 
