### PR TITLE
Update membership to 2.3.2

### DIFF
--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'checks == 3.1.0-1',
     'errors == 2.1.5-1',
     'vshard == 0.1.17-1',
-    'membership == 2.3.1-1',
+    'membership == 2.3.2-1',
     'frontend-core == 7.7.0-1',
     'graphql == 0.1.1-1',
 }


### PR DESCRIPTION
- Enhance logging of `getaddrinfo` errors when DNS malfunctions.

I didn't forget about

- [x] Tests (preserved green)
- [x] Changelog (not interesting)
- [x] Documentation (unnecessary)

