### PR TITLE
Preserve fiber.storage during pool.map_call

### DIFF
--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -138,7 +138,12 @@ local function _pack_values(maps, uri, ...)
     end
 end
 
-local function _gather_netbox_call(maps, uri, fn_name, args, opts)
+local function _gather_netbox_call(fiber_storage, maps, uri, fn_name, args, opts)
+    local self_storage = fiber.self().storage
+    for k, v in pairs(fiber_storage) do
+        self_storage[k] = v
+    end
+
     -- Perform a call, gather results and spread it across tables.
     local conn, err = connect(uri, {wait_connected = false})
 
@@ -203,7 +208,7 @@ local function map_call(fn_name, args, opts)
     for _, uri in pairs(opts.uri_list) do
         local fiber = fiber.new(
             _gather_netbox_call,
-            maps, uri, fn_name, args,
+            fiber.self().storage, maps, uri, fn_name, args,
             {timeout = opts.timeout}
         )
         fiber:name('netbox_map_call')


### PR DESCRIPTION
With this patch `pool.map_call` will carefully handle `fiber.storage`. It's needed for TDG request context passing. Earlier it wasn't preserved because `pool.map_call` makes requests in separate fibers.

Initially, we were going to get rid of fibers at all. But we can't, because `netbox.connect({wait_connected = false})` doesn't work with `conn:call({is_async = true})` and throws the error: "Connection is not established, state is initial". So we still need fibers to wait until the connection is established.

Of course, we don't need `wait_connected` if it's already connected, but this optimization should be done in a separate PR.

I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Close #1293 
