### PR TITLE
Fix pull translation fail when clean up po files

### DIFF
--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -51,7 +51,9 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
       - name: Cleanup translation files
-        run: make cleanup-po
+        run: |
+          sudo chown -R runner:docker rst/locale/ru/LC_MESSAGES
+          make cleanup-po
 
       - name: Commit translation files
         uses: stefanzweifel/git-auto-commit-action@v4.1.2


### PR DESCRIPTION
The default user can not process pulled from Crowdin translated PO files
because they have a different owner - root. Change owner to "runner:docker"
to make them writable to the default Github Actions user.
