### PR TITLE
Use get_state instead of wish_state in prepare_2pc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,9 +36,8 @@ Fixed
 - Avoid WebUI and ``pool.map_call`` requests hanging because of network
   connection problems.
 
-- ``prepare_2pc`` calls ``get_state`` instead of ``wish_state``. When instance
-  hangs in ``ConfiguringRoles`` state it results in a proper error message
-  instead of unclear "timed out" error.
+- Fix unclear "Timeout exceeded" error. It affects v2.5.0 two-phase commit
+  when an instance is stuck in ``ConfiguringRoles`` state.
 
 -------------------------------------------------------------------------------
 [2.5.0] - 2021-03-05

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,10 @@ Fixed
 - Avoid WebUI and ``pool.map_call`` requests hanging because of network
   connection problems.
 
+- ``prepare_2pc`` calls ``get_state`` instead of ``wish_state``. When instance
+  hangs in ``ConfiguringRoles`` state it results in a proper error message
+  instead of unclear "timed out" error.
+
 -------------------------------------------------------------------------------
 [2.5.0] - 2021-03-05
 -------------------------------------------------------------------------------

--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -87,7 +87,7 @@ local function prepare_2pc(upload_id)
         return nil, err
     end
 
-    local state = confapplier.wish_state('RolesConfigured')
+    local state = confapplier.get_state()
     if state ~= 'Unconfigured'
     and state ~= 'RolesConfigured'
     and state ~= 'OperationError'


### PR DESCRIPTION
``prepare_2pc`` calls ``get_state`` instead of ``wish_state``. When instance
  hangs in ``ConfiguringRoles`` state it results in a proper error message
  instead of unclear "timed out" error.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1326 
