### PR TITLE
Two-phase commit version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ Added
 - Enhance error messages when they're transferred over network. Supply it
   with the connection URI.
 
+- ``twophase.VERSION`` for the rolling update scenario to meet requirements
+  of backward compatibility.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -733,4 +733,10 @@ return {
     set_schema = set_schema,
     patch_clusterwide = patch_clusterwide,
     force_reapply = force_reapply,
+    -- Cartridge supports backward compatibility but not the forward
+    -- one. Thus operations that modify clusterwide config should be
+    -- performed by instances with the lowest twophase version. This
+    -- principal is used in the rolling update scenario via
+    -- ansible-cartridge.
+    VERSION = 2,
 }


### PR DESCRIPTION
For ansible to detect the proper host for ``edit_topology`` request two-phase commit version should be known.

I didn't forget about

- [x] Tests (unnecessary)
- [x] Changelog
- [x] Documentation

Close #1323 
