### PR TITLE
Keep yaml formatting pretty when config uploaded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,9 @@ Fixed
 
 - Allow specifying server zone in ``join_server`` API.
 
-- Querying zone names for dead servers.
+- Fix corner cases when querying server zones.
+
+- Don't make yaml formatting ugly during config upload.
 
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29

--- a/cartridge/webui/api-config.lua
+++ b/cartridge/webui/api-config.lua
@@ -13,6 +13,8 @@ json.cfg({
 })
 yaml.cfg({
     encode_use_tostring = true,
+    encode_load_metatables = false,
+    decode_save_metatables = false,
 })
 
 local DecodeYamlError = errors.new_class('DecodeYamlError')


### PR DESCRIPTION
Uploading config spoils the YAML formatting dramatically because the `/admin/config` endpoint does `decode` + `encode`. An attempt to upload a simple schema produces the following appearance. It makes further editing quite painful.

```yml
--- {'spaces': {'customer': {'sharding_key': ['customer_id'], 'temporary': false,
      'engine': 'memtx', 'is_local': false, 'indexes': [{'unique': true, 'parts': [
            {'path': 'customer_id', 'type': 'unsigned', 'is_nullable': false}], 'type': 'TREE',
          'name': 'customer_id'}, {'unique': false, 'parts': [{'path': 'bucket_id',
              'type': 'unsigned', 'is_nullable': false}], 'type': 'TREE', 'name': 'bucket_id'},
        {'unique': true, 'parts': [{'path': 'fullname', 'type': 'string', 'is_nullable': false}],
          'type': 'TREE', 'name': 'fullname'}], 'format': [{'type': 'unsigned', 'name': 'customer_id',
          'is_nullable': false}, {'type': 'unsigned', 'name': 'bucket_id', 'is_nullable': false},
        {'type': 'string', 'name': 'fullname', 'is_nullable': false}]}}}
...
```

The reason for such behavior is in the YAML settings used by the `upload_config` HTTP handler. Roughly it does the following:

```lua
conf_new = yaml.decode(req.body)
for k, v in pairs(conf_new) do
    clusterwide_config:set_plaintext(k .. '.yml', yaml.encode(v))
end
```

Unless the `yaml` module is configured with `decode_save_metatables` it adds `{__serialize = 'map'}` (or 'seq') hint to every decoded table (see [1], [2]). And further encoding renders it in a compact (unreadable) way (`[1,2,3]`).

[1] https://github.com/tarantool/tarantool/blob/90a72ffd1a9b10a8cf52871e7a7c95c9285b8cdc/third_party/lua-yaml/lyaml.cc#L213-L214
[2] https://github.com/tarantool/tarantool/blob/90a72ffd1a9b10a8cf52871e7a7c95c9285b8cdc/src/lua/utils.h#L560-L574

This patch disables `decode_save_metatables` explicitly. The `encode_load_metatables` is also disabled as a backup.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1075 
