### PR TITLE
Hide bootstrap button on unconfigured instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,7 +62,8 @@ Enhanced is WebUI
 
 - Show a suggestion to force reapply clusterwide configuration.
 
-- Hide bootstrap button in vshardless cluster.
+- Hide bootstrap button when it's not necessary
+  (e.g. before the cluster is bootstrapped, and in vshardless cluster too).
 
 -------------------------------------------------------------------------------
 [2.4.0] - 2020-12-29

--- a/webui/cypress/integration/bootstrap.spec.js
+++ b/webui/cypress/integration/bootstrap.spec.js
@@ -74,13 +74,7 @@ describe('Replicaset configuration & Bootstrap Vshard', () => {
     ////////////////////////////////////////////////////////////////////
     cy.log('Bootstrap vshard on unconfigured cluster');
     ////////////////////////////////////////////////////////////////////
-    cy.get('.meta-test__BootstrapButton').click();
-    cy.get('.meta-test__BootstrapPanel__vshard-router_disabled').should('exist');
-    cy.get('.meta-test__BootstrapPanel__vshard-storage_disabled').should('exist');
-    cy.get('.meta-test__BootstrapPanel').contains('One role from vshard-router or myrole enabled');
-    cy.get('.meta-test__BootstrapPanel').contains('One role from vshard-storage or myrole enabled');
-    cy.get('.meta-test__BootstrapPanel use:first').click();
-    cy.get('.meta-test__BootstrapPanel').should('not.exist');
+    cy.get('.meta-test__BootstrapButton').should('not.exist');
 
     ////////////////////////////////////////////////////////////////////
     cy.log('Select all roles');

--- a/webui/src/components/ClusterButtonsPanel.js
+++ b/webui/src/components/ClusterButtonsPanel.js
@@ -54,7 +54,8 @@ const mapStateToProps = (state: State) => {
 
   return {
     showFailover: !!(clusterSelf && clusterSelf.configured),
-    showBootstrap: isVshardAvailable(state) && !isBootstrapped(state),
+    showBootstrap: !!(clusterSelf && clusterSelf.configured)
+      && isVshardAvailable(state) && !isBootstrapped(state),
     showToggleAuth: !implements_add_user && !implements_list_users && implements_check_password
   }
 };


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2205188/109996120-f9014400-7d1f-11eb-9dbf-1f766f6e2c8b.png)

After:

![image](https://user-images.githubusercontent.com/2205188/109995075-ff42f080-7d1e-11eb-8997-8133987b443a.png)


I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

