### PR TITLE
Fix replication info in the WebUI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ Fixed
 
 - Don't make yaml formatting ugly during config upload.
 
+- "No value provided for non-null ReplicaStatus" GraphQL error
+  after removing a replica from the `box.space._cluster`.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced is WebUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -100,8 +100,9 @@ local function get_info(uri)
             }
         }
 
-        for i, replica in pairs(box_info.replication) do
-            ret.replication.replication_info[i] = {
+        for i = 1, table.maxn(box_info.replication) do
+            local replica = box_info.replication[i]
+            ret.replication.replication_info[i] = replica and {
                 id = replica.id,
                 lsn = replica.lsn,
                 uuid = replica.uuid,
@@ -112,7 +113,7 @@ local function get_info(uri)
                 upstream_lag = replica.upstream and replica.upstream.lag,
                 downstream_status = replica.downstream and replica.downstream.status,
                 downstream_message = replica.downstream and replica.downstream.message,
-            }
+            } or box.NULL
         end
 
         return ret

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -195,7 +195,7 @@ local boxinfo_schema = {
                             ' replication log sequence numbers',
                     },
                     replication_info = {
-                        kind = gql_types.list(gql_replica_status.nonNull),
+                        kind = gql_types.list(gql_replica_status),
                         description =
                             'Statistics for all instances' ..
                             ' in the replica set in regard to the' ..

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Mon Feb 01 2021 19:13:04 GMT+0300 (Moscow Standard Time)
+# timestamp: Tue Mar 02 2021 20:36:01 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -445,7 +445,7 @@ type ServerInfoReplication {
   """
   Statistics for all instances in the replica set in regard to the current instance
   """
-  replication_info: [ReplicaStatus!]
+  replication_info: [ReplicaStatus]
 
   """The vector clock of replication log sequence numbers"""
   vclock: [Long]

--- a/test/integration/expel_test.lua
+++ b/test/integration/expel_test.lua
@@ -1,0 +1,87 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = require('digest').urandom(6):hex(),
+        replicasets = {{
+            alias = 'A',
+            roles = {},
+            servers = 3,
+        }},
+    })
+    g.cluster:start()
+
+    g.A1 = g.cluster:server('A-1')
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.list_cluster_issues(g.A1), {})
+    end)
+
+    g.r1_uuid = g.A1.net_box:eval('return box.space._cluster:get(1).uuid')
+    g.r2_uuid = g.A1.net_box:eval('return box.space._cluster:get(2).uuid')
+    g.r3_uuid = g.A1.net_box:eval('return box.space._cluster:get(3).uuid')
+
+    -- Expel the second server, the gap is important for the test.
+    local expelled = helpers.table_find_by_attr(
+        g.cluster.servers, 'instance_uuid', g.r2_uuid
+    )
+
+    expelled:stop()
+    g.A1.net_box:eval([[
+        package.loaded.cartridge.admin_edit_topology({servers = {{
+            uuid = ...,
+            expelled = true,
+        }}})
+
+        box.space._cluster.index.uuid:delete(...)
+    ]], {expelled.instance_uuid})
+
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_api()
+    local ret = g.A1.net_box:eval('return box.info.replication')
+    t.assert_covers(ret[1], {id = 1, uuid = g.r1_uuid}, ret)
+    t.assert_covers(ret[3], {id = 3, uuid = g.r3_uuid}, ret)
+    t.assert_equals(ret[2], nil, ret)
+
+    local ret = g.A1:graphql({
+        query = [[ query($uuid: String!) {
+            servers(uuid: $uuid) {
+                boxinfo { replication { replication_info {
+                    id
+                    upstream_peer
+                    upstream_status
+                    downstream_status
+                }}}
+            }
+        }]],
+        variables = {uuid = g.r3_uuid},
+    }).data.servers[1].boxinfo.replication.replication_info
+
+    t.assert_equals(ret, {
+        [1] = {
+            id = 1,
+            upstream_peer = "admin@" .. g.A1.advertise_uri,
+            upstream_status = "follow",
+            downstream_status = "follow",
+        },
+        [2] = box.NULL,
+        [3] = {
+            id = 3,
+            upstream_peer = box.NULL,
+            upstream_status = box.NULL,
+            downstream_status = box.NULL,
+        },
+    })
+end

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -578,7 +578,7 @@ export type ServerInfoReplication = {|
   replication_skip_conflict?: ?$ElementType<Scalars, 'Boolean'>,
   replication_sync_lag?: ?$ElementType<Scalars, 'Float'>,
   /** Statistics for all instances in the replica set in regard to the current instance */
-  replication_info?: ?Array<ReplicaStatus>,
+  replication_info?: ?Array<?ReplicaStatus>,
   /** The vector clock of replication log sequence numbers */
   vclock?: ?Array<?$ElementType<Scalars, 'Long'>>,
   replication_timeout?: ?$ElementType<Scalars, 'Float'>,
@@ -818,7 +818,7 @@ export type BoxInfoQuery = ({
       }), replication: ({
           ...{ __typename?: 'ServerInfoReplication' },
         ...$Pick<ServerInfoReplication, {| replication_connect_quorum?: *, replication_connect_timeout?: *, replication_sync_timeout?: *, replication_skip_conflict?: *, replication_sync_lag?: *, vclock?: *, replication_timeout?: * |}>,
-        ...{| replication_info?: ?Array<({
+        ...{| replication_info?: ?Array<?({
             ...{ __typename?: 'ReplicaStatus' },
           ...$Pick<ReplicaStatus, {| downstream_status?: *, id?: *, upstream_peer?: *, upstream_idle?: *, upstream_message?: *, lsn?: *, upstream_lag?: *, upstream_status?: *, uuid: *, downstream_message?: * |}>
         })> |}
@@ -867,7 +867,7 @@ export type InstanceDataQuery = ({
       }), replication: ({
           ...{ __typename?: 'ServerInfoReplication' },
         ...$Pick<ServerInfoReplication, {| replication_connect_quorum?: *, replication_connect_timeout?: *, replication_sync_timeout?: *, replication_skip_conflict?: *, replication_sync_lag?: *, vclock?: *, replication_timeout?: * |}>,
-        ...{| replication_info?: ?Array<({
+        ...{| replication_info?: ?Array<?({
             ...{ __typename?: 'ReplicaStatus' },
           ...$Pick<ReplicaStatus, {| downstream_status?: *, id?: *, upstream_peer?: *, upstream_idle?: *, upstream_message?: *, lsn?: *, upstream_lag?: *, upstream_status?: *, uuid: *, downstream_message?: * |}>
         })> |}
@@ -959,7 +959,13 @@ export type ServerListQuery = ({
       ...{ __typename?: 'Apicluster' },
     ...{| suggestions?: ?({
         ...{ __typename?: 'Suggestions' },
-      ...{| refine_uri?: ?Array<({
+      ...{| disable_servers?: ?Array<({
+          ...{ __typename?: 'DisableServerSuggestion' },
+        ...$Pick<DisableServerSuggestion, {| uuid: * |}>
+      })>, force_apply?: ?Array<({
+          ...{ __typename?: 'ForceApplySuggestion' },
+        ...$Pick<ForceApplySuggestion, {| config_mismatch: *, config_locked: *, uuid: *, operation_error: * |}>
+      })>, refine_uri?: ?Array<({
           ...{ __typename?: 'RefineUriSuggestion' },
         ...$Pick<RefineUriSuggestion, {| uuid: *, uri_old: *, uri_new: * |}>
       })> |}
@@ -1183,6 +1189,22 @@ export type Set_FilesMutation = ({
     ...{| config: Array<?({
         ...{ __typename?: 'ConfigSection' },
       ...$Pick<ConfigSection, {| filename: *, content: * |}>
+    })> |}
+  }) |}
+});
+
+export type Disable_ServersMutationVariables = {
+  uuids?: ?Array<$ElementType<Scalars, 'String'>>,
+};
+
+
+export type Disable_ServersMutation = ({
+    ...{ __typename?: 'Mutation' },
+  ...{| cluster?: ?({
+      ...{ __typename?: 'MutationApicluster' },
+    ...{| disable_servers?: ?Array<?({
+        ...{ __typename?: 'Server' },
+      ...$Pick<Server, {| uuid: *, disabled?: * |}>
     })> |}
   }) |}
 });


### PR DESCRIPTION
There is a bug when a replica with medium id is removed from `box.space._cluster`. E.g. there are 2 instances and we expel the leader (switching it beforehand). It results in a gapped array `box.info.replication` and the GraphQL schema validation fails.

This patch makes the ReplicaStatus nullable in the GraphQL schema and fixes the response generation accordingly.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1283
