### PR TITLE
Proxy API calls from and an unconfigured instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Added
   to specify the host on which administrative UI and API will be opened.
 - Refactor two-phase commit logics: don't use hardcoded timeout value for the
   ``prepare`` stage, move ``upload`` to a separate stage.
+- Allow operating cluster from an unconfigured instance WebUI.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -47,18 +47,22 @@
 --
 -- @module cartridge.issues
 -- @local
+local mod_name = 'cartridge.issues'
 
 local fio = require('fio')
 local log = require('log')
 local fun = require('fun')
 local fiber = require('fiber')
 local checks = require('checks')
+local membership = require('membership')
+
 local pool = require('cartridge.pool')
 local topology = require('cartridge.topology')
-local confapplier = require('cartridge.confapplier')
 local failover = require('cartridge.failover')
-local membership = require('membership')
-local vars = require('cartridge.vars').new('cartridge.issues')
+local confapplier = require('cartridge.confapplier')
+local lua_api_proxy = require('cartridge.lua-api.proxy')
+
+local vars = require('cartridge.vars').new(mod_name)
 
 --- Thresholds for issuing warnings.
 -- All settings are local, not clusterwide. They can be changed with
@@ -337,6 +341,13 @@ local function list_on_instance(opts)
 end
 
 local function list_on_cluster()
+    local ret, err = lua_api_proxy.call(mod_name .. '.list_on_cluster')
+    if ret ~= nil then
+        return ret
+    elseif err ~= nil then
+        return nil, err
+    end
+
     local ret = {}
     local uri_list = {}
     local topology_cfg = confapplier.get_readonly('topology')

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -341,10 +341,16 @@ local function list_on_instance(opts)
 end
 
 local function list_on_cluster()
-    local ret, err = lua_api_proxy.call(mod_name .. '.list_on_cluster')
-    if ret ~= nil then
-        return ret
-    elseif err ~= nil then
+    local state, err = confapplier.get_state()
+    if state == 'Unconfigured' and lua_api_proxy.can_call()  then
+        -- Try to proxy call
+        local ret = lua_api_proxy.call(mod_name .. '.list_on_cluster')
+        if ret ~= nil then
+            return ret
+        -- else
+            -- Don't return an error, go on
+        end
+    elseif state == 'InitError' or state == 'BootError' then
         return nil, err
     end
 

--- a/cartridge/lua-api/edit-topology.lua
+++ b/cartridge/lua-api/edit-topology.lua
@@ -282,10 +282,11 @@ local function edit_topology(args)
         servers = '?table',
     })
 
-    local ret, err = lua_api_proxy.call(mod_name .. '.edit_topology', args)
-    if ret ~= nil then
-        return ret
-    elseif err ~= nil then
+    local state, err = confapplier.get_state()
+    if state == 'Unconfigured' and lua_api_proxy.can_call() then
+        -- Try to proxy call
+        return lua_api_proxy.call(mod_name .. '.edit_topology', args)
+    elseif state == 'InitError' or state == 'BootError' then
         return nil, err
     end
 

--- a/cartridge/lua-api/edit-topology.lua
+++ b/cartridge/lua-api/edit-topology.lua
@@ -1,6 +1,7 @@
 --- Administration functions (`edit-topology` implementation).
 --
 -- @module cartridge.lua-api.edit-topology
+local mod_name = 'cartridge.lua-api.edit-topology'
 
 local fun = require('fun')
 local checks = require('checks')
@@ -13,6 +14,7 @@ local twophase = require('cartridge.twophase')
 local vshard_utils = require('cartridge.vshard-utils')
 local confapplier = require('cartridge.confapplier')
 
+local lua_api_proxy = require('cartridge.lua-api.proxy')
 local lua_api_get_topology = require('cartridge.lua-api.get-topology')
 
 local EditTopologyError = errors.new_class('Editing cluster topology failed')
@@ -279,6 +281,13 @@ local function edit_topology(args)
         replicasets = '?table',
         servers = '?table',
     })
+
+    local ret, err = lua_api_proxy.call(mod_name .. '.edit_topology', args)
+    if ret ~= nil then
+        return ret
+    elseif err ~= nil then
+        return nil, err
+    end
 
     local args = table.deepcopy(args)
     local topology_cfg = confapplier.get_deepcopy('topology')

--- a/cartridge/lua-api/get-topology.lua
+++ b/cartridge/lua-api/get-topology.lua
@@ -67,16 +67,16 @@ local lua_api_proxy = require('cartridge.lua-api.proxy')
 -- @treturn[2] nil
 -- @treturn[2] table Error description
 local function get_topology()
-    local ret, err = lua_api_proxy.call(mod_name .. '.get_topology')
-    if ret ~= nil then
-        return ret
-    elseif err ~= nil then
-        return nil, err
-    end
-
     local state, err = confapplier.get_state()
-    -- OperationError doesn't influence observing topology
-    if state == 'InitError' or state == 'BootError' then
+    if state == 'Unconfigured' and lua_api_proxy.can_call() then
+        -- Try to proxy call
+        local ret = lua_api_proxy.call(mod_name .. '.get_topology')
+        if ret ~= nil then
+            return ret
+        -- else
+            -- Don't return an error, go on
+        end
+    elseif state == 'InitError' or state == 'BootError' then
         return nil, err
     end
 

--- a/cartridge/lua-api/proxy.lua
+++ b/cartridge/lua-api/proxy.lua
@@ -1,0 +1,73 @@
+local yaml = require('yaml')
+local checks = require('checks')
+local errors = require('errors')
+local membership = require('membership')
+
+local pool = require('cartridge.pool')
+local confapplier = require('cartridge.confapplier')
+
+local vars = require('cartridge.vars').new('cartridge.lua-api.proxy')
+
+vars:new('destination')
+
+local function call(function_name, ...)
+    checks('string')
+
+    if confapplier.get_state() ~= 'Unconfigured' then
+        return nil
+    end
+
+    if vars.destination ~= nil then
+        local member = membership.get_member(vars.destination)
+        if member ~= nil and member.status == 'alive' then
+            goto call
+        else
+            vars.destination = nil
+        end
+    end
+
+    for _, member in membership.pairs() do
+        if member.status ~= 'alive'
+        or member.payload.uuid == nil
+        then
+            goto continue
+        end
+
+        -- For the sake of destination determinism choose
+        -- the member with the lowest uri (lexicographically)
+        if vars.destination == nil
+        or member.uri < vars.destination
+        then
+            vars.destination = member.uri
+        end
+
+        ::continue::
+    end
+
+    if vars.destination == nil then
+        return nil
+    end
+
+::call::
+    local conn = pool.connect(vars.destination, {wait_connected = false})
+
+    -- Both get_topology and edit_topology API return recursive lua
+    -- tables which can't be passed over netbox as is. So we transfer
+    -- them as yaml.
+    local ret, err = errors.netbox_eval(conn, [[
+        local ret, err = require('cartridge.funcall').call(...)
+        if ret == nil then return nil, err end
+        return require('yaml').encode(ret)
+    ]], {function_name, ...})
+
+    if ret == nil then
+        vars.destination = nil
+        return nil, err
+    end
+
+    return yaml.decode(ret)
+end
+
+return {
+    call = call,
+}

--- a/test/integration/proxy_test.lua
+++ b/test/integration/proxy_test.lua
@@ -1,0 +1,147 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_each(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = require('digest').urandom(6):hex(),
+        replicasets = {
+            {
+                alias = 'main',
+                uuid = helpers.uuid('a'),
+                roles =  {'vshard-router', 'vshard-storage'},
+                servers = {
+                    {instance_uuid = helpers.uuid('a', 'a', 1)},
+                },
+            }
+        },
+    })
+
+    g.servers = {}
+    for i = 2, 3 do
+        local http_port = 8080 + i
+        local advertise_port = 13300 + i
+        local alias = string.format('srv%d', i - 1)
+
+        g.servers[i - 1] = helpers.Server:new({
+            alias = alias,
+            command = helpers.entrypoint('srv_basic'),
+            workdir = fio.pathjoin(g.cluster.datadir, alias),
+            cluster_cookie = g.cluster.cookie,
+            http_port = http_port,
+            advertise_port = advertise_port,
+            instance_uuid = helpers.uuid('a', 'a', i),
+        })
+    end
+
+    for _, server in pairs(g.servers) do
+        server:start()
+    end
+    g.cluster:start()
+end)
+
+g.after_each(function()
+    for _, server in pairs(g.servers or {}) do
+        server:stop()
+    end
+    g.cluster:stop()
+
+    fio.rmtree(g.cluster.datadir)
+    g.cluster = nil
+    g.servers = nil
+end)
+
+
+local function edit_topology(server, rpl_uuid, join_servers)
+    return server:graphql({query = [[
+        mutation($replicasets: [EditReplicasetInput]) {
+            cluster {
+                edit_topology(replicasets: $replicasets) {
+                    servers {uuid uri}
+                    replicasets {uuid master { uuid uri }}
+                }
+            }
+        }]],
+        variables = {
+            replicasets = {{
+                uuid = rpl_uuid,
+                join_servers = join_servers,
+            }}
+        },
+        raise = false,
+    })
+end
+
+local function get_topology(server)
+    return server:graphql({
+        query = '{ servers {uri uuid}}'
+    }).data.servers
+end
+
+function g.test_dead_destination()
+    local server = g.servers[1]
+
+    g.cluster.main_server:stop()
+    server.net_box:call(
+        'package.loaded.membership.probe_uri',
+        {g.cluster.main_server.advertise_uri}
+    )
+
+    local resp = get_topology(server)
+    t.assert_items_include(resp, {
+        {uri = 'localhost:13303', uuid = ''},
+        {uri = 'localhost:13302', uuid = ''}
+    })
+
+    local rpl_uuid = helpers.uuid('b')
+    local resp = edit_topology(server, rpl_uuid,
+        {{uri = 'localhost:13302', uuid = server.instance_uuid}}
+    ).data.cluster.edit_topology
+
+    t.assert_equals(resp.replicasets, {{
+        master = {uri = "localhost:13302", uuid = server.instance_uuid},
+        uuid = rpl_uuid,
+    }})
+    t.assert_equals(resp.servers, {
+        {uri = "localhost:13302", uuid = server.instance_uuid}
+    })
+end
+
+function g.test_alive_destination()
+    local server = g.servers[1]
+    server.net_box:call(
+        'package.loaded.membership.probe_uri',
+        {g.cluster.main_server.advertise_uri}
+    )
+
+    -- check get_topology proxy works
+    local topology_from_bootsrapped = get_topology(g.cluster.main_server)
+    local topology_from_unconfigured = get_topology(server)
+    t.assert_items_include(topology_from_bootsrapped, {
+        {uri = 'localhost:13302', uuid = ''},
+        {uri = 'localhost:13301', uuid = g.cluster.main_server.instance_uuid},
+        {uri = 'localhost:13303', uuid = ''}
+    })
+    t.assert_items_include(topology_from_unconfigured, topology_from_bootsrapped)
+
+    -- bootstrap remotely
+    local join_servers = {
+        {uri = 'localhost:13302', uuid = g.servers[1].instance_uuid},
+        {uri = 'localhost:13303', uuid = g.servers[2].instance_uuid}
+    }
+
+    local resp = edit_topology(
+        server, helpers.uuid('a'), join_servers
+    ).data.cluster.edit_topology
+
+    t.assert_equals(resp.replicasets, {{
+        master = {uri = "localhost:13301", uuid = helpers.uuid('a', 'a', 1)},
+        uuid = helpers.uuid('a'),
+    }})
+    t.assert_items_include(resp.servers, join_servers)
+end


### PR DESCRIPTION
Nowadays, every unconfigured instance only displays itself and the other unconfigured instances. Even if there's a cluster somewhere near, it isn't shown.

With this patch, a user is able to observe the cluster even from an unconfigured server. The only requirement is that it's connected to the membership.

![image](https://user-images.githubusercontent.com/2205188/109999517-5cd93c00-7d23-11eb-88e9-7b794848084b.png)

Notice, that WebUI is open on the unconfigured instance.

There're still some restrictions regarding managing the cluster. One can't edit failover params, auth and users, code and scheme, upload / download config. But the current unconfigured instance can be joined to the existing cluster. And it doesn't result in another separate cluster creation anymore.

This is the alternative implementation of #1260. The proxy calls are implemented in a more compact manner (and in a separate module).

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1244 
