### PR TITLE
Fix flaky ddl.test_space_removal test

### DIFF
--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -198,10 +198,12 @@ function g.test_space_removal()
     _set_schema(server, 'spaces: {}')
 
     for _, srv in pairs(g.cluster.servers) do
-        srv.net_box:ping()
-        t.assert(srv.net_box.space.test_space,
-            string.format('Missing test_space on %s', srv.alias)
-        )
+        helpers.retrying({}, function()
+            srv.net_box:ping()
+            t.assert(srv.net_box.space.test_space,
+                string.format('Missing test_space on %s', srv.alias)
+            )
+        end)
     end
 end
 
@@ -224,9 +226,11 @@ function g.test_example_schema()
     local space_name = next(yaml.decode(example_yml).spaces)
 
     for _, srv in pairs(g.cluster.servers) do
-        srv.net_box:ping()
-        t.assert(srv.net_box.space[space_name],
-            string.format('Missing space %q on %s', space_name, srv.alias)
-        )
+        helpers.retrying({}, function()
+            srv.net_box:ping()
+            t.assert(srv.net_box.space[space_name],
+                string.format('Missing space %q on %s', space_name, srv.alias)
+            )
+        end)
     end
 end


### PR DESCRIPTION
The test applies a cluster-wide config with a modified schema and checks the space existence on all servers. But the replication is asynchronous and the check sometimes fails on a replica. This patch wraps it with `helpers.retrying`.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

