### PR TITLE
fix unhandled error on config load

### DIFF
--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -345,6 +345,10 @@ local function load_from_file(filename)
         return nil, LoadConfigError:new(
             'Error loading %q: File is empty', filename
         )
+    elseif type(data) ~= 'table' then
+        return nil, LoadConfigError:new(
+            'Error loading %q: Config must be a table', filename
+        )
     end
 
     local _plaintext = {}

--- a/test/unit/clusterwide_config_test.lua
+++ b/test/unit/clusterwide_config_test.lua
@@ -181,6 +181,20 @@ function g.test_oldstyle_err()
         err = 'Error loading section "side_config":' ..
         ' inclusion "not_existing.txt" not found'
     })
+
+    write_tree({['config.yml'] = [[---
+        local my_var = 123
+        ...
+    ]]})
+    local cfg, err = ClusterwideConfig.load(g.tempdir .. '/config.yml')
+    t.assert_equals(cfg, nil)
+    t.assert_covers(err, {
+        class_name = 'LoadConfigError',
+        err = string.format(
+            'Error loading %q: Config must be a table',
+            fio.pathjoin(g.tempdir, 'config.yml')
+        ),
+    })
 end
 
 function g.test_preserving_plaintext()


### PR DESCRIPTION
Before this patch if we tried to load yaml file that couldn't be
parsed into Lua table we got following error:

```
.../.rocks/share/tarantool/cartridge/clusterwide-config.lua:320:
bad argument #1 to 'pairs' (table expected, got string)
```

This patch fixes such case and add a check that parsed config
is a table.
