### PR TITLE
Disable multi-return at cartridge.pool module

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,7 +28,7 @@ jobs:
         id: cache-misc-venv
         with:
           path: ./venv
-          key: cache-misc-venv-${{ matrix.runs-on }}-01
+          key: cache-misc-venv-${{ matrix.runs-on }}-02
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -130,8 +130,8 @@ local function connect(uri, opts)
 end
 
 local function _pack_values(maps, uri, res, err)
+    -- Spread call results across result map
     if res ~= nil then
-        maps[1] = maps[1] or {}
         maps[1][uri] = res
     elseif err ~= nil then
         maps[2] = maps[2] or {}
@@ -204,7 +204,7 @@ local function map_call(fn_name, args, opts)
         uri_map[uri] = true
     end
 
-    local maps = {}
+    local maps = {{}, nil}
     local fibers = {}
     for _, uri in pairs(opts.uri_list) do
         local fiber = fiber.new(

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -129,12 +129,13 @@ local function connect(uri, opts)
     return conn
 end
 
-local function _pack_values(maps, uri, ...)
-    -- Spread call results across tables
-    for i = 1, select('#', ...) do
-        local v = select(i, ...)
-        maps[i] = maps[i] or {}
-        maps[i][uri] = v
+local function _pack_values(maps, uri, res, err)
+    if res ~= nil then
+        maps[1] = maps[1] or {}
+        maps[1][uri] = res
+    elseif err ~= nil then
+        maps[2] = maps[2] or {}
+        maps[2][uri] = err
     end
 end
 

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -129,17 +129,7 @@ local function connect(uri, opts)
     return conn
 end
 
-local function _pack_values(maps, uri, res, err)
-    -- Spread call results across result map
-    if res ~= nil then
-        maps[1][uri] = res
-    elseif err ~= nil then
-        maps[2] = maps[2] or {}
-        maps[2][uri] = err
-    end
-end
-
-local function _gather_netbox_call(fiber_storage, maps, uri, fn_name, args, opts)
+local function _gather_netbox_call(fiber_storage, retmap, errmap, uri, fn_name, args, opts)
     local self_storage = fiber.self().storage
     for k, v in pairs(fiber_storage) do
         self_storage[k] = v
@@ -149,13 +139,11 @@ local function _gather_netbox_call(fiber_storage, maps, uri, fn_name, args, opts
     local conn, err = connect(uri, {wait_connected = false})
 
     if conn == nil then
-        return _pack_values(maps, uri,
-            nil, err
-        )
+        errmap[uri] = err
     else
-        return _pack_values(maps, uri,
-            errors.netbox_call(conn, fn_name, args, opts)
-        )
+        local ret, err = errors.netbox_call(conn, fn_name, args, opts)
+        retmap[uri] = ret
+        errmap[uri] = err
     end
 end
 
@@ -204,12 +192,12 @@ local function map_call(fn_name, args, opts)
         uri_map[uri] = true
     end
 
-    local maps = {{}, nil}
+    local retmap, errmap = {}, {}
     local fibers = {}
     for _, uri in pairs(opts.uri_list) do
         local fiber = fiber.new(
             _gather_netbox_call,
-            fiber.self().storage, maps, uri, fn_name, args,
+            fiber.self().storage, retmap, errmap, uri, fn_name, args,
             {timeout = opts.timeout}
         )
         fiber:name('netbox_map_call')
@@ -220,14 +208,11 @@ local function map_call(fn_name, args, opts)
     for _, uri in pairs(opts.uri_list) do
         local ok, err = fibers[uri]:join()
         if not ok then
-            _pack_values(maps, uri,
-                nil, NetboxMapCallError:new(err)
-            )
+            errmap[uri] = NetboxMapCallError:new(err)
         end
     end
 
-    local retmap, errmap = unpack(maps)
-    if errmap == nil then
+    if next(errmap) == nil then
         return retmap
     end
 


### PR DESCRIPTION
Remove multireturn handling from `pool.map_call` internals. Anyway, it's not used in results.

- [x] Tests (preserved green)
- [x] Changelog (no observable changes)
- [x] Documentation (unnecessary)

Pre-requisite for #1368 