### PR TITLE
Make clusterwide config upload a separate stage

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -124,7 +124,8 @@ jobs:
         id: cache-luatest-rocks
         with:
           path: .rocks/
-          key: cache-luatest-rocks-${{ matrix.runs-on }}
+          key: cache-luatest-rocks-${{ matrix.runs-on }}-${{ hashFiles('cartridge-scm-1.rockspec') }}
+          restore-keys: cache-luatest-rocks-${{ matrix.runs-on }}
       -
         run: tarantoolctl rocks install luatest 0.5.2
         if: steps.cache-luatest-rocks.outputs.cache-hit != 'true'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Added
   API only.
 - New ``cartridge.cfg`` option ``http_host`` (default: 0.0.0.0). It is used
   to specify the host on which administrative UI and API will be opened.
+- Refactor two-phase commit logics: don't use hardcoded timeout value for the
+  ``prepare`` stage, move ``upload`` to a separate stage.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -238,7 +238,7 @@ end
 --   Temporary directory used for saving files during clusterwide
 --   config upload. If relative path is specified, it's evaluated
 --   relative to the `workdir`.
---   (**Added** in v2.4.0-36,
+--   (**Added** in v2.4.0-43,
 --   default: `/tmp`, overridden by
 --   env `TARANTOOL_UPLOAD_PREFIX`,
 --   args `--upload-prefix`)

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -670,7 +670,7 @@ local function cfg(opts, box_opts)
         end
 
         opts.upload_prefix = path
-        upload.set_options({upload_prefix = path})
+        upload.set_upload_prefix(path)
     end
 
     -- Start console sock

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -29,6 +29,7 @@ local roles = require('cartridge.roles')
 local webui = require('cartridge.webui')
 local issues = require('cartridge.issues')
 local graphql = require('cartridge.graphql')
+local upload = require('cartridge.upload')
 local argparse = require('cartridge.argparse')
 local topology = require('cartridge.topology')
 local twophase = require('cartridge.twophase')
@@ -233,6 +234,15 @@ end
 --   Allow calling `cartridge.reload_roles`.
 --   (**Added** in v2.3.0-73, default: `false`)
 --
+-- @tparam ?string opts.upload_prefix
+--   Temporary directory used for saving files during clusterwide
+--   config upload. If relative path is specified, it's evaluated
+--   relative to the `workdir`.
+--   (**Added** in v2.4.0-36,
+--   default: `/tmp`, overridden by
+--   env `TARANTOOL_UPLOAD_PREFIX`,
+--   args `--upload-prefix`)
+--
 -- @tparam ?table box_opts
 --   tarantool extra box.cfg options (e.g. memtx_memory),
 --   that may require additional tuning
@@ -260,6 +270,7 @@ local function cfg(opts, box_opts)
         upgrade_schema = '?boolean',
         swim_broadcast = '?boolean',
         roles_reload_allowed = '?boolean',
+        upload_prefix = '?string',
     }, '?table')
 
     if opts.webui_blacklist ~= nil then
@@ -650,6 +661,17 @@ local function cfg(opts, box_opts)
     end
 
     issues.set_limits(issue_limits)
+
+    if opts.upload_prefix ~= nil then
+        local path = opts.upload_prefix
+        if not path:startswith('/') then
+            -- calc relative path
+            path = fio.pathjoin(opts.workdir, path)
+        end
+
+        opts.upload_prefix = path
+        upload.set_options({upload_prefix = path})
+    end
 
     -- Start console sock
     if opts.console_sock ~= nil then

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -93,6 +93,7 @@ local cluster_opts = {
     bucket_count = 'number', -- **number**
     upgrade_schema = 'boolean', -- **boolean**
     swim_broadcast = 'boolean', -- **boolean**
+    upload_prefix = 'string', -- **string**
 }
 
 --- Common [box.cfg](https://www.tarantool.io/en/doc/latest/reference/configuration/) tuning options.

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -36,12 +36,8 @@ vars:new('locks', {})
 vars:new('prepared_config', nil)
 vars:new('on_patch_triggers', {})
 
---- Internal module params.
--- (**Added** in v2.4.0-32)
--- @table _options
--- @tfield number NETBOX_CALL_TIMEOUT (default: 5)
 vars:new('options', {
-    NETBOX_CALL_TIMEOUT = 5,
+    netbox_call_timeout = 5,
 })
 
 --- Two-phase commit - preparation stage.
@@ -60,7 +56,7 @@ local function prepare_2pc(upload_id)
     local data
     if type(upload_id) == 'table' then
         -- Preserve compatibility with older versions.
-        -- Until cartridge 2.4.0-32 it was `prepare_2pc(data)`.
+        -- Until cartridge 2.4.0-43 it was `prepare_2pc(data)`.
         data = upload_id
     else
         data = upload.inbox[upload_id]
@@ -413,7 +409,7 @@ local function _clusterwide(patch)
             '_G.__cartridge_clusterwide_config_prepare_2pc', {upload_id},
             {
                 uri_list = uri_list,
-                timeout = vars.options.NETBOX_CALL_TIMEOUT,
+                timeout = vars.options.netbox_call_timeout,
             }
         )
 
@@ -449,7 +445,7 @@ local function _clusterwide(patch)
             '_G.__cartridge_clusterwide_config_commit_2pc', nil,
             {
                 uri_list = uri_list,
-                timeout = vars.options.NETBOX_CALL_TIMEOUT,
+                timeout = vars.options.netbox_call_timeout,
             }
         )
 
@@ -477,7 +473,7 @@ local function _clusterwide(patch)
             '_G.__cartridge_clusterwide_config_abort_2pc', nil,
             {
                 uri_list = abortion_list,
-                timeout = vars.options.NETBOX_CALL_TIMEOUT,
+                timeout = vars.options.netbox_call_timeout,
             }
         )
 
@@ -572,7 +568,7 @@ local function _force_reapply(uuids)
             {clusterwide_config:get_plaintext()},
             {
                 uri_list = uri_list,
-                timeout = vars.options.NETBOX_CALL_TIMEOUT,
+                timeout = vars.options.netbox_call_timeout,
             }
         )
 
@@ -727,7 +723,6 @@ _G.__cluster_confapplier_commit_2pc = function(...) return errors.pcall('E', com
 _G.__cluster_confapplier_abort_2pc = function(...) return errors.pcall('E', abort_2pc, ...) end
 
 return {
-    _options = vars.options,
     on_patch = on_patch,
     get_schema = get_schema,
     set_schema = set_schema,

--- a/cartridge/upload.lua
+++ b/cartridge/upload.lua
@@ -61,6 +61,8 @@ local function upload_begin(upload_id)
 
     local upload_path = get_upload_path(upload_id)
     local ok, err = utils.mktree(fio.dirname(upload_path))
+    -- If the fiber is cancelled, the `upload_fibers` is cleaned up
+    -- during the `upload_cleanup` stage (which in fact cancelled it).
     fiber.testcancel()
     if ok == nil then
         vars.upload_fibers[upload_id] = nil
@@ -96,6 +98,8 @@ local function upload_transmit(upload_id, payload)
     local upload_path = get_upload_path(upload_id)
     local payload_path = fio.pathjoin(upload_path, 'payload')
     local ok, err = utils.file_write(payload_path, payload)
+    -- If the fiber is cancelled, the `upload_fibers` is cleaned up
+    -- during the `upload_cleanup` stage (which in fact cancelled it).
     fiber.testcancel()
     if not ok then
         vars.upload_fibers[upload_id] = nil

--- a/cartridge/upload.lua
+++ b/cartridge/upload.lua
@@ -1,0 +1,324 @@
+--- Spread the data across instances in a network-efficient manner.
+--
+-- (**Added** in v2.4.0-32)
+--
+-- @module cartridge.upload
+-- @local
+
+local log = require('log')
+local fio = require('fio')
+local fun = require('fun')
+local errno = require('errno')
+local fiber = require('fiber')
+local checks = require('checks')
+local errors = require('errors')
+local digest = require('digest')
+local msgpack = require('msgpack')
+local pool = require('cartridge.pool')
+local utils = require('cartridge.utils')
+
+local vars = require('cartridge.vars').new('cartridge.upload')
+
+local UploadError = errors.new_class('UploadError')
+
+--- The uploaded data.
+-- `{[upload_id] = data}`
+-- @table inbox
+vars:new('inbox', {})
+
+--- Internal module params.
+-- @table options
+local default_options = {
+    upload_prefix = '/tmp', -- string: *default*: "/tmp".
+    netbox_call_timeout = 1, -- number: *default*: 1.
+    transmission_timeout = 30, -- number: *default*: 30.
+}
+vars:new('options', default_options)
+
+-- All four functions begin / transmit / finish / cleanup do yield.
+-- Since they are called over netbox (each in an individual fiber),
+-- there may be a situation (usually abnormal), when cleanup starts
+-- before previous stages finish.
+vars:new('upload_fibers', {})
+
+vars:new('get_upload_path', function(upload_id)
+    return fio.pathjoin(
+        vars.options.upload_prefix,
+        'cartridge-upload.' .. upload_id
+    )
+end)
+
+-- The upload starts by creating a shared resource - a directory named
+-- after the `upload_id`. The instances who can create it before
+-- others are the transmitters. The others wait patiently till the
+-- `upload_finish()`.
+local function upload_begin(upload_id)
+    checks('string')
+
+    vars.upload_fibers[upload_id] = fiber.self()
+
+    local upload_path = vars.get_upload_path(upload_id)
+    local ok, err = utils.mktree(fio.dirname(upload_path))
+    fiber.testcancel()
+    if ok == nil then
+        vars.upload_fibers[upload_id] = nil
+        return nil, err
+    end
+
+    local ok = fio.mkdir(upload_path)
+    local _errno = errno()
+    fiber.testcancel()
+
+    vars.upload_fibers[upload_id] = nil
+
+    if ok then
+        return true
+    elseif fio.path.is_dir(upload_path) then
+        return false
+    else
+        return nil, UploadError:new(
+            'Error creating directory %q: %s',
+            upload_path, errno.strerror(_errno)
+        )
+    end
+end
+
+-- The communication only goes with transmitters - the instances who
+-- replied `upload_begin() == true` i.e affirmed they own the shared
+-- resource. The other instances will read the data from that resource
+-- during the `upload_finish()` step.
+local function upload_transmit(upload_id, payload)
+    checks('string', 'string')
+
+    vars.upload_fibers[upload_id] = fiber.self()
+
+    local upload_path = vars.get_upload_path(upload_id)
+    local payload_path = fio.pathjoin(upload_path, 'payload')
+    local ok, err = utils.file_write(payload_path, payload)
+    fiber.testcancel()
+    if not ok then
+        vars.upload_fibers[upload_id] = nil
+        return nil, err
+    end
+
+    vars.upload_fibers[upload_id] = nil
+    return true
+end
+
+-- The uploaded data is read from the shared resource on every instance,
+-- not only on the transmitter.
+local function upload_finish(upload_id)
+    checks('string')
+
+    vars.upload_fibers[upload_id] = fiber.self()
+
+    local upload_path = vars.get_upload_path(upload_id)
+    local payload_path = fio.pathjoin(upload_path, 'payload')
+    local payload, err = utils.file_read(payload_path)
+
+    vars.upload_fibers[upload_id] = nil
+
+    fiber.testcancel()
+    if err then
+        return nil, err
+    end
+
+    local ok, data = pcall(msgpack.decode, payload)
+    if not ok then
+        return nil, UploadError:new(data)
+    end
+    vars.inbox[upload_id] = data
+    return true
+end
+
+-- Remove shared resources. Be idempotent.
+local function upload_cleanup(upload_id)
+    checks('string')
+    if vars.upload_fibers[upload_id] ~= nil then
+        pcall(fiber.cancel, vars.upload_fibers[upload_id])
+        vars.upload_fibers[upload_id] = nil
+    end
+
+    local upload_path = vars.get_upload_path(upload_id)
+    local random_path = utils.randomize_path(upload_path)
+
+    local ok = fio.rename(upload_path, random_path)
+    local _errno = errno()
+    if not ok then
+        if not fio.path.is_dir(upload_path) then
+            -- No such file, upload_path is already clean.
+            return true
+        else
+            log.warn(
+                'Error removing %s: %s',
+                upload_path, errno.strerror(_errno)
+            )
+            return false
+        end
+    end
+
+    local ok = fio.rmtree(random_path)
+    local _errno = errno()
+    if not ok then
+        log.warn(
+            "Error removing %s: %s",
+            random_path, errno.strerror(_errno)
+        )
+        return false
+    end
+
+    return true
+end
+
+--- Spread the data across the cluster.
+--
+-- For each separate upload, a random `upload_id` is generated. All the
+-- instances try to create `/tmp/<upload_id>` on their side, and those
+-- who succeed act as transmitters.
+--
+-- When the upload finishes, all the instances load the data into the
+-- `inbox` table and the temporary files are cleared. The inbox isn't
+-- garbage-collected automatically. It's the user's responsibility to
+-- clean it up after use.
+--
+-- @function upload
+--
+-- @param data
+--   any Lua object.
+-- @tparam {string,...} uri_list
+--   array of URIs.
+--
+-- @treturn[1] string `upload_id` (if at least one upload succeded)
+-- @treturn[2] nil
+-- @treturn[2] table Error description
+local function upload(data, uri_list)
+    checks('?', 'table')
+    local ok, payload = pcall(msgpack.encode, data)
+    if not ok then
+        return nil, UploadError:new(
+            'Error serializing msgpack: %s', payload
+        )
+    end
+
+    local upload_id = digest.urandom(6):hex()
+    local transmitters_list = {}
+    local _upload_error
+
+    do -- begin
+        local retmap, errmap = pool.map_call(
+            '_G.__cartridge_upload_begin', {upload_id},
+            {
+                uri_list = uri_list,
+                timeout = vars.options.netbox_call_timeout,
+            }
+        )
+
+        for _, uri in ipairs(uri_list) do
+            if retmap == nil or retmap[uri] == nil then
+                local err = errmap and errmap[uri]
+                if err == nil then
+                    err = UploadError:new('Unknown error at %s', uri)
+                end
+                log.error('Error uploading files to %s:\n%s', uri, err)
+                _upload_error = err
+            elseif retmap[uri] == true then
+                table.insert(transmitters_list, uri)
+            end
+        end
+
+        if _upload_error ~= nil then
+            goto cleanup
+        end
+    end
+
+    do -- transmit
+        local retmap, errmap = pool.map_call(
+            '_G.__cartridge_upload_transmit', {upload_id, payload},
+            {
+                uri_list = transmitters_list,
+                timeout = vars.options.transmission_timeout,
+            }
+        )
+
+        for _, uri in ipairs(transmitters_list) do
+            if retmap == nil or retmap[uri] == nil then
+                local err = errmap and errmap[uri]
+                if err == nil then
+                    err = UploadError:new('Unknown error at %s', uri)
+                end
+                log.error('Error transmitting data to %s:\n%s', uri, err)
+                _upload_error = err
+            end
+        end
+
+        if _upload_error ~= nil then
+            goto cleanup
+        end
+    end
+
+    do -- finish
+        local retmap, errmap = pool.map_call(
+            '_G.__cartridge_upload_finish', {upload_id},
+            {
+                uri_list = uri_list,
+                timeout = vars.options.netbox_call_timeout,
+            }
+        )
+
+        for _, uri in ipairs(uri_list) do
+            if retmap == nil or retmap[uri] == nil then
+                log.warn(
+                    'Error finishing upload on %s:\n%s',
+                    uri, errmap and errmap[uri]
+                )
+            end
+        end
+    end
+
+::cleanup::
+    do -- cleanup
+        local retmap, errmap = pool.map_call(
+            '_G.__cartridge_upload_cleanup', {upload_id},
+            {
+                uri_list = uri_list,
+                timeout = vars.options.netbox_call_timeout,
+            }
+        )
+
+        for _, uri in ipairs(uri_list) do
+            if retmap == nil or retmap[uri] == nil then
+                log.warn(
+                    'Error cleaning up %s:\n%s',
+                    uri, errmap and errmap[uri]
+                )
+            end
+        end
+    end
+
+    if _upload_error ~= nil then
+        return nil, _upload_error
+    end
+
+    return upload_id
+end
+
+local function set_options(options)
+    checks({
+        upload_prefix = '?string',
+        netbox_call_timeout = '?number',
+        transmission_timeout = '?number',
+    })
+    vars.options = fun.chain(vars.options, options):tomap()
+    return true
+end
+
+_G.__cartridge_upload_begin = function(...) return errors.pcall('E', upload_begin, ...) end
+_G.__cartridge_upload_transmit = function(...) return errors.pcall('E', upload_transmit, ...) end
+_G.__cartridge_upload_finish = function(...) return errors.pcall('E', upload_finish, ...) end
+_G.__cartridge_upload_cleanup = function(...) return errors.pcall('E', upload_cleanup, ...) end
+
+return {
+    inbox = vars.inbox,
+    upload = upload,
+    set_options = set_options,
+}

--- a/cartridge/upload.lua
+++ b/cartridge/upload.lua
@@ -67,8 +67,7 @@ local function upload_begin(upload_id)
         return nil, err
     end
 
-    local ok = fio.mkdir(upload_path)
-    local _errno = errno()
+    local ok, _errno = fio.mkdir(upload_path), errno()
     fiber.testcancel()
 
     vars.upload_fibers[upload_id] = nil
@@ -144,8 +143,7 @@ local function upload_cleanup(upload_id)
     local upload_path = get_upload_path(upload_id)
     local random_path = utils.randomize_path(upload_path)
 
-    local ok = fio.rename(upload_path, random_path)
-    local _errno = errno()
+    local ok, _errno = fio.rename(upload_path, random_path), errno()
     if not ok then
         if not fio.path.is_dir(upload_path) then
             -- No such file, upload_path is already clean.
@@ -159,8 +157,7 @@ local function upload_cleanup(upload_id)
         end
     end
 
-    local ok = fio.rmtree(random_path)
-    local _errno = errno()
+    local ok, _errno = fio.rmtree(random_path), errno()
     if not ok then
         log.warn(
             "Error removing %s: %s",

--- a/cartridge/upload.lua
+++ b/cartridge/upload.lua
@@ -1,6 +1,6 @@
 --- Spread the data across instances in a network-efficient manner.
 --
--- (**Added** in v2.4.0-32)
+-- (**Added** in v2.4.0-43)
 --
 -- @module cartridge.upload
 -- @local
@@ -26,20 +26,17 @@ local UploadError = errors.new_class('UploadError')
 -- @table inbox
 vars:new('inbox', {})
 
---- Internal module params.
--- @table options
-local default_options = {
-    upload_prefix = '/tmp', -- string: *default*: "/tmp".
-    netbox_call_timeout = 1, -- number: *default*: 1.
-    transmission_timeout = 30, -- number: *default*: 30.
-}
-vars:new('options', default_options)
-
 -- All four functions begin / transmit / finish / cleanup do yield.
 -- Since they are called over netbox (each in an individual fiber),
 -- there may be a situation (usually abnormal), when cleanup starts
 -- before previous stages finish.
 vars:new('upload_fibers', {})
+
+vars:new('options', {
+    upload_prefix = '/tmp',
+    netbox_call_timeout = 1,
+    transmission_timeout = 30,
+})
 
 vars:new('get_upload_path', function(upload_id)
     return fio.pathjoin(

--- a/config.ld
+++ b/config.ld
@@ -12,6 +12,7 @@ file = {
     "cartridge/rpc.lua",
     "cartridge/tar.lua",
     "cartridge/pool.lua",
+    "cartridge/upload.lua",
     "cartridge/confapplier.lua",
     "cartridge/test-helpers.lua",
     "cartridge/test-helpers/cluster.lua",

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -11,8 +11,8 @@ errors.set_deprecation_handler(function(err)
     os.exit(1)
 end)
 
-local frontend = require('frontend-core')
-if frontend.set_variable then
+local frontend = package.loaded['frontend-core']
+if frontend and frontend.set_variable then
     -- Compatibility tests run on cartridge 1.2.0
     -- which doesn't support it yet.
     frontend.set_variable('cartridge_refresh_interval', 500)
@@ -171,6 +171,9 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     },
     webui_blacklist = webui_blacklist,
     roles_reload_allowed = roles_reload_allowed,
+    -- Compatibility tests run on cartridge 1.2.0
+    -- which doesn't support it yet.
+    upload_prefix = package.loaded['cartridge.upload'] and '../upload',
 })
 if not ok then
     log.error('%s', err)

--- a/test/integration/upload_test.lua
+++ b/test/integration/upload_test.lua
@@ -1,0 +1,159 @@
+local t = require('luatest')
+local g = t.group()
+
+local fio = require('fio')
+local fiber = require('fiber')
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.datadir = fio.tempdir()
+    g.upload_path_1 = fio.pathjoin(g.datadir, 'upload-1')
+    g.upload_path_2 = fio.pathjoin(g.datadir, 'upload-2')
+
+    g.cluster = helpers.Cluster:new({
+        datadir = g.datadir,
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = helpers.random_cookie(),
+        replicasets = {{
+            alias = 'main',
+            uuid = helpers.uuid('a'),
+            roles = {},
+            servers = {
+                -- first upload group: s1 and s2
+                {env = {TARANTOOL_UPLOAD_PREFIX = g.upload_path_1}},
+                {env = {TARANTOOL_UPLOAD_PREFIX = g.upload_path_1}},
+                -- second upload group: s3
+                {env = {TARANTOOL_UPLOAD_PREFIX = g.upload_path_2}},
+            },
+        }},
+    })
+    g.cluster:start()
+
+    g.s1 = g.cluster:server('main-1')
+    g.s2 = g.cluster:server('main-2')
+    g.s3 = g.cluster:server('main-3')
+
+    -- This makes g.s1 to establish all pool connections.
+    -- Without it the first begining_failure test (with a SIGSTOP) is
+    -- slower and usually fails because the error message varies.
+    helpers.list_cluster_issues(g.s1)
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_begining_failure()
+    g.s2.process:kill('STOP')
+
+    local future = g.s1.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide',
+        {{['todo_list.txt'] = 'gotta go fast'}},
+        {is_async = true}
+    )
+
+    t.helpers.retrying({}, function()
+        t.assert(fio.listdir(g.upload_path_1)[1])
+        t.assert(fio.listdir(g.upload_path_2)[1])
+    end)
+
+    local res, err = unpack(future:wait_result())
+    t.assert_equals(res, nil)
+    t.assert_covers(err, {
+        class_name = 'NetboxCallError',
+        err = 'Timeout exceeded',
+    })
+
+    -- prefix should be cleaned up even if upload_begin fails
+    t.assert_equals(fio.listdir(g.upload_path_1), {})
+    t.assert_equals(fio.listdir(g.upload_path_2), {})
+
+    g.s2.process:kill('CONT')
+    -- give the instance some time to wake up after stop
+    fiber.sleep(0.3)
+
+    t.assert_equals(fio.listdir(g.upload_path_1), {})
+    t.assert_equals(fio.listdir(g.upload_path_2), {})
+end
+
+function g.test_transmission_failure()
+    g.s3.net_box:eval([[
+        _G.upload_transmit_original = _G.__cartridge_upload_transmit
+        _G.__cartridge_upload_transmit = function()
+            require('fiber').sleep(0.3)
+            error('Artificial transmission failure', 0)
+        end
+    ]])
+
+    local future = g.s1.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide',
+        {{['todo_list.txt'] = 'gotta go faster'}},
+        {is_async = true}
+    )
+
+    t.helpers.retrying({}, function()
+        t.assert(fio.listdir(g.upload_path_1)[1])
+        t.assert(fio.listdir(g.upload_path_2)[1])
+    end)
+
+    local res, err = unpack(future:wait_result())
+    t.assert_equals(res, nil)
+    t.assert_covers(err, {
+        class_name = 'NetboxCallError',
+        err = 'Artificial transmission failure',
+    })
+
+    -- prefix should be cleaned up even if upload_transmit fails
+    t.assert_equals(fio.listdir(g.upload_path_1), {})
+    t.assert_equals(fio.listdir(g.upload_path_2), {})
+
+    -- Revert all hacks
+    g.s3.net_box:eval([[
+        _G.__cartridge_upload_transmit = _G.upload_transmit_original
+    ]])
+end
+
+function g.test_finish_failure()
+    g.s1.net_box:eval([[
+        package.loaded['cartridge.upload'].set_options({netbox_call_timeout = 0.1})
+        _G.upload_finish_original = _G.__cartridge_upload_finish
+        _G.__cartridge_upload_finish = function()
+            require('fiber').sleep(0.3)
+            return _G.upload_finish_original
+        end
+    ]])
+
+    local future = g.s1.net_box:call(
+        'package.loaded.cartridge.config_patch_clusterwide',
+        {{['todo_list.txt'] =
+            'The only problem with ' ..
+            'being faster than light is ' ..
+            'that you can only live in darkness.'
+        }},
+        {is_async = true}
+    )
+
+    t.helpers.retrying({}, function()
+        t.assert(fio.listdir(g.upload_path_1)[1])
+        t.assert(fio.listdir(g.upload_path_2)[1])
+    end)
+
+    local res, err = unpack(future:wait_result())
+    t.assert_equals(res, nil)
+    t.assert_covers(err, {
+        class_name = 'Prepare2pcError',
+        err = 'Upload not found, see earlier logs for the details',
+    })
+
+    -- prefix should be cleaned up even if upload_transmit fails
+    t.assert_equals(fio.listdir(g.upload_path_1), {})
+    t.assert_equals(fio.listdir(g.upload_path_2), {})
+
+    -- Revert all hacks
+    g.s1.net_box:eval([[
+        package.loaded['cartridge.upload'].set_options({netbox_call_timeout = 1})
+        _G.__cartridge_upload_finish = _G.upload_finish_original
+    ]])
+end

--- a/test/integration/upload_test.lua
+++ b/test/integration/upload_test.lua
@@ -117,7 +117,8 @@ end
 
 function g.test_finish_failure()
     g.s1.net_box:eval([[
-        package.loaded['cartridge.upload'].set_options({netbox_call_timeout = 0.1})
+        local twophase_vars = require('cartridge.vars').new('cartridge.twophase')
+        twophase_vars.options.netbox_call_timeout = 0.1
         _G.upload_finish_original = _G.__cartridge_upload_finish
         _G.__cartridge_upload_finish = function()
             require('fiber').sleep(0.3)
@@ -153,7 +154,8 @@ function g.test_finish_failure()
 
     -- Revert all hacks
     g.s1.net_box:eval([[
-        package.loaded['cartridge.upload'].set_options({netbox_call_timeout = 1})
+        local twophase_vars = require('cartridge.vars').new('cartridge.twophase')
+        twophase_vars.options.netbox_call_timeout = 0.1
         _G.__cartridge_upload_finish = _G.upload_finish_original
     ]])
 end

--- a/test/integration/workdir_test.lua
+++ b/test/integration/workdir_test.lua
@@ -56,7 +56,7 @@ function g.test_abspath()
     local workdir = g.cluster.main_server.workdir
     t.assert_items_equals(
         fio.listdir(g.datadir),
-        {'wal', 'memtx', 'vinyl', fio.basename(workdir)}
+        {'wal', 'memtx', 'vinyl', fio.basename(workdir), 'upload'}
     )
     t.assert_items_equals(
         fio.listdir(workdir),
@@ -117,7 +117,7 @@ function g.test_chdir()
     local workdir = g.cluster.main_server.workdir
     t.assert_items_equals(
         fio.listdir(g.datadir),
-        {'cd', 'wal', 'memtx', fio.basename(workdir)}
+        {'cd', 'wal', 'memtx', fio.basename(workdir), 'upload'}
     )
     t.assert_items_equals(
         fio.listdir(workdir),

--- a/test/unit/upload_test.lua
+++ b/test/unit/upload_test.lua
@@ -1,0 +1,185 @@
+local t = require('luatest')
+local g = t.group()
+
+local fio = require('fio')
+local errno = require('errno')
+local msgpack = require('msgpack')
+
+local utils
+local upload
+local upload_vars
+local log_warn_original
+
+g.before_all(function()
+    utils = require('cartridge.utils')
+    upload = require('cartridge.upload')
+    upload_vars = require('cartridge.vars').new('cartridge.upload')
+    log_warn_original = package.loaded.log.warn
+end)
+
+g.before_each(function()
+    g.datadir = fio.tempdir()
+
+    g.warnings = {}
+    package.loaded.log.warn = function(...)
+        table.insert(g.warnings, {...})
+    end
+
+end)
+
+g.after_each(function()
+    os.execute('chmod -R 755 ' .. g.datadir)
+    fio.rmtree(g.datadir)
+    g.datadir = nil
+
+    g.warnings = nil
+    package.loaded.log.warn = log_warn_original
+end)
+
+function g.test_begin()
+    local prefix = g.datadir
+    upload.set_options({upload_prefix = prefix})
+    t.assert_equals(_G.__cartridge_upload_begin('1'), true)
+    t.assert_equals(_G.__cartridge_upload_begin('1'), false)
+
+    -- Upload can create a prefix if it doesn't exist
+    local prefix = g.datadir .. '/subdir'
+    upload.set_options({upload_prefix = prefix})
+    t.assert_equals(_G.__cartridge_upload_begin('2'), true)
+
+    local prefix = g.datadir .. '/not-a-dir'
+    upload.set_options({upload_prefix = prefix})
+    utils.file_write(prefix, '')
+    local ok, err = _G.__cartridge_upload_begin('3')
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'MktreeError',
+        err = string.format(
+            'Error creating directory %q: %s',
+            prefix, errno.strerror(errno.EEXIST)
+        )
+    })
+
+    local prefix = g.datadir
+    upload.set_options({upload_prefix = prefix})
+    utils.file_write(upload_vars.get_upload_path('4'), '')
+    local ok, err = _G.__cartridge_upload_begin('4')
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'UploadError',
+        err = string.format(
+            'Error creating directory %q: %s',
+            upload_vars.get_upload_path('4'),
+            errno.strerror(errno.EEXIST)
+        )
+    })
+end
+
+function g.test_transmit()
+    local prefix = g.datadir
+    upload.set_options({upload_prefix = prefix})
+
+    local ok, err = _G.__cartridge_upload_transmit('upload_id', 'data')
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'OpenFileError',
+        err = string.format(
+            '%s/payload: %s',
+            upload_vars.get_upload_path('upload_id'),
+            errno.strerror(errno.ENOENT)
+        )
+    })
+
+    _G.__cartridge_upload_begin('upload_id')
+    local ok, err = _G.__cartridge_upload_transmit('upload_id', 'data')
+    t.assert_equals({ok, err}, {true, nil})
+end
+
+function g.test_finish()
+    local prefix = g.datadir
+    upload.set_options({upload_prefix = prefix})
+
+    local ok, err = _G.__cartridge_upload_finish('upload_id')
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'OpenFileError',
+        err = string.format(
+            '%s/payload: %s',
+            upload_vars.get_upload_path('upload_id'),
+            errno.strerror(errno.ENOENT)
+        )
+    })
+
+    _G.__cartridge_upload_begin('upload_id')
+    _G.__cartridge_upload_transmit('upload_id', '')
+
+    local ok, err = _G.__cartridge_upload_finish('upload_id')
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'UploadError',
+        err = 'msgpack.decode: invalid MsgPack',
+    })
+
+    _G.__cartridge_upload_transmit('upload_id', msgpack.encode('data'))
+
+    local ok, err = _G.__cartridge_upload_finish('upload_id')
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_equals(upload.inbox['upload_id'], 'data')
+end
+
+function g.test_cleanup()
+    local prefix = g.datadir .. '/cleanup_failure'
+    upload.set_options({upload_prefix = prefix})
+
+    _G.__cartridge_upload_begin('upload_id')
+    _G.__cartridge_upload_transmit('upload_id', '')
+
+    local upload_path = upload_vars.get_upload_path('upload_id')
+    local payload_path = fio.pathjoin(upload_path, 'payload')
+    t.assert(fio.path.exists(payload_path))
+
+    -- The first attempt fails: can't rename
+    fio.chmod(prefix, tonumber('555', 8))
+
+    table.clear(g.warnings)
+    _G.__cartridge_upload_cleanup('upload_id')
+    t.assert(fio.path.exists(payload_path))
+    t.assert_equals(g.warnings, {{
+        'Error removing %s: %s', upload_path,
+        errno.strerror(errno.EACCES)
+    }})
+
+    fio.chmod(prefix, tonumber('755', 8))
+
+    -- The second attempt fails: can't rmtree
+    fio.chmod(upload_path, tonumber('555', 8))
+
+    table.clear(g.warnings)
+    _G.__cartridge_upload_cleanup('upload_id')
+    local random_path = prefix .. '/' .. fio.listdir(prefix)[1]
+    t.assert_equals(g.warnings, {{
+        'Error removing %s: %s', random_path,
+        errno.strerror(errno.EACCES)
+    }})
+    fio.rename(random_path, upload_path)
+
+    fio.chmod(upload_path, tonumber('755', 8))
+
+    -- The third attempt succeeds
+    _G.__cartridge_upload_cleanup('upload_id')
+    t.assert_equals(fio.listdir(prefix), {})
+end
+
+function g.test_upload()
+    local ok, err = upload.upload(function() end, {})
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'UploadError',
+        err = "Error serializing msgpack: unsupported Lua type 'function'",
+    })
+
+    local ok, err = upload.upload(box.NULL, {})
+    t.assert_not(err)
+    t.assert(ok)
+end

--- a/webui/cypress/integration/sigstop.spec.js
+++ b/webui/cypress/integration/sigstop.spec.js
@@ -52,7 +52,7 @@ describe('Checking for situations when a connection is lost using SIGSTOP', () =
     cy.get('.meta-test__ClusterIssuesButton').contains('Issues: 1');
     cy.get('.meta-test__ClusterIssuesButton').click();
     cy.get('.meta-test__ClusterIssuesModal')
-      .contains("warning: Replication from localhost:13302 (dummy-2) to localhost:13301 (dummy-1) is disconnected (timed out)");
+      .contains("warning: Replication from localhost:13302 (dummy-2) to localhost:13301 (dummy-1)");
     cy.get('.meta-test__ClusterIssuesModal button[type="button"]').click();
 
     //Check buckets
@@ -79,8 +79,6 @@ describe('Checking for situations when a connection is lost using SIGSTOP', () =
     //Cluster page: Try to add new zone
     openServerDetailsModal('dummy-2');
     tryToSubmitTestZone();
-    cy.get('.ZoneAddModal_error').find('span:contains(Two-phase commit is locked)', { timeout: 15000 });
-    cy.get('h2:contains(Add name of zone)').next().click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Close)').click();
 
     //Cluster page: Check buckets
@@ -92,11 +90,7 @@ describe('Checking for situations when a connection is lost using SIGSTOP', () =
     cy.contains('dummy-2').closest('li').contains('healthy');
 
     //Cluster page: Check Issue
-    cy.get('.meta-test__ClusterIssuesButton').contains('Issues: 1');
-    cy.get('.meta-test__ClusterIssuesButton').click();
-    cy.get('.meta-test__ClusterIssuesModal')
-      .contains("warning: Configuration is prepared and locked on localhost:13302 (dummy-2)");
-    cy.get('.meta-test__ClusterIssuesModal button[type="button"]').click();
+    cy.get('.meta-test__ClusterIssuesButton').contains('Issues: 0');
   });
 
 });


### PR DESCRIPTION
For historical reasons, there were two issues in the `patch_clusterwide` logics:

1. The 5-second timeout for all communications was hardcoded.
2. No optimizations were undertaken there, it was was suboptimal and wasteful.

It was OK when the config was small and there were only a few instances in the cluster, but it's a problem for big installations nowadays.

This patch introduces a new `patch_clusterwide` stage - upload (consolidated in a separate module). It spreads the data across instances in a network-efficient manner.

Also in this patch:

- Change `issues_test.lua` and remove unnecessary checks from cypress `sigstop.spec.js` because the SIGStOP doesn't result in config lock and mismatch anymore.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1145 
