### PR TITLE
Don't start instances that are absent in instances.yml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Changed
 - Update ``errors`` dependency to 2.2.0.
 - Add default ``pool.map_call`` timeout 10 seconds.
 - Update ``frontend-core`` dependency to 7.8.0.
+- Argparse throws an error when it encouters ``instance_name`` missing in
+  instances.yml.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -287,6 +287,9 @@ local function parse_file(filename, search_name)
         table.insert(section_names, section_name)
     end
 
+    package.loaded.log.info(file_sections)
+    package.loaded.log.info(section_names)
+
     local ret = {}
     for section_index, section_name in ipairs(section_names) do
         local content = file_sections[section_name]

--- a/test/unit/argparse_test.lua
+++ b/test/unit/argparse_test.lua
@@ -77,6 +77,10 @@ function g:test_sections()
                 x = '@custom.sub.sub',
                 y_subsub = true,
             },
+            ['custom.x.y.z'] = {
+                x = '@custom.x.y.z',
+                y_xyz = true,
+            },
         })
     )
 
@@ -104,11 +108,14 @@ function g:test_sections()
         y_default = 0,
     })
 
-    check('--instance-name unknown', {
-        instance_name = 'unknown',
-        x = '@default',
-        y_default = 0,
-    })
+    t.assert_error_msg_contains(
+        'ParseConfigError: Missing section name: unknown',
+        check, '--instance-name unknown', {
+            instance_name = 'unknown',
+            x = '@default',
+            y_default = 0,
+        }
+    )
 
     check('--instance-name custom', {
         instance_name = 'custom',
@@ -116,6 +123,16 @@ function g:test_sections()
         y_default = 0,
         y_custom = '$',
     })
+
+    t.assert_error_msg_contains(
+        'ParseConfigError: Missing section name: custom.bad',
+        check, '--instance-name custom.bad', {
+            instance_name = 'custom.bad',
+            x = '@custom',
+            y_default = 0,
+            y_custom = '$',
+        }
+    )
 
     check('--instance-name custom.sub', {
         instance_name = 'custom.sub',
@@ -132,6 +149,14 @@ function g:test_sections()
         y_custom = '$',
         y_sub = 3.14,
         y_subsub = true,
+    })
+
+    check('--instance_name custom.x.y.z', {
+        instance_name = 'custom.x.y.z',
+        x = '@custom.x.y.z',
+        y_default = 0,
+        y_custom = '$',
+        y_xyz = true,
     })
 end
 

--- a/test/unit/argparse_test.lua
+++ b/test/unit/argparse_test.lua
@@ -117,13 +117,6 @@ function g:test_sections()
         y_custom = '$',
     })
 
-    check('--instance-name custom.bad', {
-        instance_name = 'custom.bad',
-        x = '@custom',
-        y_default = 0,
-        y_custom = '$',
-    })
-
     check('--instance-name custom.sub', {
         instance_name = 'custom.sub',
         x = '@custom.sub',
@@ -297,6 +290,17 @@ function g:test_badfile()
     )
     local ret = self:run('--cfg tarantool.yml', {}, {ignore_errors = true})
     t.assert_str_contains(ret.err, 'DecodeYamlError: tarantool.yml: unexpected END event')
+
+    utils.file_write(
+        fio.pathjoin(self.tempdir, 'tarantool.yml'),
+        yaml.encode({['app_name.instance_name'] = {x = 'sup'}})
+    )
+    local ret = self:run(
+        '--cfg tarantool.yml' ..
+        ' --app_name app_name' ..
+        ' --instance_name harry',
+        {}, {ignore_errors = true})
+    t.assert_str_contains(ret.err, 'ParseConfigError: Missing section name: app_name.harry')
 end
 
 function g:test_box_opts()

--- a/test/unit/argparse_test.lua
+++ b/test/unit/argparse_test.lua
@@ -114,11 +114,7 @@ function g:test_sections()
 
     t.assert_error_msg_contains(
         'ParseConfigError: Missing section: unknown',
-        check, '--instance-name unknown', {
-            instance_name = 'unknown',
-            x = '@default',
-            y_default = 0,
-        }
+        check, '--instance-name unknown'
     )
 
     check('--instance-name custom', {
@@ -130,12 +126,7 @@ function g:test_sections()
 
     t.assert_error_msg_contains(
         'ParseConfigError: Missing section: custom.bad',
-        check, '--instance-name custom.bad', {
-            instance_name = 'custom.bad',
-            x = '@custom',
-            y_default = 0,
-            y_custom = '$',
-        }
+        check, '--instance-name custom.bad'
     )
 
     check('--instance-name custom.sub', {
@@ -171,13 +162,7 @@ function g:test_sections()
 
     t.assert_error_msg_contains(
         'ParseConfigError: Missing section: custom.x\n',
-        check, '--instance-name custom.x.y.z', {
-            instance_name = 'custom.bad',
-            x = '@custom.x.y.z',
-            y_default = 0,
-            y_custom = '$',
-            y_xyz = true,
-        }
+        check, '--instance-name custom.x.y.z'
     )
 end
 


### PR DESCRIPTION
Argparse throws an error when it encounters instance_name missing in instances.yml

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1437 
