### PR TITLE
Take care of errno constants

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -636,13 +636,13 @@ local function cfg(opts, box_opts)
                 sock:close()
                 fio.unlink(unix_port)
                 ok = false
-                _errno = errno.ENOBUFS
+                _errno = assert(errno.ENOBUFS)
             end
         end
 
         if not ok then
             local strerror
-            if _errno == errno.ENOBUFS then
+            if _errno == assert(errno.ENOBUFS) then
                 strerror = 'Too long console_sock exceeds UNIX_PATH_MAX limit'
             else
                 strerror = errno.strerror(_errno)

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -511,9 +511,10 @@ local function load(path)
     checks('string')
 
     if not fio.path.lexists(path) then
+        local ENOENT = assert(errno.ENOENT)
         local err = LoadConfigError:new(
             'Error loading %q: %s',
-            path, errno.strerror(errno.ENOENT)
+            path, errno.strerror(ENOENT)
         )
         return nil, err
     end

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -171,9 +171,10 @@ local function mktree(path)
                 )
             end
         elseif not stat:is_dir() then
+            local EEXIST = assert(errno.EEXIST)
             return nil, errors.new('MktreeError',
                 'Error creating directory %q: %s',
-                current_dir, errno.strerror(errno.EEXIST)
+                current_dir, errno.strerror(EEXIST)
             )
         end
     end

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -4,6 +4,14 @@ local fio = require('fio')
 local digest = require('digest')
 local helpers = table.copy(require('cartridge.test-helpers'))
 
+local errno = require('errno')
+local errno_list = getmetatable(errno).__index
+setmetatable(errno_list, {
+    __index = function(_, k)
+        error("errno '" .. k .. "' is not declared")
+    end,
+})
+
 helpers.project_root = fio.dirname(debug.sourcedir())
 
 fio.tempdir = function(base)

--- a/test/unit/helpers_test.lua
+++ b/test/unit/helpers_test.lua
@@ -141,3 +141,11 @@ function g.test_new_with_env()
     t.assert_covers(cluster.servers[2].env, expected)
     t.assert_covers(cluster.servers[3].env, shared_env)
 end
+
+function g.test_errno()
+    local errno = require('errno')
+    t.assert_error_msg_contains(
+        "errno 'ENOSUCHERRNO' is not declared",
+        function() return errno.ENOSUCHERRNO end
+    )
+end


### PR DESCRIPTION
While working on another patch we encountered weird test behavior.
Occasionally it used to fail with impossible message:

```
t.assert_equals(errno.strerror(errno.ENOPERM), 'Permission denied')

-- ./test/unit/upload_test.lua:178:
-- expected: "Permission denied"
--   actual: "No such file or directory"
```

That was a misspelling - it's actually `EPERM`, but not `ENOPERM`.
But the debugging took a while.

This patch makes work with errno stricter:

- In test helpers, errno list is supplied with asserting metatable.
- In the code, all constants are asserted manually.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

