### PR TITLE
Accept remote-control connections in InitError state

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,7 +28,7 @@ jobs:
         id: cache-misc-venv
         with:
           path: ./venv
-          key: cache-misc-venv-${{ matrix.runs-on }}-02
+          key: cache-misc-venv-${{ matrix.runs-on }}-01
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,12 +13,18 @@ and this project adheres to
 -------------------------------------------------------------------------------
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Make remote-control accept connections even in the ``InitError`` state.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced in WebUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Highlights if file name exists in file create/rename mode on Code page.
+- Highlight if file name exists in file create/rename mode on Code page.
 
-- Removed tooltip for replicaset alias on Cluster page.
+- Remove the replicaset alias tooltip on the Cluster page.
 
 -------------------------------------------------------------------------------
 [2.5.1] - 2021-03-24

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ and this project adheres to
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Make remote-control accept connections even in the ``InitError`` state.
+- Fix unclear timeout errors in case of ``InitError`` and ``BootError`` states
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced in WebUI

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -616,6 +616,12 @@ local function init(opts)
         set_state('ConfigFound')
         local clusterwide_config, err = ClusterwideConfig.load(config_filename)
         if clusterwide_config == nil then
+            -- box.cfg{listen = ...} will not be called
+            -- and remote-control should remain accepting connections
+            remote_control.accept({
+                username = cluster_cookie.username(),
+                password = cluster_cookie.cookie(),
+            })
             set_state('InitError', err)
             return true
         end
@@ -625,6 +631,12 @@ local function init(opts)
         vars.clusterwide_config = clusterwide_config:lock()
         local ok, err = validate_config(clusterwide_config)
         if not ok then
+            -- box.cfg{listen = ...} will not be called
+            -- and remote-control should remain accepting connections
+            remote_control.accept({
+                username = cluster_cookie.username(),
+                password = cluster_cookie.cookie(),
+            })
             set_state('InitError', err)
             return true
         end

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -381,6 +381,12 @@ local function boot_instance(clusterwide_config)
                 " Bootstrap impossible, check advertise_uri correctness",
                 vars.advertise_uri
             )
+            -- box.cfg{listen = ...} will not be called
+            -- and remote-control should remain accepting connections
+            remote_control.accept({
+                username = cluster_cookie.username(),
+                password = cluster_cookie.cookie(),
+            })
             set_state('BootError', err)
             return nil, err
         end


### PR DESCRIPTION
Remote control is accepting connections even if instance enters ``InitError`` state.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1286 
