### PR TITLE
fix funcall compatibility

### DIFF
--- a/cartridge/graphql/funcall.lua
+++ b/cartridge/graphql/funcall.lua
@@ -4,4 +4,4 @@ errors.deprecate(
     " Use `require('cartridge.funcall')` instead."
 )
 
-require('cartridge.funcall')
+return require('cartridge.funcall')


### PR DESCRIPTION
Previously (cd7521d32b84187ccb9e6b7da7292a928d66ac72) we moved
funcall into different directory but to preserve backward
compatibility we preserved old API. Unfortunately there was a typo
- one return was missed, this patch fixes it.

