### PR TITLE
Update errors module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,11 @@ and this project adheres to
 Added
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Issues and suggestions:
-
 - Extend GraphQL ``issues`` API with ``aliens`` topic. The issues warns if
   two separate clusters share the same cluster cookie.
+
+- Enhance error messages when they're transferred over network. Supply it
+  with the connection URI.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ add_custom_command(
   VERBATIM
 )
 
-if(LDOC_FOUND AND SPHINX_FOUND)
+if(Ldoc_FOUND AND Sphinx_FOUND)
   add_custom_target(doc ALL
     DEPENDS "${DOC_OUTPUT}/index.html")
 else()

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -9,7 +9,7 @@ dependencies = {
     'ddl == 1.3.0-1',
     'http == 1.1.0-1',
     'checks == 3.1.0-1',
-    'errors == 2.1.4-1',
+    'errors == 2.1.5-1',
     'vshard == 0.1.16-1',
     'membership == 2.3.1-1',
     'frontend-core == 7.5.0-1',

--- a/cmake/FindLdoc.cmake
+++ b/cmake/FindLdoc.cmake
@@ -5,7 +5,7 @@ find_program(LDOC ldoc
 )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LDOC
+find_package_handle_standard_args(Ldoc
     REQUIRED_VARS LDOC
 )
 

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -5,7 +5,7 @@ find_program(SPHINX sphinx-build
 )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SPHINX
+find_package_handle_standard_args(Sphinx
     REQUIRED_VARS SPHINX
 )
 

--- a/test/integration/api_join_test.lua
+++ b/test/integration/api_join_test.lua
@@ -133,7 +133,7 @@ function g.test_join_server()
     )
 
     t.assert_error_msg_equals(
-        [[Missing localhost:13302 in clusterwide config,]] ..
+        [["127.0.0.1:13302": Missing localhost:13302 in clusterwide config,]] ..
         [[ check advertise_uri correctness]],
         function()
             return main:graphql({

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -520,7 +520,7 @@ function g.test_operation_error()
     })
 
     local err = resp.errors[1]
-    t.assert_covers(err, {message = 'Artificial Error'})
+    t.assert_covers(err, {message = '"localhost:13304": Artificial Error'})
     t.assert_covers(err.extensions, {
         ['io.tarantool.errors.class_name'] = 'ApplyConfigError',
     })

--- a/test/integration/api_uninitialized_test.lua
+++ b/test/integration/api_uninitialized_test.lua
@@ -108,7 +108,7 @@ function g.test_uninitialized()
 
     -- edit_topology message slightly differs from join_server
     t.assert_error_msg_equals(
-        [[Missing localhost:13301 in clusterwide config,]] ..
+        [["127.0.0.1:13301": Missing localhost:13301 in clusterwide config,]] ..
         [[ check advertise_uri correctness]],
         function()
             return g.server:graphql({query = [[

--- a/test/integration/ddl_test.lua
+++ b/test/integration/ddl_test.lua
@@ -132,7 +132,7 @@ function g.test_luaapi()
 
     t.assert_equals(
         {call('cartridge_set_schema', {'{}'})},
-        {box.NULL, 'spaces: must be a table, got nil'}
+        {box.NULL, '"localhost:13302": spaces: must be a table, got nil'}
     )
 
     t.assert_equals(

--- a/test/integration/failover_stateful_test.lua
+++ b/test/integration/failover_stateful_test.lua
@@ -422,14 +422,14 @@ add('test_leader_promote', function(g)
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'AppointmentError',
-        err = [[Server "invalid_uuid" doesn't exist]],
+        err = [["localhost:13301": Server "invalid_uuid" doesn't exist]],
     })
 
     local ok, err = S1.net_box:eval(q_promote, {{['invalid_uuid'] = storage_1_uuid}})
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'AppointmentError',
-        err = [[Replicaset "invalid_uuid" doesn't exist]],
+        err = [["localhost:13301": Replicaset "invalid_uuid" doesn't exist]],
     })
 
     local ok, err = S1.net_box:eval(q_promote, {{[router_uuid] = storage_1_uuid}})
@@ -437,7 +437,7 @@ add('test_leader_promote', function(g)
     t.assert_covers(err, {
         class_name = 'AppointmentError',
         err = string.format(
-            [[Server %q doesn't belong to replicaset %q]],
+            [["localhost:13301": Server %q doesn't belong to replicaset %q]],
             storage_1_uuid, router_uuid
         ),
     })

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -62,7 +62,7 @@ function g.test_twophase_config_locked()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'Prepare2pcError',
-        err = 'Two-phase commit is locked',
+        err = '"localhost:13302": Two-phase commit is locked',
     })
 
     -- But force reapply comes to the rescue!
@@ -154,7 +154,7 @@ function g.test_suggestions()
         end
     ]])
     t.assert_error_msg_equals(
-        'Artificial Error',
+        '"localhost:13303": Artificial Error',
         force_reapply, {g.A3.instance_uuid}
     )
 

--- a/test/integration/pool_map_call_test.lua
+++ b/test/integration/pool_map_call_test.lua
@@ -92,7 +92,7 @@ function g.test_timeout()
 
     t.assert_equals(retmap, {})
     assert_err_equals(errmap, 'localhost:13301',
-        'NetboxCallError: Timeout exceeded'
+        'NetboxCallError: "localhost:13301": Timeout exceeded'
     )
 end
 
@@ -185,8 +185,8 @@ function g.test_negative()
 
     t.assert_equals(retmap, {})
     assert_err_equals(errmap, '!@#$%^&*()',      'FormatURIError: Invalid URI "!@#$%^&*()"')
-    assert_err_equals(errmap, 'localhost:13301', 'NetboxCallError: Too long WAL write')
-    assert_err_equals(errmap, 'localhost:13302', 'NetboxCallError: Too long WAL write')
+    assert_err_equals(errmap, 'localhost:13301', 'NetboxCallError: "localhost:13301": Too long WAL write')
+    assert_err_equals(errmap, 'localhost:13302', 'NetboxCallError: "localhost:13302": Too long WAL write')
     assert_err_equals(errmap, 'localhost:13309', 'NetboxConnectError: "localhost:13309": Invalid greeting')
     assert_err_equals(errmap, 'localhost:9',
         'NetboxConnectError: "localhost:9": ' .. errno.strerror(errno.ECONNREFUSED),
@@ -221,7 +221,7 @@ function g.test_errors_united()
         err.err:split('\n'),
         {
             'Invalid URI ")(*&^%$#@!"',
-            'Segmentation fault',
+            '"localhost:13302": Segmentation fault',
             '"localhost:13309": Invalid greeting',
         }
     )

--- a/test/integration/proxy_test.lua
+++ b/test/integration/proxy_test.lua
@@ -139,7 +139,7 @@ function g.test_dead_destination()
                 uri = g.unconfigured.advertise_uri,
             }}
         }}).errors[1],
-        {message = 'Connection refused'}
+        {message = '"localhost:13301": Connection refused'}
     )
 end
 

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -63,11 +63,14 @@ function g.test_api()
     t.assert_not(err)
     t.assert_equals(res, 'initialized')
 
-    local res, err = rpc_call(server, 'myrole', 'fn_undefined')
+    local res, err = rpc_call(server, 'myrole',
+        'fn_undefined', nil,
+        {uri = "127.0.0.1:13303"}
+    )
     t.assert_not(res)
     t.assert_covers(err, {
         class_name = 'RemoteCallError',
-        err =  'Role "myrole" has no method "fn_undefined"'
+        err =  '"127.0.0.1:13303": Role "myrole" has no method "fn_undefined"'
     })
 
     local res, err = rpc_call(server, 'unknown-role', 'fn_undefined')
@@ -85,7 +88,7 @@ function g.test_errors()
     t.assert_not(res)
     t.assert_covers(err, {
         class_name = 'RemoteCallError',
-        err = 'Boo',
+        err = '"localhost:13302": Boo',
     })
     t.assert_str_contains(err.stack, 'during net.box call to localhost:13302')
 

--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -261,7 +261,7 @@ function g.test_leader_death()
 
     -- Trigger patch_clusterwide
     t.assert_error_msg_equals(
-        "Apply fails sometimes, who'd have thought?",
+        [["localhost:13301": Apply fails sometimes, who'd have thought?]],
         function()
             return g.master:graphql({query = [[
                 mutation{ cluster{
@@ -679,7 +679,7 @@ function g.test_operation_error()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'ApplyConfigError',
-        err = 'Artificial Error',
+        err = '"localhost:13302": Artificial Error',
     })
 
     local ok, err = g.master.net_box:eval(set_roles, {uA, {}})

--- a/test/integration/stateboard_test.lua
+++ b/test/integration/stateboard_test.lua
@@ -135,8 +135,8 @@ function g.test_appointments()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'NetboxCallError',
-        err = "Duplicate key exists in unique index 'ordinal'" ..
-        " in space 'leader_audit'"
+        err = '"localhost:13301": Duplicate key exists' ..
+        " in unique index 'ordinal' in space 'leader_audit'"
     })
 end
 
@@ -264,7 +264,7 @@ function g.test_client_session()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'NetboxCallError',
-        err = 'Peer closed',
+        err = '"localhost:13301": Peer closed',
     })
     t.assert_is_not(client:get_session(), session)
 
@@ -291,7 +291,7 @@ function g.test_client_drop_session()
     t.assert_equals(ok, nil)
     t.assert_covers(err, {
         class_name = 'NetboxCallError',
-        err = 'Connection closed',
+        err = '"localhost:13301": Connection closed',
     })
 
     -- dropping session releases lock and make it dead

--- a/test/integration/switchover_test.lua
+++ b/test/integration/switchover_test.lua
@@ -531,7 +531,7 @@ add('test_enabling', function(g)
                 g.name == 'integration.switchover.etcd2' and
                 g.state_provider.client_url .. "/v2/members:" ..
                 " Couldn't connect to server" or
-                "Connection refused"),
+                '"127.0.0.1:14401": Connection refused'),
         }, {
             level = "warning",
             topic = "switchover",
@@ -675,7 +675,7 @@ add('test_api', function(g)
 
     -- Consistent promotion fails because the keeper is still "nobody"
     t.assert_error_msg_equals(
-        'timed out',
+        '"localhost:13303": timed out',
         A1.graphql, A1, {
             query = query,
             variables = {

--- a/test/integration/upload_test.lua
+++ b/test/integration/upload_test.lua
@@ -63,7 +63,7 @@ function g.test_begining_failure()
     t.assert_equals(res, nil)
     t.assert_covers(err, {
         class_name = 'NetboxCallError',
-        err = 'Timeout exceeded',
+        err = '"localhost:13302": Timeout exceeded',
     })
 
     -- prefix should be cleaned up even if upload_begin fails
@@ -102,7 +102,7 @@ function g.test_transmission_failure()
     t.assert_equals(res, nil)
     t.assert_covers(err, {
         class_name = 'NetboxCallError',
-        err = 'Artificial transmission failure',
+        err = '"localhost:13303": Artificial transmission failure',
     })
 
     -- prefix should be cleaned up even if upload_transmit fails
@@ -145,7 +145,7 @@ function g.test_finish_failure()
     t.assert_equals(res, nil)
     t.assert_covers(err, {
         class_name = 'Prepare2pcError',
-        err = 'Upload not found, see earlier logs for the details',
+        err = '"localhost:13301": Upload not found, see earlier logs for the details',
     })
 
     -- prefix should be cleaned up even if upload_transmit fails

--- a/webui/cypress/integration/switchover.spec.js
+++ b/webui/cypress/integration/switchover.spec.js
@@ -219,7 +219,8 @@ describe('Leader promotion tests', () => {
     cy.get('span:contains(Edit is OK. Please wait for list refresh...)').click();
 
     dropdownMenu('13302').contains('Promote a leader').click();
-    cy.get('span:contains(Leader promotion error) + span:contains(WaitRwError: timed out)').click();
+    cy.get('span:contains(Leader promotion error)' +
+      ' + span:contains(WaitRwError: "localhost:13302": timed out)').click();
 
     leaderFlag('13302').invoke('css', 'fill', orangeIcon);
     leaderFlag('13303').should('not.exist');


### PR DESCRIPTION
This patch makes netbox errors more verbose. All errors transferred over the network are now prefixed with a URI of the producer.

Before the patch:

```text
Prepare2pcError: Two-phase commit is locked
```

Now:

```text
Prepare2pcError: "localhost:3303": Two-phase commit is locked
```

Also in this patch:

- Eliminate cmake warnings similar to https://github.com/tarantool/errors/pull/29

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

