### PR TITLE
Enchance failover logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Leaders replaced during stateful failover can be expelled now.
+- Make failover logging more verbose.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26


### PR DESCRIPTION
New logs added.

In `failover-coordinator`:

```
main/4097/main I> Replicaset f819966c-6e69-4436-8c02-375b29978561: appoint af6ecb27-84cc-444c-871e-0822fe0d70ec ("localhost:3302") (manual)
```

When an instance fetches new appointments:

```
main/132/cartridge.stateful-failover I> Replicaset f819966c-6e69-4436-8c02-375b29978561 (me):
    new leader af6ecb27-84cc-444c-871e-0822fe0d70ec (me),
    was 7ee5e32c-2884-405c-a004-998734fe7eee ("localhost:3303")
main/132/cartridge.stateful-failover I> Failover triggered, reapply scheduled (fiber 192) 
```

If consequent `consititute_oneself` fails:

```
main/192/cartridge.failover.task I> Consistency isn't reached yet: "localhost:3303": Connection timed out
```

I didn't forget about

- [x] Tests (nope)
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1400
