### PR TITLE
Properly handle re-running Github Actions

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -8,6 +8,14 @@ env:
   CMAKE_DUMMY_WEBUI: false
 
 jobs:
+  set-build-id:
+    runs-on: ubuntu-18.04
+    steps:
+      - id: set-build-id
+        run: echo "::set-output name=build-id::$(date +%s)"
+    outputs:
+      build-id: ${{ steps.set-build-id.outputs.build-id }}
+
   webui-test:
     strategy:
       fail-fast: false
@@ -17,6 +25,7 @@ jobs:
           - cypress-1
           - cypress-2
     runs-on: ubuntu-18.04
+    needs: set-build-id
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -88,6 +97,7 @@ jobs:
           --parallel
           --record
           --key ${{ secrets.CYPRESS_RECORD_KEY }}
+          --ci-build-id ${{ needs.set-build-id.outputs.build-id }}
 
       ##################################################################
       # Cleanup cached paths


### PR DESCRIPTION
Our cypress tests are parallelized. Cypress guesses the `--ci-build-id` implicitly from the environment.

Github provides `$GITHUB_RUN_ID` env variable, but re-running a job doesn't change its value. Cypress dashboard thinks it's another parallel runner in the same pool. Since all the specs were already tested, the re-run does nothing and skips them all.

As a result, re-running frontend tests always make it green.

This patch makes `--ci-build-id` generation explicit.

Here are two runs in the dashboard for the same commit (and same `$GITHUB_RUN_ID`):

* https://dashboard.cypress.io/projects/icijqq/runs/731/overview
* https://dashboard.cypress.io/projects/icijqq/runs/734/overview

![image](https://user-images.githubusercontent.com/2205188/117836679-76e24e00-b281-11eb-8c48-d8a2126d6dd4.png)
![image](https://user-images.githubusercontent.com/2205188/117836849-9da08480-b281-11eb-87f7-6d6dcd081c5c.png)


I didn't forget about

- [x] Tests
- [x] Changelog (unnecessary)
- [x] Documentation (unnecessary)

Part of #1406
