### PR TITLE
Add bootstrap proxy calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ Added
 - Show an issue when ``ConfiguringRoles`` state stucks for more than 5s.
 - New GraphQL API: ``{cluster {suggestions {disable_servers {uuid}}}}``
   to restore the quorum in case of some servers go offline.
+- Implement proxy calls from `Unconfigured` instances for next functions:
+
+  - ``cartrige.lua-api.edit_topology``
+  - ``cartrige.lua-api.get_topology``
+  - ``cartrige.lua-api.bootstrap_vshard``
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/lua-api/get-topology.lua
+++ b/cartridge/lua-api/get-topology.lua
@@ -3,8 +3,10 @@
 -- @module cartridge.lua-api.get-topology
 
 local fun = require('fun')
+local yaml = require('yaml')
 local membership = require('membership')
 
+local rpc = require('cartridge.rpc')
 local utils = require('cartridge.utils')
 local roles = require('cartridge.roles')
 local failover = require('cartridge.failover')
@@ -68,6 +70,13 @@ local function get_topology()
     -- OperationError doesn't influence observing topology
     if state == 'InitError' or state == 'BootError' then
         return nil, err
+    end
+
+    if state == 'Unconfigured' and rpc.is_proxy_call_possible() then
+        local res = rpc.proxy_call('_G.__proxy_get_topology')
+        if res ~= nil then
+            return yaml.decode(res)
+        end
     end
 
     local members = membership.members()
@@ -226,6 +235,16 @@ local function get_topology()
         replicasets = replicasets,
     }
 end
+
+local function proxy_get_topology()
+    local res, err = get_topology()
+    if not res then
+        return nil, err
+    end
+    return yaml.encode(res)
+end
+
+_G.__proxy_get_topology = proxy_get_topology
 
 return {
     get_topology = get_topology,

--- a/cartridge/lua-api/vshard.lua
+++ b/cartridge/lua-api/vshard.lua
@@ -3,6 +3,7 @@
 -- @module cartridge.lua-api.vshard
 
 local rpc = require('cartridge.rpc')
+local confapplier = require('cartridge.confapplier')
 
 --- Call `vshard.router.bootstrap()`.
 -- This function distributes all buckets across the replica sets.
@@ -11,8 +12,18 @@ local rpc = require('cartridge.rpc')
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function bootstrap_vshard()
+    local state = confapplier.get_state()
+    if state == 'Unconfigured' and rpc.is_proxy_call_possible() then
+        local res, err = rpc.proxy_call('_G.__proxy_bootstrap_vshard')
+        if err ~= nil then
+            return nil, err
+        end
+        return res
+    end
     return rpc.call('vshard-router', 'bootstrap')
 end
+
+_G.__proxy_bootstrap_vshard = bootstrap_vshard
 
 return {
     bootstrap_vshard = bootstrap_vshard,

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -17,6 +17,8 @@ local confapplier = require('cartridge.confapplier')
 local service_registry = require('cartridge.service-registry')
 
 local RemoteCallError = errors.new_class('RemoteCallError')
+local ProxyCallError = errors.new_class('ProxyCallError')
+
 
 local function call_local(role_name, fn_name, args)
     checks('string', 'string', '?table')
@@ -282,10 +284,86 @@ local function call_remote(role_name, fn_name, args, opts)
     end
 end
 
+--- Check that proxy call can be performed.
+-- If exists one inststance in membership with state ~= 'Unconfigured'
+-- then proxy call can be performed.
+--
+-- @function is_proxy_call_possible
+--
+-- @return boolean
+local function is_proxy_call_possible()
+    local members = membership.members()
+    for _, member in pairs(members) do
+        local member_state = member.payload and member.payload.state
+        if member_state and member_state ~= 'Unconfigured' then
+            return true
+        end
+    end
+    return false
+end
+
+--- Perform proxy call.
+-- Find a suitable healthy instance and perform a [`net.box` `conn:call`](
+-- https://tarantool.io/en/doc/latest/reference/reference_lua/net_box/#net-box-call)
+--
+-- @function proxy_call
+--
+-- @tparam string fn_name
+-- @tparam[opt] table args
+-- @tparam[opt] table opts
+-- @param opts.timeout passed to `net.box` `conn:call` options.
+--
+-- @return[1] `conn:call()` result
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function proxy_call(fn_name, args, opts)
+    opts = opts or {}
+    checks('string', '?table', {
+        timeout = '?'
+    })
+
+    local uri_proxy_list = {}
+    local members = membership.members()
+    for _, member in pairs(members) do
+        if member.status == 'alive' or member.status == 'suspect' then
+            local member_state = member.payload and member.payload.state
+
+            -- Add uri of configured instances at the begin of proxy list
+            if member_state == 'RolesConfigured' then
+                table.insert(uri_proxy_list, 1, member.uri)
+            elseif member_state and member_state ~= 'Unconfigured' then
+                table.insert(uri_proxy_list, member.uri)
+            end
+        end
+    end
+
+    if #uri_proxy_list == 0 then
+        return nil, ProxyCallError:new(
+            'No available instances to perform proxy call'
+        )
+    end
+
+    local conn, err
+    for _, uri in ipairs(uri_proxy_list) do
+        conn, err = pool.connect(uri)
+    end
+
+    if not conn then
+        return nil, err
+    end
+
+    args = args and {args}
+    return conn:call(fn_name, args, {
+        timeout = opts.timeout
+    })
+end
+
 _G.__cluster_rpc_call_local = call_local
 
 return {
     get_candidates = get_candidates,
     get_connection = get_connection,
     call = call_remote,
+    proxy_call = proxy_call,
+    is_proxy_call_possible = is_proxy_call_possible,
 }

--- a/test/integration/proxy_calls_test.lua
+++ b/test/integration/proxy_calls_test.lua
@@ -1,0 +1,165 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_each(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = require('digest').urandom(6):hex(),
+        replicasets = {
+            {
+                alias = 'main',
+                uuid = helpers.uuid('a'),
+                roles =  {'vshard-router', 'vshard-storage'},
+                servers = {
+                    {instance_uuid = helpers.uuid('a', 'a', 1)},
+                },
+            }
+        },
+    })
+
+    g.servers = {}
+    for i = 2, 3 do
+        local http_port = 8080 + i
+        local advertise_port = 13300 + i
+        local alias = string.format('srv%d', i - 1)
+
+        g.servers[i - 1] = helpers.Server:new({
+            alias = alias,
+            command = helpers.entrypoint('srv_basic'),
+            workdir = fio.pathjoin(g.cluster.datadir, alias),
+            cluster_cookie = g.cluster.cookie,
+            http_port = http_port,
+            advertise_port = advertise_port,
+            instance_uuid = helpers.uuid('a', 'a', i),
+        })
+    end
+
+    for _, server in pairs(g.servers) do
+        server:start()
+    end
+    g.cluster:start()
+end)
+
+g.after_each(function()
+    for _, server in pairs(g.servers or {}) do
+        server:stop()
+    end
+    g.cluster:stop()
+
+    fio.rmtree(g.cluster.datadir)
+    g.cluster = nil
+    g.servers = nil
+end)
+
+
+local function join_servers(server, join_servers)
+    return server:graphql({query = [[
+        mutation($replicasets: [EditReplicasetInput]) {
+            cluster {
+                edit_topology(replicasets: $replicasets) {
+                    servers {uuid uri}
+                    replicasets {uuid master { uuid uri }}
+                }
+            }
+        }]],
+        variables = {
+            replicasets = {{
+                uuid = helpers.uuid('a'),
+                join_servers = join_servers,
+            }}
+        },
+        raise = false,
+    })
+end
+
+local function update_membership_data(member_uri)
+    g.servers[1].net_box:eval([[
+        require('membership').probe_uri(...)
+    ]], {member_uri})
+end
+
+function g.test_proxy_call_on_dead_instance()
+    update_membership_data('localhost:13301')
+
+    g.cluster.main_server:stop()
+
+    local function check_error(err)
+        t.assert_equals(err.message, 'No available instances to perform proxy call')
+        t.assert_covers(err.extensions, {
+            ['io.tarantool.errors.class_name'] = 'ProxyCallError',
+        })
+    end
+
+    local server = g.servers[1]
+    t.helpers.retrying({}, function()
+        server.net_box:eval([[
+            local member = require('membership').get_member('localhost:13301')
+            assert(member.status ~= 'alive' and member.status ~= 'suspect')
+        ]])
+    end)
+
+    local resp = join_servers(server, {
+        {uri = 'localhost:13302', uuid = server.uuid}
+    })
+    check_error(resp.errors[1])
+
+    local resp = server:graphql({
+        query = 'mutation { bootstrap_vshard }',
+        raise = false
+    })
+    check_error(resp.errors[1])
+
+    -- Proxy call wasn't performed
+    local resp = server:graphql({query = [[{
+        servers { uri uuid status }
+    }]]})
+    t.assert_items_include(resp.data.servers, {
+        {status = 'unconfigured', uri = 'localhost:13303', uuid = ''},
+        {status = 'unconfigured', uri = 'localhost:13302', uuid = ''}
+    })
+end
+
+function g.test_proxy_call_ok()
+    update_membership_data('localhost:13301')
+
+    local function get_topology_servers(server)
+        return server:graphql({query = [[{
+            servers {uri uuid}
+        }]]}).data.servers
+    end
+
+    local server = g.servers[1]
+
+    -- check get_topology proxy works
+    local topology_from_bootsrapped = get_topology_servers(g.cluster.main_server)
+    local topology_from_unconfigured = get_topology_servers(server)
+    t.assert_items_include(topology_from_bootsrapped, {
+        {uri = 'localhost:13302', uuid = ''},
+        {uri = 'localhost:13301', uuid = g.cluster.main_server.instance_uuid},
+        {uri = 'localhost:13303', uuid = ''}
+    })
+    t.assert_items_include(topology_from_unconfigured, topology_from_bootsrapped)
+
+    -- check bootstrap vshard proxy works
+    local resp = server:graphql({query = 'mutation { bootstrap_vshard }'})
+    t.assert_equals(resp.data.bootstrap_vshard, true)
+
+    -- bootstrap remotely (edit_topology)
+    local resp = join_servers(server, {
+        {uri = 'localhost:13302', uuid = g.servers[1].instance_uuid},
+        {uri = 'localhost:13303', uuid = g.servers[2].instance_uuid}
+    })
+    t.assert_items_include(resp.data.cluster.edit_topology.replicasets, {{
+        master = {uri = "localhost:13301", uuid = helpers.uuid('a', 'a', 1)},
+        uuid = helpers.uuid('a'),
+    }})
+    t.assert_items_include(resp.data.cluster.edit_topology.servers, {
+        {uri = "localhost:13302", uuid = g.servers[1].instance_uuid},
+        {uri = "localhost:13303", uuid = g.servers[2].instance_uuid},
+    })
+end


### PR DESCRIPTION
* Added proxy calls to configured instances for:
  - botstrap_vshard
  - edit_topology
  - get_topology
* Added new methods at cartridge.rpc

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1244
