### PR TITLE
Make "isn't bootstrapped" error more clear

### DIFF
--- a/cartridge/auth.lua
+++ b/cartridge/auth.lua
@@ -116,7 +116,7 @@ local function set_params(opts)
 
     if confapplier.get_readonly() == nil then
         return nil, errors.new('AuthSetParamsError',
-            "Cluster isn't bootstrapped yet"
+            "Current instance isn't bootstrapped yet"
         )
     end
 

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -101,7 +101,9 @@ local function set_params(opts)
 
     local topology_cfg = confapplier.get_deepcopy('topology')
     if topology_cfg == nil then
-        return nil, FailoverSetParamsError:new("Cluster isn't bootstrapped yet")
+        return nil, FailoverSetParamsError:new(
+            "Current instance isn't bootstrapped yet"
+        )
     end
 
     if opts == nil then

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -346,7 +346,7 @@ local function _clusterwide(patch)
     local topology_new = clusterwide_config_new:get_readonly('topology')
     if topology_new == nil then
         return nil, PatchClusterwideError:new(
-            "Topology not specified, seems that cluster isn't bootstrapped"
+            "Current instance isn't bootstrapped yet"
         )
     end
 
@@ -631,7 +631,7 @@ end
 local function get_schema()
     if confapplier.get_readonly() == nil then
         return nil, GetSchemaError:new(
-            "Cluster isn't bootstrapped yet"
+            "Current instance isn't bootstrapped yet"
         )
     end
     local schema_yml = confapplier.get_readonly('schema.yml')

--- a/cartridge/webui/api-config.lua
+++ b/cartridge/webui/api-config.lua
@@ -78,7 +78,9 @@ local function download_config_handler(req)
 
     local clusterwide_config = confapplier.get_active_config()
     if clusterwide_config == nil then
-        local err = DownloadConfigError:new("Cluster isn't bootstrapped yet")
+        local err = DownloadConfigError:new(
+            "Current instance isn't bootstrapped yet"
+        )
         return http_finalize_error(409, err)
     end
 
@@ -139,7 +141,9 @@ local function upload_config_handler(req)
     end
 
     if confapplier.get_readonly() == nil then
-        local err = UploadConfigError:new("Cluster isn't bootstrapped yet")
+        local err = UploadConfigError:new(
+            "Current instance isn't bootstrapped yet"
+        )
         return http_finalize_error(409, err)
     end
 
@@ -192,7 +196,9 @@ local function get_sections(_, args)
     checks('?', {sections = '?table'})
     local clusterwide_config = confapplier.get_active_config()
     if clusterwide_config == nil then
-        local err = DownloadConfigError:new("Cluster isn't bootstrapped yet")
+        local err = DownloadConfigError:new(
+            "Current instance isn't bootstrapped yet"
+        )
         return nil, err
     end
 
@@ -213,7 +219,9 @@ end
 local function set_sections(_, args)
     checks('?', {sections = '?table'})
     if confapplier.get_readonly() == nil then
-        local err = UploadConfigError:new("Cluster isn't bootstrapped yet")
+        local err = UploadConfigError:new(
+            "Current instance isn't bootstrapped yet"
+        )
         return nil, err
     end
 
@@ -247,7 +255,9 @@ end
 local function force_reapply(_, args)
     checks('?', {uuids = '?table'})
     if confapplier.get_readonly() == nil then
-        local err = ForceReapplyError:new("Cluster isn't bootstrapped yet")
+        local err = ForceReapplyError:new(
+            "Current instance isn't bootstrapped yet"
+        )
         return nil, err
     end
 

--- a/cartridge/webui/api-ddl.lua
+++ b/cartridge/webui/api-ddl.lua
@@ -36,7 +36,7 @@ local gql_type_check_result = gql_types.object({
 local function graphql_get_schema()
     if confapplier.get_readonly() == nil then
         return nil, GetSchemaError:new(
-            "Cluster isn't bootstrapped yet"
+            "Current instance isn't bootstrapped yet"
         )
     end
     local schema_yml = confapplier.get_readonly(_section_name)
@@ -52,7 +52,7 @@ end
 local function graphql_set_schema(_, args)
     if confapplier.get_readonly() == nil then
         return nil, GetSchemaError:new(
-            "Cluster isn't bootstrapped yet"
+            "Current instance isn't bootstrapped yet"
         )
     end
     local patch = {[_section_name] = args.as_yaml}
@@ -68,7 +68,7 @@ local function graphql_check_schema(_, args)
     local topology_cfg = confapplier.get_readonly('topology')
     if topology_cfg == nil then
         return nil, CheckSchemaError:new(
-            "Cluster isn't bootstrapped yet"
+            "Current instance isn't bootstrapped yet"
         )
     end
 

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -130,7 +130,7 @@ function g.test_uninitialized()
     t.assert_equals(resp['data']['cluster']['failover'], false)
 
     t.assert_error_msg_contains(
-        "Cluster isn't bootstrapped yet",
+        "Current instance isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[
@@ -143,7 +143,7 @@ function g.test_uninitialized()
     )
 
     t.assert_error_msg_contains(
-        "Cluster isn't bootstrapped yet",
+        "Current instance isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[
@@ -153,7 +153,7 @@ function g.test_uninitialized()
         end
     )
     t.assert_error_msg_contains(
-        "Cluster isn't bootstrapped yet",
+        "Current instance isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[
@@ -165,7 +165,7 @@ function g.test_uninitialized()
 
 
     t.assert_error_msg_contains(
-        "Cluster isn't bootstrapped yet",
+        "Current instance isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[
@@ -175,7 +175,7 @@ function g.test_uninitialized()
         end
     )
     t.assert_error_msg_contains(
-        "Cluster isn't bootstrapped yet",
+        "Current instance isn't bootstrapped yet",
         function()
             return g.server:graphql({
                 query = [[

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -478,8 +478,7 @@ function g.test_uninitialized()
     check_200(g.server, {headers = {cookie = 'lsid=' .. lsid}})
 
     t.assert_error_msg_contains(
-        "PatchClusterwideError: Topology not specified, " ..
-        "seems that cluster isn't bootstrapped",
+        "PatchClusterwideError: Current instance isn't bootstrapped yet",
         _add_user, g.server, 'new_admin', 'password'
     )
 

--- a/webui/cypress/integration/uninitialized.spec.js
+++ b/webui/cypress/integration/uninitialized.spec.js
@@ -36,7 +36,7 @@ describe('Uninitialized', () => {
     cy.get('button[type="button"]:contains("Reload")').click();
     cy.get('body').contains('Are you sure you want to reload all the files?');
     cy.get('button[type="button"]:contains("Ok")').click();
-    cy.get('span:contains("Cluster isn\'t bootstrapped yet")').click();
+    cy.get('span:contains("Current instance isn\'t bootstrapped yet")').click();
 
     // create file
     cy.get('.meta-test__addFileBtn').click();
@@ -45,7 +45,7 @@ describe('Uninitialized', () => {
 
     // file upload should fail too
     cy.get('button[type="button"]:contains("Apply")').click();
-    cy.get('span:contains("Cluster isn\'t bootstrapped yet")').click();
+    cy.get('span:contains("Current instance isn\'t bootstrapped yet")').click();
 
     ////////////////////////////////////////////////////////////////////
     cy.log('Schema without bootstrap');
@@ -53,13 +53,13 @@ describe('Uninitialized', () => {
     cy.get('a[href="/admin/cluster/schema"]').click();
 
     cy.get('button[type="button"]:contains("Validate")').click();
-    cy.get('#root').contains('Cluster isn\'t bootstrapped yet');
+    cy.get('#root').contains('Current instance isn\'t bootstrapped yet');
 
     cy.get('button[type="button"]:contains("Reload")').click();
     cy.get('.monaco-editor textarea').should('have.value', '');
 
     cy.get('button[type="button"]:contains("Apply")').click();
-    cy.get('#root').contains('Cluster isn\'t bootstrapped yet');
+    cy.get('#root').contains('Current instance isn\'t bootstrapped yet');
 
     ////////////////////////////////////////////////////////////////////
     cy.log('Try to add user without bootstrap');
@@ -73,7 +73,7 @@ describe('Uninitialized', () => {
       .type('111');
     cy.get('.meta-test__UserAddForm button[type="submit"]').contains('Add').click();
     cy.get('.meta-test__UserAddForm')
-      .contains('Topology not specified, seems that cluster isn\'t bootstrapped');
+      .contains('Current instance isn\'t bootstrapped yet');
     cy.get('.meta-test__UserAddForm button[type="button"]').contains('Cancel').click();
     cy.contains('unitialisedUser').should('not.exist');
   });


### PR DESCRIPTION
"Cluster isn't bootstrapped yet" -> "Current instance isn't bootstrapped yet". Because sometimes users open WebUI of an unconfigured instance and this message confuses them.

Pre-requisite for #1278 

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)
