### PR TITLE
Add zones to helpers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Added
   - ``/`` and ``<PREFIX>/`` redirect to ``/<PREFIX>/admin`` (if enabled).
 
 - New validate_config method in GraphQL API.
+- Add ``zone`` and ``zone_distances`` parameters to server and cluster helpers
+  respectively.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/cartridge/test-helpers/server.lua
+++ b/cartridge/test-helpers/server.lua
@@ -25,6 +25,7 @@ local checks = require('checks')
 -- @string object.cluster_cookie Value to be passed in `TARANTOOL_CLUSTER_COOKIE` and used as default net_box password.
 -- @string[opt] object.instance_uuid Server identifier.
 -- @string[opt] object.replicaset_uuid Replicaset identifier.
+-- @string[opt] object.zone Vshard zone.
 -- @return input object
 local Server = luatest.Server:inherit({})
 
@@ -36,7 +37,8 @@ Server.constructor_checks = fun.chain(Server.constructor_checks, {
 
     instance_uuid = '?string',
     replicaset_uuid = '?string',
-    labels = '?table'
+    labels = '?table',
+    zone = '?string'
 }):tomap()
 
 function Server:initialize()


### PR DESCRIPTION
Add ``zone`` and ``zone_distances`` parameters to server and cluster helpers respectively.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1229 
