### PR TITLE
Remove expelled instances from _cluster

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ Fixed
 - Make failover logging more verbose.
 - Fix hotreload for roles who leave gaps in httpd routes.
 - Check user e-mail uniquness when editing.
+- Expelled instances are removed from ``_cluster`` space.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -61,12 +61,20 @@ local e_config = errors.new_class('Invalid cluster topology config')
 }]]
 
 -- to be used in fun.filter
+local function expelled(_, srv)
+    return srv == 'expelled'
+end
+
+local function disabled(uuid, srv)
+    return expelled(uuid, srv) or srv.disabled
+end
+
 local function not_expelled(_, srv)
-    return srv ~= 'expelled'
+    return not expelled(_, srv)
 end
 
 local function not_disabled(uuid, srv)
-    return not_expelled(uuid, srv) and not srv.disabled
+    return not disabled(uuid, srv)
 end
 
 --- Get full list of replicaset leaders.
@@ -1060,6 +1068,8 @@ return {
         return e_config:pcall(validate, ...)
     end,
 
+    expelled = expelled,
+    disabled = disabled,
     not_expelled = not_expelled,
     not_disabled = not_disabled,
 

--- a/test/integration/expel_test.lua
+++ b/test/integration/expel_test.lua
@@ -38,9 +38,10 @@ g.before_all(function()
             uuid = ...,
             expelled = true,
         }}})
-
-        box.space._cluster.index.uuid:delete(...)
     ]], {expelled.instance_uuid})
+
+    g.A1.net_box:call('package.loaded.cartridge.admin_edit_topology',
+        {{servers = {{uuid = expelled.instance_uuid, expelled = true}}}})
 
 end)
 
@@ -84,4 +85,10 @@ function g.test_api()
             downstream_status = box.NULL,
         },
     })
+
+    -- Check explicitly that expelled leader is not in _cluster. Just in case.
+    t.assert_items_equals(
+        g.A1.net_box.space._cluster:select(),
+        {{1, g.r1_uuid}, {3, g.r3_uuid}}
+    )
 end


### PR DESCRIPTION
Expelled instances are removed from _cluster.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1445 
