### PR TITLE
Reorganize modules

### DIFF
--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -399,12 +399,6 @@ local function load_from_dir(path)
     return new(plaintext)
 end
 
-local function randomize(filename)
-    local random = digest.urandom(9)
-    local suffix = digest.base64_encode(random, {urlsafe = true})
-    return filename .. '.' .. suffix
-end
-
 --- Remove config from filesystem atomically.
 --
 -- The atomicity is achieved by splitting it into two phases:
@@ -420,10 +414,7 @@ end
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function remove(path)
-    local random_path = fio.pathjoin(
-        fio.dirname(path),
-        randomize(fio.basename(path))
-    )
+    local random_path = utils.randomize_path(path)
 
     local ok = fio.rename(path, random_path)
     if not ok then
@@ -458,15 +449,9 @@ end
 -- @treturn[2] table Error description
 local function save(clusterwide_config, path)
     checks('ClusterwideConfig', 'string')
+    local random_path = utils.randomize_path(path)
 
-    local random_path = fio.pathjoin(
-        fio.dirname(path),
-        randomize(fio.basename(path))
-    )
-
-    local ok, err
-
-    ok, err = utils.mktree(random_path)
+    local ok, err = utils.mktree(random_path)
     if not ok then
         return nil, err
     end

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -10,6 +10,7 @@ local errno = require('errno')
 local fiber = require('fiber')
 local checks = require('checks')
 local errors = require('errors')
+local digest = require('digest')
 
 local FcntlError = errors.new_class('FcntlError')
 local OpenFileError = errors.new_class('OpenFileError')
@@ -224,6 +225,13 @@ local function file_write(path, data, opts, perm)
     return data
 end
 
+--- Add random suffix to the file path.
+local function randomize_path(path)
+    path = string.gsub(path, '/$', '')
+    local random = digest.urandom(9)
+    local suffix = digest.base64_encode(random, {urlsafe = true})
+    return path .. '.' .. suffix
+end
 
 local mt_readonly = {
     __newindex = function()
@@ -434,6 +442,7 @@ return {
     file_read = file_read,
     file_write = file_write,
     file_exists = file_exists,
+    randomize_path = randomize_path,
 
     under_systemd = under_systemd,
     is_email_valid = is_email_valid,

--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -16,3 +16,21 @@ function g.test_upvalues()
         utils.assert_upvalues, f, {'t3'}
     )
 end
+
+function g.test_randomize_path()
+    local digest = require('digest')
+    local urandom_original = digest.urandom
+    digest.urandom = function(n) return string.rep("\0", n) end
+
+    t.assert_equals(
+        utils.randomize_path('/some/file'),
+        '/some/file.AAAAAAAAAAAA'
+    )
+
+    t.assert_equals(
+        utils.randomize_path('/some/dir/'),
+        '/some/dir.AAAAAAAAAAAA'
+    )
+
+    digest.urandom = urandom_original
+end


### PR DESCRIPTION
- Move `randomize_path` function to utils

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation
