### PR TITLE
Add suggestion to disable malfunctioning servers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Added
   heal the cluster in case of config errors like ``Configuration checksum mismatch``,
   ``Configuration is prepared and locked``, and sometimes ``OperationError``.
 - Show an issue when ``ConfiguringRoles`` state stucks for more than 5s.
+- New GraphQL API: ``{cluster {suggestions {disable_servers {uuid}}}}``
+  to restore the quorum in case of some servers go offline.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Wed Jan 27 2021 15:01:55 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Feb 01 2021 17:26:24 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -66,6 +66,13 @@ type DDLCheckResult {
 """The schema"""
 type DDLSchema {
   as_yaml: String!
+}
+
+"""
+A suggestion to disable malfunctioning servers  in order to restore the quorum
+"""
+type DisableServersSuggestion {
+  uuid: String!
 }
 
 """Parameters for editing a replicaset"""
@@ -528,8 +535,9 @@ type ServerStat {
 }
 
 type Suggestions {
-  refine_uri: [RefineUriSuggestion!]
   force_apply: [ForceApplySuggestion!]
+  refine_uri: [RefineUriSuggestion!]
+  disable_servers: [DisableServersSuggestion!]
 }
 
 """A single user account information"""

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -64,6 +64,9 @@ function helpers.get_suggestions(server)
                     config_mismatch
                     operation_error
                 }
+                disable_servers  {
+                    uuid
+                }
             }}
         }]]
     }).data.cluster.suggestions

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -147,6 +147,7 @@ function g.test_2pc()
     t.assert_equals(helpers.get_suggestions(g.A1), {
         refine_uri = box.NULL,
         force_apply = box.NULL,
+        disable_servers = box.NULL,
     })
     helpers.retrying({}, function()
         -- Replication takes time to re-establish

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -168,6 +168,7 @@ function g.test_suggestions()
             cluster { suggestions {
                 refine_uri {}
                 force_apply {}
+                disable_servers {}
             }}
         }]]
     }).data.cluster.suggestions
@@ -175,6 +176,7 @@ function g.test_suggestions()
     t.assert_equals(suggestions, {
         refine_uri = box.NULL,
         force_apply = box.NULL,
+        disable_servers = box.NULL,
     })
 end
 

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -50,6 +50,7 @@ function g.test_uninitialized()
                     suggestions {
                         refine_uri {}
                         force_apply {}
+                        disable_servers {}
                     }
                     can_bootstrap_vshard
                     vshard_bucket_count
@@ -83,6 +84,7 @@ function g.test_uninitialized()
     t.assert_equals(resp['data']['cluster']['suggestions'], {
         refine_uri = box.NULL,
         force_apply = box.NULL,
+        disable_servers = box.NULL,
     })
 
     t.assert_equals(resp['data']['cluster']['can_bootstrap_vshard'], false)

--- a/test/integration/disable_test.lua
+++ b/test/integration/disable_test.lua
@@ -4,7 +4,7 @@ local g = t.group()
 
 local helpers = require('test.helper')
 
-g.before_all = function()
+g.before_each(function()
     g.cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = helpers.entrypoint('srv_basic'),
@@ -30,18 +30,23 @@ g.before_all = function()
                     http_port = 8082,
                 }}
             }
+        },
+        env = {
+            TARANTOOL_SWIM_SUSPECT_TIMEOUT_SECONDS = 0,
         }
     })
-    g.cluster:start()
-end
+    g.victim = g.cluster:server('victim')
 
-g.after_all = function()
+    g.cluster:start()
+end)
+
+g.after_each(function()
     g.cluster:stop()
     fio.rmtree(g.cluster.datadir)
-end
+end)
 
 function g.test_api_disable()
-    g.cluster:server('victim'):stop()
+    g.victim:stop()
 
     g.cluster.main_server:graphql({query = [[
         mutation {
@@ -60,4 +65,21 @@ function g.test_api_disable()
     local servers = res.data.servers
     t.assert_equals(#servers, 1)
     t.assert_equals(servers[1], {disabled = true})
+end
+
+function g.test_suggestion()
+    g.victim:stop()
+
+    local suggestions = helpers.get_suggestions(g.cluster.main_server)
+    t.assert_equals(suggestions.disable_servers, {{
+        uuid = g.victim.instance_uuid
+    }})
+
+    g.cluster.main_server:graphql({query = [[
+        mutation {
+            cluster { disable_servers(uuids: ["bbbbbbbb-bbbb-0000-0000-000000000001"]) {} }
+        }
+    ]]})
+    local suggestions = helpers.get_suggestions(g.cluster.main_server)
+    t.assert_equals(suggestions.disable_servers, box.NULL)
 end

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -85,6 +85,12 @@ export type DdlSchema = {|
   as_yaml: $ElementType<Scalars, 'String'>,
 |};
 
+/** A suggestion to disable malfunctioning servers  in order to restore the quorum */
+export type DisableServersSuggestion = {|
+  __typename?: 'DisableServersSuggestion',
+  uuid: $ElementType<Scalars, 'String'>,
+|};
+
 /** Parameters for editing a replicaset */
 export type EditReplicasetInput = {|
   uuid?: ?$ElementType<Scalars, 'String'>,
@@ -255,13 +261,14 @@ export type MutationEdit_ReplicasetArgs = {|
 export type MutationJoin_ServerArgs = {|
   instance_uuid?: ?$ElementType<Scalars, 'String'>,
   timeout?: ?$ElementType<Scalars, 'Float'>,
+  zone?: ?$ElementType<Scalars, 'String'>,
   uri: $ElementType<Scalars, 'String'>,
   vshard_group?: ?$ElementType<Scalars, 'String'>,
   labels?: ?Array<?LabelInput>,
   replicaset_alias?: ?$ElementType<Scalars, 'String'>,
-  replicaset_weight?: ?$ElementType<Scalars, 'Float'>,
-  roles?: ?Array<$ElementType<Scalars, 'String'>>,
   replicaset_uuid?: ?$ElementType<Scalars, 'String'>,
+  roles?: ?Array<$ElementType<Scalars, 'String'>>,
+  replicaset_weight?: ?$ElementType<Scalars, 'Float'>,
 |};
 
 
@@ -643,8 +650,9 @@ export type ServerStat = {|
 
 export type Suggestions = {|
   __typename?: 'Suggestions',
-  refine_uri?: ?Array<RefineUriSuggestion>,
   force_apply?: ?Array<ForceApplySuggestion>,
+  refine_uri?: ?Array<RefineUriSuggestion>,
+  disable_servers?: ?Array<DisableServersSuggestion>,
 |};
 
 /** A single user account information */
@@ -699,7 +707,7 @@ type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $Elem
 
 export type ServerStatFieldsFragment = ({
     ...{ __typename?: 'Server' },
-  ...$Pick<Server, {| uuid: *, uri: *, zone?: * |}>,
+  ...$Pick<Server, {| uuid: *, uri: * |}>,
   ...{| statistics?: ?({
       ...{ __typename?: 'ServerStat' },
     ...$Pick<ServerStat, {| quota_used_ratio: *, arena_used_ratio: *, items_used_ratio: * |}>,
@@ -910,7 +918,7 @@ export type ServerListQuery = ({
     ...{ __typename?: 'Query' },
   ...{| serverList?: ?Array<?({
       ...{ __typename?: 'Server' },
-    ...$Pick<Server, {| uuid: *, alias?: *, uri: *, status: *, message: * |}>,
+    ...$Pick<Server, {| uuid: *, alias?: *, uri: *, zone?: *, status: *, message: * |}>,
     ...{| boxinfo?: ?({
         ...{ __typename?: 'ServerInfo' },
       ...{| general: ({


### PR DESCRIPTION
New suggestion to disable malfunctioning servers in order to restore the quorum:

```GraphQl
query {
  cluster {
    suggestions {
      disable_servers  {
        uuid
      } 
    }
  }
}
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation

Close #1068 
