### PR TITLE
Avoid WebUI and pool.map_call requests hanging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Fixed
   the ``apply_config`` is made by every instance individually. The validation
   step is never skipped.
 
+- Avoid WebUI and ``pool.map_call`` requests hanging because of network
+  connection problems.
+
 -------------------------------------------------------------------------------
 [2.5.0] - 2021-03-05
 -------------------------------------------------------------------------------

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -119,15 +119,14 @@ local function get_info(uri)
         return ret
     end
 
-    local conn, err = pool.connect(uri)
+    local conn, err = pool.connect(uri, {wait_connected = false})
     if not conn then
         return nil, err
     end
 
     return errors.netbox_call(
-        conn,
-        '_G.__cluster_admin_get_info',
-        {}, {timeout = 1}
+        conn, '_G.__cluster_admin_get_info',
+        nil, {timeout = 1}
     )
 end
 

--- a/cartridge/lua-api/deprecated.lua
+++ b/cartridge/lua-api/deprecated.lua
@@ -117,7 +117,9 @@ local function join_server(args)
             member.payload.state == 'ConfiguringRoles' or
             member.payload.state == 'RolesConfigured'
         ) then
-            conn = pool.connect(args.uri)
+            conn = pool.connect(args.uri, {
+                wait_connected = deadline - fiber.clock()
+            })
         end
     end
     membership.unsubscribe(cond)

--- a/cartridge/lua-api/stat.lua
+++ b/cartridge/lua-api/stat.lua
@@ -45,15 +45,14 @@ local function get_stat(uri)
         }
     end
 
-    local conn, err = pool.connect(uri)
+    local conn, err = pool.connect(uri, {wait_connected = false})
     if not conn then
         return nil, err
     end
 
     return errors.netbox_call(
-        conn,
-        '_G.__cluster_admin_get_stat',
-        {}, {timeout = 1}
+        conn, '_G.__cluster_admin_get_stat',
+        nil, {timeout = 1}
     )
 end
 

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -140,7 +140,7 @@ end
 
 local function _gather_netbox_call(maps, uri, fn_name, args, opts)
     -- Perform a call, gather results and spread it across tables.
-    local conn, err = connect(uri)
+    local conn, err = connect(uri, {wait_connected = false})
 
     if conn == nil then
         return _pack_values(maps, uri,

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -144,17 +144,8 @@ local function bootstrap_group(group_name, vsgroup)
 
     for _, replicaset in pairs(info.replicasets or {}) do
         local uri = replicaset.master.uri
-        local conn, _ = pool.connect(uri)
-
-        if conn == nil then
-            return nil, e_bootstrap_vshard:new(
-                '%q in %s not ready yet',
-                uri, router_name
-            )
-        end
-
         local ready = errors.netbox_eval(
-            conn,
+            pool.connect(uri, {wait_connected = false}),
             'return box.space._bucket ~= nil',
             {}, {timeout = 1}
         )

--- a/test/integration/pool_map_call_test.lua
+++ b/test/integration/pool_map_call_test.lua
@@ -92,7 +92,8 @@ function g.test_timeout()
 
     t.assert_equals(retmap, {})
     assert_err_equals(errmap, 'localhost:13301',
-        'NetboxCallError: "localhost:13301": Timeout exceeded'
+        'NetboxCallError: "localhost:13301":' ..
+        ' Connection is not established, state is "initial"'
     )
 end
 
@@ -187,10 +188,10 @@ function g.test_negative()
     assert_err_equals(errmap, '!@#$%^&*()',      'FormatURIError: Invalid URI "!@#$%^&*()"')
     assert_err_equals(errmap, 'localhost:13301', 'NetboxCallError: "localhost:13301": Too long WAL write')
     assert_err_equals(errmap, 'localhost:13302', 'NetboxCallError: "localhost:13302": Too long WAL write')
-    assert_err_equals(errmap, 'localhost:13309', 'NetboxConnectError: "localhost:13309": Invalid greeting')
+    assert_err_equals(errmap, 'localhost:13309', 'NetboxCallError: "localhost:13309": Invalid greeting')
     assert_err_equals(errmap, 'localhost:9',
-        'NetboxConnectError: "localhost:9": ' .. errno.strerror(errno.ECONNREFUSED),
-        'NetboxConnectError: "localhost:9": ' .. errno.strerror(errno.ENETUNREACH)
+        'NetboxCallError: "localhost:9": ' .. errno.strerror(errno.ECONNREFUSED),
+        'NetboxCallError: "localhost:9": ' .. errno.strerror(errno.ENETUNREACH)
     )
 end
 

--- a/test/integration/slow_requests_test.lua
+++ b/test/integration/slow_requests_test.lua
@@ -1,0 +1,138 @@
+local fio = require('fio')
+local fiber = require('fiber')
+local errno = require('errno')
+local netbox = require('net.box')
+
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.expected_request_time = 2
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = helpers.random_cookie(),
+        replicasets = {{
+            alias = 'main',
+            roles = {},
+            servers = 2
+        }}
+    })
+    g.cluster:start()
+    g.s1 = g.cluster:server('main-1')
+    g.s2 = g.cluster:server('main-2')
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+g.before_each(function()
+    g.s2.process:kill('STOP')
+    g.s1.net_box:eval([[
+        require('cartridge.pool').connect(...):close()
+    ]], {g.s2.advertise_uri, {wait_connected = false}})
+end)
+
+g.after_each(function()
+    g.s2.process:kill('CONT')
+end)
+
+local function graphql_bench(srv, args)
+    local t1 = fiber.clock()
+    srv:graphql(args)
+    local t2 = fiber.clock()
+
+    return t2 - t1
+end
+
+function g.test_boxinfo()
+    local t = graphql_bench(g.s1, {
+        query = '{servers {boxinfo {general {pid}}}}',
+    })
+    helpers.assert_le(t, 2)
+end
+
+function g.test_stat()
+    local t = graphql_bench(g.s1, {
+        query = [[query($uuid: String!) {
+            servers(uuid: $uuid) {statistics {arena_size}}
+        }]],
+        variables = {uuid = g.s2.instance_uuid},
+    })
+    helpers.assert_le(t, 2)
+end
+
+function g.test_issues()
+    local t = graphql_bench(g.s1, {
+        query = '{cluster {issues {message}}}',
+    })
+    helpers.assert_le(t, 2)
+end
+
+function g.test_suggestions()
+    local t = graphql_bench(g.s1, {
+        query = [[{
+            cluster {suggestions {
+                force_apply {uuid}
+                refine_uri {uuid}
+                disable_servers {uuid}
+            }}
+        }]],
+    })
+    helpers.assert_le(t, 2)
+end
+
+function g.test_netbox_timeouts()
+    local t0 = fiber.clock()
+
+    local conn = netbox.connect(g.s2.advertise_uri, {
+        wait_connected = false,
+        user = 'admin',
+        password = g.cookie,
+        connect_timeout = 1,
+    })
+    t.assert_covers(conn, {state = 'initial'})
+
+    -- Async request will fail.
+    -- Tarantool calls:
+    -- - remote_methods:_request
+    -- - transport.perform_async_request
+    t.assert_error_msg_contains(
+        'Connection is not established, state is "initial"',
+        conn.eval, conn, "return 'something'", nil, {is_async = true}
+    )
+    t.assert_covers(conn, {state = 'initial'})
+
+    -- Tarantool calls:
+    -- - remote_methods:_request
+    -- - wait_state('active', 1)
+    -- - transport.perform_request
+    -- - transport.perform_async_request
+    local t1 = fiber.clock()
+    t.assert_error_msg_contains(
+        'Connection is not established, state is "initial"',
+        conn.eval, conn, "return 'something'", nil, {timeout = 0.3}
+    )
+    local t2 = fiber.clock()
+    t.assert_covers(conn, {state = 'initial'})
+    t.assert_almost_equals(t2-t1, 0.3, 0.03)
+
+    -- check that connection have status error after connect_timeout
+    -- perform nb call -> remote_methods:_request ->
+    -- wait_state('active', TIMEOUT_INF) -> establish_connection will
+    -- fail after connect timeout
+    t.assert_error_msg_equals(
+        errno.strerror(errno.ETIMEDOUT),
+        conn.eval, conn, "return 'something'", nil
+    )
+    t.assert_covers(conn, {
+        state = 'error',
+        error = errno.strerror(errno.ETIMEDOUT),
+    })
+
+    t.assert_almost_equals(fiber.clock()-t0, 1, 0.1)
+end

--- a/webui/cypress/integration/disable-server.spec.js
+++ b/webui/cypress/integration/disable-server.spec.js
@@ -95,7 +95,7 @@ describe('Disable server', () => {
       .find('.meta-test__ReplicasetServerListItem__dropdownBtn').click();
     cy.get('.meta-test__ReplicasetServerListItem__dropdown *').contains('Enable server').click();
     cy.get('span:contains(Disabled state setting error) +' +
-      'span:contains(NetboxConnectError: "localhost:13302": Connection refused)').click();
+      'span:contains(NetboxCallError: "localhost:13302": Connection refused)').click();
     cy.get('.ServerLabelsHighlightingArea:contains(dummy-2)')
       .should('have.css', 'background-color', 'rgb(250, 250, 250)');
 
@@ -106,7 +106,7 @@ describe('Disable server', () => {
     cy.get('.meta-test__ServerDetailsModal .meta-test__ReplicasetServerListItem__dropdownBtn').click();
     cy.get('.meta-test__ReplicasetServerListItem__dropdown div').contains('Enable server').click();
     cy.get('span:contains(Disabled state setting error) +' +
-      'span:contains(NetboxConnectError: "localhost:13303": Connection refused)').click();
+      'span:contains(NetboxCallError: "localhost:13303": Connection refused)').click();
     cy.get('.meta-test__ServerDetailsModal span:contains(Disabled)').should('exist');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
 

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -150,7 +150,7 @@ describe('Server details', () => {
 
     cy.get('div').contains('Mordor').should('exist');
     cy.get('.meta-test__ZoneListItem').contains('Mordor').click();
-    cy.get('span:contains(NetboxConnectError: "localhost:13302": Connection refused)').click();
+    cy.get('span:contains(NetboxCallError: "localhost:13302": Connection refused)').click();
 
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Mordor)').click();
     cy.get('button:contains(Add new zone)').click();
@@ -183,7 +183,7 @@ describe('Server details', () => {
       .click();
     cy.get('.meta-test__ReplicasetServerListItem__dropdown div')
       .contains('Enable server').click();
-    cy.get('span:contains(NetboxConnectError: "localhost:13302": Connection refused)')
+    cy.get('span:contains(NetboxCallError: "localhost:13302": Connection refused)')
       .click();
     cy.get('.meta-test__ServerDetailsModal span:contains(Disabled)').should('exist');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();


### PR DESCRIPTION
The use of `pool.connect()` across the code is revised.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1274
