### PR TITLE
Cluster option to disable webui

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Added
 - Show an issue when ``ConfiguringRoles`` state stucks for more than 5s.
 - New GraphQL API: ``{cluster {suggestions {disable_servers {uuid}}}}``
   to restore the quorum in case of some servers go offline.
+- New cluster option ``webui_enabled`` to disable webui, HTTP and GraphQL API.
+  (by default it's enabled).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,8 +22,9 @@ Added
 - Show an issue when ``ConfiguringRoles`` state stucks for more than 5s.
 - New GraphQL API: ``{cluster {suggestions {disable_servers {uuid}}}}``
   to restore the quorum in case of some servers go offline.
-- New cluster option ``webui_enabled`` to disable webui, HTTP and GraphQL API.
-  (by default it's enabled).
+- New ``cartridge.cfg`` option ``webui_enabled`` (default: true). Otherwise,
+  HTTP server remains operable (and GraphQL too), but serves user-defined roles
+  API only.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -170,12 +170,13 @@ end
 --  env `TARANTOOL_HTTP_ENABLED`,
 --  args `--http-enabled`)
 --
--- (**Added** in v2.4.0-37)
 -- @tparam ?boolean opts.webui_enabled
---  whether webui should be initialized. It also enables HTTP and
---  GraphQL API (issues, suggestions, etc). Doesn't affect opts.auth_enabled
---  Ignored if http_enabled = false
---  (default: true, overridden by
+--  whether WebUI and corresponding API (HTTP + GraphQL) should be
+--  initialized. Ignored if `http_enabled` is `false`. Doesn't
+--  affect `auth_enabled`.
+--
+--  (**Added** in v2.4.0-38,
+--  default: true, overridden by
 --  env `TARANTOOL_WEBUI_ENABLED`,
 --  args `--webui-enabled`)
 --
@@ -592,21 +593,21 @@ local function cfg(opts, box_opts)
             return nil, err
         end
 
-        if opts.webui_enabled then
-            local ok, err = HttpInitError:pcall(webui.init, httpd)
-            if not ok then
-                return nil, err
-            end
-        else
-            graphql.init(httpd)
-        end
-
         local ok, err = CartridgeCfgError:pcall(auth.init, httpd)
         if not ok then
             return nil, err
         end
 
-        webui.set_blacklist(opts.webui_blacklist)
+        graphql.init(httpd)
+
+        if opts.webui_enabled then
+            local ok, err = HttpInitError:pcall(webui.init, httpd)
+            if not ok then
+                return nil, err
+            end
+
+            webui.set_blacklist(opts.webui_blacklist)
+        end
 
         local srv_name = httpd.tcp_server:name()
         log.info('Listening HTTP on %s:%s', srv_name.host, srv_name.port)

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -84,6 +84,7 @@ local cluster_opts = {
     workdir = 'string', -- **string**
     http_port = 'number', -- **number**
     http_enabled = 'boolean', -- **boolean**
+    webui_enabled = 'boolean', -- **boolean**
     advertise_uri = 'string', -- **string**
     cluster_cookie = 'string', -- **string**
     console_sock = 'string', -- **string**

--- a/cartridge/webui.lua
+++ b/cartridge/webui.lua
@@ -30,7 +30,6 @@ local function init(httpd)
     front.init(httpd)
     front.add('cluster', front_bundle)
 
-    graphql.init(httpd)
     graphql.add_mutation_prefix('cluster', 'Cluster management')
     graphql.add_callback_prefix('cluster', 'Cluster management')
 

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -355,11 +355,11 @@ g.test_webui_disabled = function()
     membership.broadcast = function() error('Forbidden', 0) end
 
     local opts = {
-            workdir = '/tmp',
-            advertise_uri = 'unused:0',
-            http_enabled = true,
-            webui_enabled = false,
-            swim_broadcast = false,
+        workdir = '/tmp',
+        advertise_uri = 'unused:0',
+        http_enabled = true,
+        webui_enabled = false,
+        swim_broadcast = false,
         roles = {
             'cartridge.roles.vshard-storage',
             'cartridge.roles.vshard-router',
@@ -372,16 +372,10 @@ g.test_webui_disabled = function()
 
     local service = require('cartridge.service-registry')
     local httpd = service.get('httpd')
-    local routes = httpd.routes
+    t.assert_items_equals(
+        require('fun').iter(httpd.routes):map(function(r) return r.path end):totable(),
+        {"/login", "/logout", "/admin/api"}
+    )
 
-    local function compare_routes(a,b)
-        return a['path'] < b['path']
-    end
-    table.sort(routes, compare_routes)
-
-    t.assert_equals(#routes, 3)
-    t.assert_equals(routes[1].path, '/admin/api')
-    t.assert_equals(routes[2].path, '/login')
-    t.assert_equals(routes[3].path, '/logout')
     httpd:stop()
 end


### PR DESCRIPTION
New `cartridge.cfg` option `webui_enabled` (default: true). Otherwise, HTTP server remains operable (and GraphQL too), but serves user-defined roles API only.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #551 
