### PR TITLE
Configurable http host for administrative UI and API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Added
 - New ``cartridge.cfg`` option ``webui_enabled`` (default: true). Otherwise,
   HTTP server remains operable (and GraphQL too), but serves user-defined roles
   API only.
+- New ``cartridge.cfg`` option ``http_host`` (default: 0.0.0.0). It is used
+  to specify the host on which administrative UI and API will be opened.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -188,6 +188,13 @@ end
 --  env `TARANTOOL_HTTP_PORT`,
 --  args `--http-port`)
 --
+-- @tparam ?string opts.http_host
+--  host to open administrative UI and API on
+--  (**Added** in v2.4.0-3?
+--  default: 0.0.0.0, overridden by
+--  env `TARANTOOL_HTTP_HOST`,
+--  args `--http-host`)
+--
 -- @tparam ?string opts.alias
 -- human-readable instance name that will be available in administrative UI
 --  (default: argparse instance name, overridden by
@@ -240,6 +247,7 @@ local function cfg(opts, box_opts)
         cluster_cookie = '?string',
         bucket_count = '?number',
         http_port = '?string|number',
+        http_host = '?string',
         http_enabled = '?boolean',
         webui_enabled = '?boolean',
         alias = '?string',
@@ -575,6 +583,9 @@ local function cfg(opts, box_opts)
             opts.http_port = 8081
         end
     end
+    if opts.http_host == nil then
+        opts.http_host = '0.0.0.0'
+    end
 
     if opts.http_enabled == nil then
         opts.http_enabled = true
@@ -584,7 +595,7 @@ local function cfg(opts, box_opts)
     end
     if opts.http_enabled then
         local httpd = http.new(
-            '0.0.0.0', opts.http_port,
+            opts.http_host, opts.http_port,
             { log_requests = false }
         )
 

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -190,8 +190,8 @@ end
 --
 -- @tparam ?string opts.http_host
 --  host to open administrative UI and API on
---  (**Added** in v2.4.0-3?
---  default: 0.0.0.0, overridden by
+--  (**Added** in v2.4.0-42
+--  default: "0.0.0.0", overridden by
 --  env `TARANTOOL_HTTP_HOST`,
 --  args `--http-host`)
 --

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -83,6 +83,7 @@ local cluster_opts = {
     alias = 'string', -- **string**
     workdir = 'string', -- **string**
     http_port = 'number', -- **number**
+    http_host = 'string', -- **string**
     http_enabled = 'boolean', -- **boolean**
     webui_enabled = 'boolean', -- **boolean**
     advertise_uri = 'string', -- **string**

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -8,7 +8,6 @@ g.server = t.Server:new({
     command = helpers.entrypoint('srv_empty'),
     workdir = fio.tempdir(),
     net_box_port = 13300,
-    http_port = 8082,
     net_box_credentials = {user = 'admin', password = ''},
 })
 
@@ -147,16 +146,55 @@ g.test_advertise_uri = function()
     end)
 end
 
-g.test_http_host = function()
-    check_error('Can\'t create tcp_server: Input/output error',
-        cartridge.cfg, {
-            workdir = g.tempdir,
-            http_host = 'invalid-host',
+-- http -----------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+
+g.test_http = function()
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local errno = require('errno')
+
+        local ok, err = require('cartridge').cfg({
+            swim_broadcast = false,
             advertise_uri = 'localhost:13301',
+            http_host = '255.255.255.255',
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
             roles = {},
-        }
-    )
-    membership.leave()
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'HttpInitError'})
+        t.assert_str_matches(err.err, '.+: ' ..
+            "Can't create tcp_server: " ..
+                errno.strerror(assert(errno.EINVAL))
+        )
+    end)
+
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        local errno = require('errno')
+
+        local _sock = require('socket')('AF_INET', 'SOCK_STREAM', 'tcp')
+        _sock:bind('0.0.0.0', 18080)
+
+        local ok, err = require('cartridge').cfg({
+            swim_broadcast = false,
+            advertise_uri = 'localhost:13301',
+            http_port = 18080,
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {class_name = 'HttpInitError'})
+        t.assert_str_matches(err.err, '.+: ' ..
+            "Can't create tcp_server: " ..
+                errno.strerror(assert(errno.EADDRINUSE))
+        )
+
+        _sock:close()
+    end)
 end
 
 -- roles ----------------------------------------------------------------------
@@ -384,6 +422,7 @@ g.test_positive = function()
         local opts = {
             workdir = os.getenv('TARANTOOL_WORKDIR'),
             advertise_uri = 'unused:0',
+            http_host = '127.0.0.1',
             http_enabled = true,
             webui_enabled = false,
             swim_broadcast = false,
@@ -398,6 +437,16 @@ g.test_positive = function()
 
         local service = require('cartridge.service-registry')
         local httpd = service.get('httpd')
+        t.assert_equals(
+            setmetatable(httpd.tcp_server:name(), nil),
+            {
+                protocol = "tcp",
+                family = "AF_INET",
+                type = "SOCK_STREAM",
+                host = "127.0.0.1",
+                port = 8081,
+            }
+        )
         t.assert_items_equals(
             fun.map(function(r) return r.path end, httpd.routes):totable(),
             {"/login", "/logout", "/admin/api"}

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -147,6 +147,18 @@ g.test_advertise_uri = function()
     end)
 end
 
+g.test_http_host = function()
+    check_error('Can\'t create tcp_server: Input/output error',
+        cartridge.cfg, {
+            workdir = g.tempdir,
+            http_host = 'invalid-host',
+            advertise_uri = 'localhost:13301',
+            roles = {},
+        }
+    )
+    membership.leave()
+end
+
 -- roles ----------------------------------------------------------------------
 -------------------------------------------------------------------------------
 g.test_roles = function()


### PR DESCRIPTION
New ``cartridge.cfg`` option ``http_host`` (default: 0.0.0.0). It is used to specify the host on which administrative UI and API will be opened.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1258 
