### PR TITLE
Fix hotreload exceptions on gapped http routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 
 - Leaders replaced during stateful failover can be expelled now.
 - Make failover logging more verbose.
+- Fix hotreload for roles who leave gaps in httpd routes.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26

--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -112,7 +112,7 @@ local function save_state()
 
     local httpd = service_registry.get('httpd')
     if httpd ~= nil then
-        vars.routes_count = #httpd.routes
+        vars.routes_count = table.maxn(httpd.routes)
     else
         vars.routes_count = 0
     end
@@ -175,13 +175,19 @@ local function load_state()
 
     local httpd = service_registry.get('httpd')
     if httpd ~= nil then
-        for n = #httpd.routes, vars.routes_count + 1, -1 do
+        for n = table.maxn(httpd.routes), vars.routes_count + 1, -1 do
             local r = httpd.routes[n]
+            if r == nil then
+                goto continue
+            end
+
             log.info('Removing HTTP route %q (%s)', r.path, r.method)
             if httpd.iroutes[r.name] ~= nil then
                 httpd.iroutes[r.name] = nil
             end
             httpd.routes[n] = nil
+
+            ::continue::
         end
     end
 end

--- a/test/hotreload/myrole_test.lua
+++ b/test/hotreload/myrole_test.lua
@@ -214,7 +214,15 @@ function g.test_routes()
         httpd:route({method = 'ANY', path = '/route-a'}, echo)
         httpd:route({method = 'GET', path = '/route-b'}, echo)
 
-        return {role_name = 'myrole'}
+        return {
+            role_name = 'myrole',
+            stop = function()
+                -- Some external roles may remove routes improperly
+                -- and leave gaps in the routes table. Test that
+                -- cartridge can handle it.
+                httpd.routes[#httpd.routes-1] = nil
+            end,
+        }
     end)
 
     t.assert_covers(


### PR DESCRIPTION
Some external roles may remove HTTP routes improperly and leave gaps in the routes table. See, for example, https://github.com/tarantool/migrations/issues/35.

This patch makes Cartridge handle it no matter what.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)
