### PR TITLE
Sandbox unit.cfg_errors test

### DIFF
--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -1,381 +1,401 @@
-#!/usr/bin/env tarantool
-
 local t = require('luatest')
 local g = t.group()
 
-if not pcall(require, 'cartridge.front-bundle') then
-    -- to be loaded in development environment
-    package.preload['cartridge.front-bundle'] = function()
-        return require('webui.build.bundle')
-    end
-end
-
-local log = require('log')
+local helpers = require('test.helper')
 local fio = require('fio')
-local errno = require('errno')
-local fiber = require('fiber')
-local checks = require('checks')
-local socket = require('socket')
-local cartridge = require('cartridge')
-local membership = require('membership')
 
-g.before_all(function()
-    g.tempdir = fio.tempdir()
-    g.membership_backup = table.copy(membership)
+g.server = t.Server:new({
+    command = helpers.entrypoint('srv_empty'),
+    workdir = fio.tempdir(),
+    net_box_port = 13300,
+    http_port = 8082,
+    net_box_credentials = {user = 'admin', password = ''},
+})
+
+g.before_each(function()
+    g.server:start()
+    helpers.retrying({}, function() g.server:connect_net_box() end)
 end)
-
-g.after_all(function()
-    fio.rmtree(g.tempdir)
-end)
-
-local fn_true = function() return true end
-local fn_false = function() return false end
-
-function g.mock_membership()
-    table.clear(membership)
-    membership.init = fn_true
-    membership.probe_uri = fn_true
-    membership.broadcast = fn_true
-    membership.set_encryption_key = fn_true
-    membership.set_payload = fn_true
-    membership.subscribe = function()
-        return fiber.cond()
-    end
-    membership.myself = function()
-        return {
-            uri = 'unused:0',
-            status = require('membership.options').ALIVE,
-            incarnation = 1,
-            payload = {},
-        }
-    end
-end
 
 g.after_each(function()
-    table.clear(membership)
-    for k, v in pairs(g.membership_backup) do
-        membership[k] = v
-    end
-
-    cartridge = nil
-    for name, _ in pairs(package.loaded) do
-        if name:startswith('cartridge') then
-            package.loaded[name] = nil
-        end
-    end
-    rawset(_G, "_cluster_vars_defaults", nil)
-    rawset(_G, "_cluster_vars_values", nil)
-    cartridge = require('cartridge')
+    g.server:stop()
+    fio.rmtree(g.server.workdir)
 end)
 
-local function check_error(expected_error, fn, ...)
-    checks('string', 'function')
-    local ok, err = fn(...)
-    if type(ok) ~= 'nil' then
-        error("Call succeded, but it shouldn't", 2)
-    end
+local function mock()
+    local fiber = require('fiber')
+    local fn_true = function() return true end
 
-    for _, l in pairs(string.split(tostring(err), '\n')) do
-        log.info('-- %s', l)
-    end
+    package.loaded['membership'] = {
+        init = fn_true,
+        probe_uri = fn_true,
+        broadcast = fn_true,
+        set_payload = fn_true,
+        set_encryption_key = fn_true,
+        subscribe = function() return fiber.cond() end,
+        myself = function()
+            return {
+                uri = 'unused:0',
+                status = 1,
+                incarnation = 1,
+                payload = {},
+            }
+        end,
+    }
 
-    if not string.find(err.err, expected_error, nil, true) then
-        local e = string.format(
-            "Mismatching error message:\n" ..
-            "expected: %s\n" ..
-            "  actual: %s\n",
-            expected_error, err
-        )
-        log.error('\n%s', e)
-        error(e, 2)
-    end
+    package.loaded['cartridge.remote-control'] = {
+        bind = fn_true,
+        accept = fn_true,
+    }
 end
 
 -- workdir --------------------------------------------------------------------
 -------------------------------------------------------------------------------
 g.test_workdir = function()
-    -- Test malformed opts.workdir
-    check_error(
-        'Error creating directory "/dev/null": File exists',
-        cartridge.cfg, {
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        os.setenv('TARANTOOL_WORKDIR', nil)
+        -- Test malformed opts.workdir
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
             workdir = '/dev/null',
-            advertise_uri = 'localhost:13301',
             roles = {},
-        }
-    )
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'MktreeError',
+            err = 'Error creating directory "/dev/null": File exists',
+        })
+    end)
 end
 
 -- advertise_uri --------------------------------------------------------------
 -------------------------------------------------------------------------------
 
 g.test_advertise_uri = function()
-    -- Test malformed opts.advertise_uri
-    check_error('Invalid port in advertise_uri "localhost:invalid"',
-        cartridge.cfg, {
-            workdir = g.tempdir,
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'localhost:invalid',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
+        })
 
-    check_error('Invalid advertise_uri ":1111"',
-        cartridge.cfg, {
-            workdir = g.tempdir,
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Invalid port in advertise_uri "localhost:invalid"',
+        })
+    end)
+
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        local ok, err = require('cartridge').cfg({
             advertise_uri = ':1111',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
+        })
 
-    local _sock = socket('AF_INET', 'SOCK_DGRAM', 'udp')
-    _sock:bind('0.0.0.0', 13301)
-    check_error(
-        'Socket bind error (13301/udp): ' ..
-        errno.strerror(errno.EADDRINUSE),
-        cartridge.cfg, {
-            workdir = g.tempdir,
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Invalid advertise_uri ":1111"',
+        })
+    end)
+
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local errno = require('errno')
+
+        local _sock = require('socket')('AF_INET', 'SOCK_DGRAM', 'udp')
+        _sock:bind('0.0.0.0', 13301)
+
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'localhost:13301',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
-    _sock:close()
+        })
 
-    check_error('Can not ping myself',
-        cartridge.cfg, {
-            workdir = g.tempdir,
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Socket bind error (13301/udp): ' ..
+                errno.strerror(assert(errno.EADDRINUSE)),
+        })
+
+        _sock:close()
+    end)
+
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'invalid-host:13301',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
-    membership.leave()
+        })
 
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Can not ping myself: ping was not sent',
+        })
+    end)
 end
 
 -- roles ----------------------------------------------------------------------
 -------------------------------------------------------------------------------
 g.test_roles = function()
-    g.mock_membership()
-    -- Test malformed opts.roles
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
 
-    check_error([[module 'unknown-role' not found]],
-        cartridge.cfg, {
-            workdir = g.tempdir,
-            advertise_uri = 'unused:0',
-            http_enabled = false,
-            roles = {
-                'cartridge.roles.vshard-storage',
-                'cartridge.roles.vshard-router',
-                'unknown-role',
-            },
-        }
-    )
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'localhost:13301',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {'unknown-role'},
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'RegisterRoleError'})
+        t.assert_str_matches(err.err, "module 'unknown%-role' not found:\n.+")
+    end)
 end
-
 
 -- auth_backend ---------------------------------------------------------------
 -------------------------------------------------------------------------------
 
 g.test_auth_backend = function()
-    g.mock_membership()
-    -- Test malformed opts.auth_backend_name
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
 
-    check_error([[module 'unknown-auth' not found]],
-        cartridge.cfg, {
-            workdir = g.tempdir,
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'unused:0',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
             auth_backend_name = 'unknown-auth',
-            roles = {},
-        }
-    )
+        })
 
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'CartridgeCfgError'})
+        t.assert_str_matches(err.err, "module 'unknown%-auth' not found:\n.+")
+    end)
 
-    package.preload['myauth'] = function()
-        error('My auth can not be loaded')
-    end
-    check_error('My auth can not be loaded',
-        cartridge.cfg, {
-            workdir = g.tempdir,
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        package.loaded.myauth = nil
+        package.preload['myauth'] = function()
+            error('My auth can not be loaded', 0)
+        end
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'unused:0',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
             auth_backend_name = 'myauth',
-            roles = {},
-        }
-    )
+        })
 
-    package.preload['auth-unknown-method'] = function()
-        return {
-            unknown_method = function() end,
-        }
-    end
-    check_error('unexpected argument callbacks.unknown_method to set_callbacks',
-        cartridge.cfg, {
-            workdir = g.tempdir,
-            advertise_uri = 'unused:0',
-            auth_backend_name = 'auth-unknown-method',
-            roles = {},
-        }
-    )
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'My auth can not be loaded',
+        })
+    end)
 
-    package.preload['auth-invalid-method'] = function()
-        return {
-            check_password = 'not-a-function',
-        }
-    end
-    check_error('bad argument callbacks.check_password to set_callbacks',
-        cartridge.cfg, {
-            workdir = g.tempdir,
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        package.loaded.myauth = nil
+        package.preload['myauth'] = function()
+            return { unknown_method = function() end }
+        end
+        local ok, err = require('cartridge').cfg({
             advertise_uri = 'unused:0',
-            auth_backend_name = 'auth-invalid-method',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
+            auth_backend_name = 'myauth',
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'CartridgeCfgError'})
+        t.assert_str_matches(err.err, '.+: unexpected' ..
+            ' argument callbacks.unknown_method to set_callbacks'
+        )
+    end)
+
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+
+        package.loaded.myauth = nil
+        package.preload['myauth'] = function()
+            return { check_password = 'not-a-function' }
+        end
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+            auth_backend_name = 'myauth',
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'CartridgeCfgError'})
+        t.assert_str_matches(err.err, '.+: bad argument' ..
+            ' callbacks.check_password to set_callbacks' ..
+            ' %(%?function expected, got string%)'
+        )
+    end)
 end
 
 g.test_console_sock_enobufs = function()
-    g.mock_membership()
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local fio = require('fio')
+        local workdir = os.getenv('TARANTOOL_WORKDIR')
 
-    local sock_dir = fio.pathjoin(g.tempdir, 'sock')
-    local sock_name = string.format('%s/%s.sock', sock_dir, ('a'):rep(110))
-    fio.mktree(sock_dir)
+        local sock_dir = fio.pathjoin(workdir, 'sock')
+        local sock_name = sock_dir .. '/' .. ('a'):rep(110) .. '.sock'
+        fio.mktree(sock_dir)
 
-    local ok, err = cartridge.cfg({
-        workdir = '/tmp',
-        advertise_uri = 'unused:0',
-        http_enabled = false,
-        roles = {},
-        console_sock = sock_name,
-    })
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
+            http_enabled = false,
+            workdir = workdir,
+            roles = {},
+            console_sock = sock_name,
+        })
 
-    t.assert_not(ok)
-    log.info('%s', err)
-    t.assert_covers(err, {
-        class_name = 'ConsoleListenError',
-        err = 'unix/:' .. sock_name .. ': ' ..
-            'Too long console_sock exceeds UNIX_PATH_MAX limit',
-    })
-    t.assert_equals(fio.listdir(sock_dir), {})
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'ConsoleListenError',
+            err = 'unix/:' .. sock_name .. ': ' ..
+                'Too long console_sock exceeds UNIX_PATH_MAX limit',
+        })
+        t.assert_equals(fio.listdir(sock_dir), {})
+    end)
 end
 
 g.test_console_sock_enoent = function()
-    g.mock_membership()
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local errno = require('errno')
 
-    local sock_name = fio.pathjoin(g.tempdir, 'no', 'such', 'file')
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
+            http_enabled = false,
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+            console_sock = '/no/such/file',
+        })
 
-    local ok, err = cartridge.cfg({
-        workdir = '/tmp',
-        advertise_uri = 'unused:0',
-        http_enabled = false,
-        roles = {},
-        console_sock = sock_name,
-    })
-
-    t.assert_not(ok)
-    log.info('%s', err)
-    t.assert_covers(err, {
-        class_name = 'ConsoleListenError',
-        err = 'unix/:' .. sock_name .. ': ' .. errno.strerror(errno.ENOENT),
-    })
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'ConsoleListenError',
+            err = 'unix/:/no/such/file: ' ..
+                errno.strerror(assert(errno.ENOENT)),
+        })
+    end)
 end
 
 -- resolve_dns ----------------------------------------------------------------
 -------------------------------------------------------------------------------
 
-g.test_dns_resolve_after_wait = function()
-    g.mock_membership()
-    membership.probe_uri = fn_false
-    os.setenv('TARANTOOL_PROBE_URI_TIMEOUT', '0.3')
+g.test_dns_resolve_timeout = function()
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local fiber = require('fiber')
+        t.assert_not(package.loaded['cartridge'])
+        t.assert_not(package.loaded['cartridge.confapplier'])
+        local membership = assert(package.loaded.membership)
 
-    fiber.create(function()
-        -- sleep time < probe_uri_timeout == 0.3
-        fiber.sleep(0.1)
-        membership.probe_uri = fn_true
+        os.setenv('TARANTOOL_PROBE_URI_TIMEOUT', '0.3')
+        membership.probe_uri = function() return false, 'go away' end
+
+        local start_time = fiber.clock()
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
+            http_enabled = false,
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+        })
+
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Can not ping myself: go away',
+        })
+
+        t.assert(fiber.clock() - start_time > 0.3,
+            'Waited time < probe_uri_timeout')
     end)
 
-    local ok, err = cartridge.cfg({
-        workdir = g.tempdir,
-        advertise_uri = 'localhost:13001',
-        roles = {},
-        http_enabled = false,
-    })
-    t.assert(ok, err)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local fiber = require('fiber')
+        local membership = assert(package.loaded.membership)
 
-    os.setenv('TARANTOOL_PROBE_URI_TIMEOUT', nil)
-    membership.probe_uri = fn_true
-end
+        fiber.new(function()
+            -- sleep time < probe_uri_timeout == 0.3
+            fiber.sleep(0.1)
+            membership.probe_uri = function() return true end
+        end)
 
-g.test_dns_not_resolve_after_wait = function()
-    g.mock_membership()
-    membership.probe_uri = fn_false
-    os.setenv('TARANTOOL_PROBE_URI_TIMEOUT', '0.3')
-
-    local start_time = fiber.clock()
-    check_error('Can not ping myself',
-        cartridge.cfg, {
-            workdir = g.tempdir,
-            advertise_uri = 'localhost:13001',
-            roles = {},
+        local ok, err = require('cartridge').cfg({
+            advertise_uri = 'unused:0',
             http_enabled = false,
-        }
-    )
-    t.assert(fiber.clock() - start_time > 0.3, 'Waited time < probe_uri_timeout')
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+        })
 
-    os.setenv('TARANTOOL_PROBE_URI_TIMEOUT', nil)
-    membership.probe_uri = fn_true
+        t.assert(ok, err)
+    end)
 end
 
 -- ok -------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
 g.test_positive = function()
-    g.mock_membership()
-    membership.broadcast = function() error('Forbidden', 0) end
-    -- Test successful cartridge.cfg
+    helpers.run_remotely(g.server, mock)
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local fun = require('fun')
+        local membership = assert(package.loaded.membership)
+        membership.broadcast = function() error('Forbidden', 0) end
 
-    local opts = {
-            workdir = '/tmp',
+        local opts = {
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             advertise_uri = 'unused:0',
-            http_enabled = false,
+            http_enabled = true,
+            webui_enabled = false,
             swim_broadcast = false,
-        roles = {
-            'cartridge.roles.vshard-storage',
-            'cartridge.roles.vshard-router',
-        },
-    }
+            roles = {
+                'cartridge.roles.vshard-storage',
+                'cartridge.roles.vshard-router',
+            },
+        }
 
-    local ok, err = cartridge.cfg(opts)
-    t.assert_equals(err, nil)
-    t.assert_equals(ok, true)
-    log.info('----------------')
+        local ok, err = require('cartridge').cfg(opts)
+        t.assert(ok, err)
 
-    check_error('Cluster is already initialized',
-        cartridge.cfg, opts
-    )
-end
+        local service = require('cartridge.service-registry')
+        local httpd = service.get('httpd')
+        t.assert_items_equals(
+            fun.map(function(r) return r.path end, httpd.routes):totable(),
+            {"/login", "/logout", "/admin/api"}
+        )
 
-g.test_webui_disabled = function()
-    g.mock_membership()
-    membership.broadcast = function() error('Forbidden', 0) end
-
-    local opts = {
-        workdir = '/tmp',
-        advertise_uri = 'unused:0',
-        http_enabled = true,
-        webui_enabled = false,
-        swim_broadcast = false,
-        roles = {
-            'cartridge.roles.vshard-storage',
-            'cartridge.roles.vshard-router',
-        },
-    }
-
-    local ok, err = cartridge.cfg(opts)
-    t.assert_equals(err, nil)
-    t.assert_equals(ok, true)
-
-    local service = require('cartridge.service-registry')
-    local httpd = service.get('httpd')
-    t.assert_items_equals(
-        require('fun').iter(httpd.routes):map(function(r) return r.path end):totable(),
-        {"/login", "/logout", "/admin/api"}
-    )
-
-    httpd:stop()
+        local ok, err = require('cartridge').cfg(opts)
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'CartridgeCfgError',
+            err = 'Cluster is already initialized',
+        })
+    end)
 end


### PR DESCRIPTION
Recently we've encountered a weird test behavior: a test (`unit.upload` from #1266) succeded when run alone, but failed in conjunction with `unit.cfg_errors` test. The reason is in monkeypatching and reloading of lua modules used there.

With this patch, all test functions are moved to a simple empty server and run over netbox (remote-control).

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
