### PR TITLE
Fix hotreload.myrole_test for macOS

### DIFF
--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -23,8 +23,9 @@ local function reload_myrole(fn)
 end
 
 g.before_all(function()
+    local tempdir = fio.tempdir()
     g.cluster = helpers.Cluster:new({
-        datadir = fio.tempdir(),
+        datadir = tempdir,
         use_vshard = false,
         server_command = helpers.entrypoint('srv_basic'),
         cookie = helpers.random_cookie(),
@@ -35,7 +36,7 @@ g.before_all(function()
         }},
     })
     g.srv = g.cluster:server('A-1')
-    g.srv.env['TARANTOOL_CONSOLE_SOCK'] = g.srv.workdir .. '/console.sock'
+    g.srv.env['TARANTOOL_CONSOLE_SOCK'] = fio.pathjoin(tempdir, 'console.sock')
     g.cluster:start()
 
     local ok, err = g.srv.net_box:eval([[


### PR DESCRIPTION
* On macOS creating console socket at server.workdir raises an error
  like:
    `/var/folders/../localhost-13301/console.sock: Too long
    console_sock exceeds UNIX_PATH_MAX limit).`
  To fix this behaviour create socket file at tempdir instead of
  server.workdir

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

