### PR TITLE
Fix stateboard longpolling inconsistency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Fixed
 
 - Fix unclear timeout errors in case of ``InitError`` and ``BootError`` states.
 
+- Fix inconsistency which could occur while longpolling stateboard in unstable
+  networks.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Enhanced in WebUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/stateboard-client.lua
+++ b/cartridge/stateboard-client.lua
@@ -213,6 +213,7 @@ local function get_session(client)
         lock_acquired = false,
         call_timeout = client.cfg.call_timeout,
         connection = connection,
+        longpoll_ordinal = -1,
     }
     client.session = setmetatable(session, session_mt)
     return client.session
@@ -236,11 +237,13 @@ local function longpoll(client, timeout)
         local timeout = deadline - fiber.clock()
 
         local ret, err = errors.netbox_call(session.connection,
-            'longpoll', {timeout},
+            'longpoll', {timeout, session.longpoll_ordinal},
             {timeout = timeout + client.cfg.call_timeout}
         )
 
         if ret ~= nil then
+            session.longpoll_ordinal = ret.ordinal
+            ret.ordinal = nil
             return ret
         end
 


### PR DESCRIPTION
The stateboard long-polling algorithm has the bug. It persists `longpoll_index` in the `box.session.storage` upon the response, but it doesn't mean the client is able to receive the result. In case of networking problems, the `longpoll` may result in a temporary error

```
main/131/cartridge.stateful-failover failover.lua:554 W> "localhost:4401": Timeout exceeded
```

but the connection remains alive. The next `longpoll` request proceeds with the `longpoll_index` already incremented in the `box.session.storage` and the client never receives the promotion.

With this patch, the `longpoll_index` is passed by the client explicitly.

Both forward and backward compatibility is preserved. It was tested manually in two ways:

- new stateboard + old cartridge instances;
- old stateboard + new cartridge instances;

In both cases all related tests remain green:

- `integration.switchover.stateboard`
- `integration.failover_stateful.stateboard`
- `integration.fencing.stateboard`

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1375 
