### PR TITLE
Add API to restart replication

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -31,7 +31,7 @@ jobs:
         id: cache-misc-venv
         with:
           path: ./venv
-          key: cache-misc-venv-${{ matrix.runs-on }}-00
+          key: cache-misc-venv-${{ matrix.runs-on }}-${{ hashFiles('rst/requirements.txt') }}-06
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate
@@ -123,8 +123,7 @@ jobs:
         id: cache-pytest
         with:
           path: ./pytest-venv
-          key: cache-pytest-venv-${{ matrix.runs-on }}-${{ hashFiles('test/integration/requirements.txt') }}
-          restore-keys: cache-pytest-venv-${{ matrix.runs-on }}
+          key: cache-pytest-venv-${{ matrix.runs-on }}-${{ hashFiles('test/integration/requirements.txt') }}-06
       -
         run: |
           python -m venv ./pytest-venv && . ./pytest-venv/bin/activate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Added
 - New validate_config method in GraphQL API.
 - Add ``zone`` and ``zone_distances`` parameters to server and cluster helpers
   respectively.
+- New restart_replication method in GraphQL API and corresponding suggestion.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -896,6 +896,11 @@ return {
     admin_disable_servers = lua_api_topology.disable_servers,
 
     --- .
+    -- @refer cartridge.lua-api.topology.restart_replication
+    -- @function admin_bootstrap_vshard
+    admin_restart_replication = lua_api_topology.restart_replication,
+
+    --- .
     -- @refer cartridge.lua-api.vshard.bootstrap_vshard
     -- @function admin_bootstrap_vshard
     admin_bootstrap_vshard = lua_api_vshard.bootstrap_vshard,

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -137,6 +137,7 @@ local function list_on_instance(opts)
                 topic = 'replication',
                 replicaset_uuid = replicaset_uuid,
                 instance_uuid = instance_uuid,
+                upstream_uuid = replication_info.uuid,
                 message = string.format(
                     "Replication from %s to %s isn't running",
                     describe(replica.uri),
@@ -150,6 +151,7 @@ local function list_on_instance(opts)
                 topic = 'replication',
                 replicaset_uuid = replicaset_uuid,
                 instance_uuid = instance_uuid,
+                upstream_uuid = replication_info.uuid,
                 message = string.format(
                     'Replication from %s to %s state %q (%s)',
                     describe(replica.uri),

--- a/cartridge/webui/api-topology.lua
+++ b/cartridge/webui/api-topology.lua
@@ -287,6 +287,10 @@ local function disable_servers(_, args)
     return lua_api_topology.disable_servers(args.uuids)
 end
 
+local function restart_replication(_, args)
+    return lua_api_topology.restart_replication(args.uuids)
+end
+
 local function edit_replicaset(_, args)
     return lua_api_deprecated.edit_replicaset(args)
 end
@@ -413,6 +417,17 @@ local function init(graphql)
         callback = module_name .. '.disable_servers',
     })
 
+    graphql.add_mutation({
+        prefix = 'cluster',
+        name = 'restart_replication',
+        doc = 'Restart replication on specified by uuid servers',
+        args = {
+            uuids = gql_types.list(gql_types.string.nonNull),
+        },
+        kind = gql_types.boolean,
+        callback = module_name .. '.restart_replication',
+    })
+
     graphql.add_callback({
         prefix = 'cluster',
         name = 'self',
@@ -469,6 +484,7 @@ return {
     edit_replicaset = edit_replicaset, -- deprecated
     expel_server = expel_server, -- deprecated
     disable_servers = disable_servers,
+    restart_replication = restart_replication,
 
     edit_topology = edit_topology,
 

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Wed Jun 09 2021 12:28:07 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Jul 12 2021 03:57:45 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -227,8 +227,11 @@ type Mutation {
 
 """Cluster management"""
 type MutationApicluster {
-  """Remove user"""
-  remove_user(username: String!): User
+  """Disable listed servers by uuid"""
+  disable_servers(uuids: [String!]): [Server]
+
+  """Applies DDL schema on cluster"""
+  schema(as_yaml: String!): DDLSchema!
 
   """
   Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.2-2)
@@ -238,34 +241,34 @@ type MutationApicluster {
   """Configure automatic failover."""
   failover_params(fencing_enabled: Boolean, fencing_timeout: Float, failover_timeout: Float, mode: String, state_provider: String, tarantool_params: FailoverStateProviderCfgInputTarantool, fencing_pause: Float, etcd2_params: FailoverStateProviderCfgInputEtcd2): FailoverAPI!
 
-  """Applies updated config on cluster"""
-  config(sections: [ConfigSectionInput]): [ConfigSection]!
+  """Remove user"""
+  remove_user(username: String!): User
 
   """Checks that schema can be applied on cluster"""
   check_schema(as_yaml: String!): DDLCheckResult!
 
+  """Restart replication on specified by uuid servers"""
+  restart_replication(uuids: [String!]): Boolean
+  edit_vshard_options(rebalancer_max_receiving: Int, sched_ref_quota: Long, collect_bucket_garbage_interval: Float, sync_timeout: Float, collect_lua_garbage: Boolean, rebalancer_disbalance_threshold: Float, name: String!, sched_move_quota: Long): VshardGroup!
+  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
+
   """Create a new user"""
   add_user(password: String!, username: String!, fullname: String, email: String): User
 
-  """Reapplies config on the specified nodes"""
-  config_force_reapply(uuids: [String]): Boolean!
-  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
+  """Edit an existing user"""
+  edit_user(password: String, username: String!, fullname: String, email: String): User
 
   """Edit cluster topology"""
   edit_topology(replicasets: [EditReplicasetInput], servers: [EditServerInput]): EditTopologyResult
 
-  """Edit an existing user"""
-  edit_user(password: String, username: String!, fullname: String, email: String): User
-  edit_vshard_options(rebalancer_max_receiving: Int, sched_ref_quota: Long, collect_bucket_garbage_interval: Float, sync_timeout: Float, collect_lua_garbage: Boolean, rebalancer_disbalance_threshold: Float, name: String!, sched_move_quota: Long): VshardGroup!
-
   """Promote the instance to the leader of replicaset"""
   failover_promote(force_inconsistency: Boolean, replicaset_uuid: String!, instance_uuid: String!): Boolean!
 
-  """Applies DDL schema on cluster"""
-  schema(as_yaml: String!): DDLSchema!
+  """Reapplies config on the specified nodes"""
+  config_force_reapply(uuids: [String]): Boolean!
 
-  """Disable listed servers by uuid"""
-  disable_servers(uuids: [String!]): [Server]
+  """Applies updated config on cluster"""
+  config(sections: [ConfigSectionInput]): [ConfigSection]!
 }
 
 type Query {
@@ -337,6 +340,11 @@ type ReplicaStatus {
   upstream_status: String
   uuid: String!
   downstream_message: String
+}
+
+"""A suggestion to restart malfunctioning replications"""
+type RestartReplicationSuggestion {
+  uuid: String!
 }
 
 type Role {
@@ -539,6 +547,7 @@ type ServerStat {
 
 type Suggestions {
   force_apply: [ForceApplySuggestion!]
+  restart_replication: [RestartReplicationSuggestion!]
   refine_uri: [RefineUriSuggestion!]
   disable_servers: [DisableServerSuggestion!]
 }

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -77,6 +77,9 @@ function helpers.get_suggestions(server)
                 disable_servers  {
                     uuid
                 }
+                restart_replication  {
+                    uuid
+                }
             }}
         }]]
     }).data.cluster.suggestions

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -144,14 +144,15 @@ function g.test_2pc()
         }},
     })
 
-    t.assert_equals(helpers.get_suggestions(g.A1), {
-        refine_uri = box.NULL,
-        force_apply = box.NULL,
-        disable_servers = box.NULL,
-    })
     helpers.retrying({}, function()
         -- Replication takes time to re-establish
         t.assert_equals(helpers.list_cluster_issues(g.A1), {})
+        t.assert_equals(helpers.get_suggestions(g.A1), {
+            refine_uri = box.NULL,
+            force_apply = box.NULL,
+            disable_servers = box.NULL,
+            restart_replication = box.NULL,
+        })
     end)
 
     g.cluster.main_server:graphql({

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -608,6 +608,7 @@ g.test_sigstop = function()
     -- See: https://github.com/tarantool/tarantool/issues/4668
     t.helpers.retrying({}, function()
         t.assert_equals(helpers.list_cluster_issues(cluster.main_server), {})
+        t.assert_equals(helpers.get_suggestions(cluster.main_server), {})
     end)
 
     set_failover(true)
@@ -656,6 +657,8 @@ g.test_sigstop = function()
         topic = 'replication',
     }})
 
+    t.assert_equals(helpers.get_suggestions(cluster.main_server).restart_replication, box.NULL)
+
     -- Send SIGCONT to server1
     cluster:server('storage-1').process:kill('CONT') -- SIGCONT
     cluster:wait_until_healthy()
@@ -680,5 +683,6 @@ g.test_sigstop = function()
 
     t.helpers.retrying({}, function()
         t.assert_equals(helpers.list_cluster_issues(cluster.main_server), {})
+        t.assert_equals(helpers.get_suggestions(cluster.main_server), {})
     end)
 end

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -198,6 +198,7 @@ function g.test_replication_idle()
             cluster {
                 issues { level topic instance_uuid replicaset_uuid }
                 issues_msg: issues { message }
+                suggestions { restart_replication {uuid} }
             }
         }]]}).data.cluster
 
@@ -215,6 +216,12 @@ function g.test_replication_idle()
         resp.issues_msg[1].message,
         'Replication from localhost:1330[23] %(replica[12]%)' ..
         ' to localhost:13301 %(master%): long idle %(.+ > 1%)'
+    )
+
+    -- Warning isn't a reason for showing suggestion
+    t.assert_equals(
+        resp.suggestions,
+        {restart_replication = box.NULL}
     )
 
     -- Revert all the hacks

--- a/test/integration/restart_replication_test.lua
+++ b/test/integration/restart_replication_test.lua
@@ -36,7 +36,7 @@ g.after_all(function()
     fio.rmtree(g.cluster.datadir)
 end)
 
-function g.test_api()
+function g.test_suggestion()
     -- Trigger replication issue
     g.A1.net_box:call('box.cfg', {{replication = box.NULL}})
 
@@ -85,7 +85,7 @@ function g.test_api()
     end)
 end
 
-function g.test_restart_replication_errors()
+function g.test_errors()
     local _, err = g.A1.net_box:call(
         'package.loaded.cartridge.admin_restart_replication',
         {{'1-0-1-0'}}

--- a/test/integration/restart_replication_test.lua
+++ b/test/integration/restart_replication_test.lua
@@ -1,0 +1,117 @@
+local t = require('luatest')
+local h = require('test.helper')
+local g = t.group()
+
+local fio = require('fio')
+
+g.before_all(function()
+    g.cluster = h.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = false,
+        server_command = h.entrypoint('srv_basic'),
+        cookie = h.random_cookie(),
+        replicasets = {{
+            alias = 'A',
+            roles = {},
+            servers = 2,
+        }},
+    })
+    g.cluster:start()
+    g.A1 = g.cluster:server('A-1')
+    g.A2 = g.cluster:server('A-2')
+
+    g.unconfigured = h.Server:new({
+        alias = 'unconfigured',
+        workdir = fio.pathjoin(g.cluster.datadir, 'unconfigured'),
+        command = h.entrypoint('srv_basic'),
+        cluster_cookie = g.cluster.cookie,
+        advertise_port = 13309,
+        http_port = 8089,
+    })
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    g.unconfigured:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_api()
+    -- Trigger replication issue
+    g.A1.net_box:call('box.cfg', {{replication = box.NULL}})
+
+    local replication_issue = {
+        level = 'critical',
+        topic = 'replication',
+        instance_uuid = g.A1.instance_uuid,
+        replicaset_uuid = g.A1.replicaset_uuid,
+        message = "Replication from localhost:13302 (A-2)" ..
+            " to localhost:13301 (A-1) isn't running",
+    }
+
+    t.assert_equals(h.list_cluster_issues(g.A1), {replication_issue})
+    t.assert_items_equals(
+        h.get_suggestions(g.A1).restart_replication,
+        {{uuid = g.A1.instance_uuid}}
+    )
+
+    g.A2.process:kill('STOP')
+
+    t.assert_equals(h.list_cluster_issues(g.A1), {replication_issue})
+    t.assert_equals(h.get_suggestions(g.A1).restart_replication, nil)
+
+    g.A2.process:kill('CONT')
+
+    t.assert_equals(h.list_cluster_issues(g.A1), {replication_issue})
+    t.assert_items_equals(
+        h.get_suggestions(g.A1).restart_replication,
+        {{uuid = g.A1.instance_uuid}}
+    )
+
+    g.A1:graphql({
+        query = [[
+            mutation ($uuids : [String!]) {
+                cluster {
+                    restart_replication(uuids: $uuids)
+                }
+            }
+        ]],
+        variables = {uuids = {g.A1.instance_uuid}}
+    })
+
+    t.helpers.retrying({}, function()
+        t.assert_equals(h.list_cluster_issues(g.A1), {})
+        t.assert_equals(h.get_suggestions(g.A1).restart_replication, nil)
+    end)
+end
+
+function g.test_restart_replication_errors()
+    local _, err = g.A1.net_box:call(
+        'package.loaded.cartridge.admin_restart_replication',
+        {{'1-0-1-0'}}
+    )
+    t.assert_covers(err, {err = 'Server 1-0-1-0 not in clusterwide config'})
+
+    g.A1.net_box:eval([[
+        package.loaded.cartridge.admin_disable_servers({...})
+    ]], {g.A2.instance_uuid})
+    local _, err = g.A1.net_box:call(
+        'package.loaded.cartridge.admin_restart_replication',
+        {{g.A2.instance_uuid}}
+    )
+    t.assert_covers(err, {
+        err = 'Server ' .. g.A2.instance_uuid .. ' is disabled,' ..
+            ' not suitable for restarting replication',
+    })
+
+    g.A1.net_box:eval([[
+        package.loaded.cartridge.admin_enable_servers({...})
+    ]], {g.A2.instance_uuid})
+
+    g.unconfigured:start()
+    local _, err = g.unconfigured.net_box:call(
+        'package.loaded.cartridge.admin_restart_replication',
+        {{g.unconfigured.instance_uuid}}
+    )
+    t.assert_covers(err, {err = 'Current instance isn\'t bootstrapped yet'})
+end

--- a/test/integration/switchover_test.lua
+++ b/test/integration/switchover_test.lua
@@ -350,6 +350,10 @@ add('test_promotion_abortion', function(g)
                 " to " .. B2.advertise_uri .. " (B2) isn't running",
         }}
     )
+    t.assert_items_equals(
+        helpers.get_suggestions(A1).restart_replication,
+        {{uuid = uB2}}
+    )
 
     -- Revert B1 leadership
     t.assert(g.session:set_leaders({{uB, uB1}}))

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -287,38 +287,46 @@ export type MutationExpel_ServerArgs = {|
 /** Cluster management */
 export type MutationApicluster = {|
   __typename?: 'MutationApicluster',
-  /** Remove user */
-  remove_user?: ?User,
+  /** Disable listed servers by uuid */
+  disable_servers?: ?Array<?Server>,
+  /** Applies DDL schema on cluster */
+  schema: DdlSchema,
   /** Enable or disable automatic failover. Returns new state. (Deprecated since v2.0.2-2) */
   failover: $ElementType<Scalars, 'Boolean'>,
   /** Configure automatic failover. */
   failover_params: FailoverApi,
-  /** Applies updated config on cluster */
-  config: Array<?ConfigSection>,
+  /** Remove user */
+  remove_user?: ?User,
   /** Checks that schema can be applied on cluster */
   check_schema: DdlCheckResult,
+  /** Restart replication on specified by uuid servers */
+  restart_replication?: ?$ElementType<Scalars, 'Boolean'>,
+  edit_vshard_options: VshardGroup,
+  auth_params: UserManagementApi,
   /** Create a new user */
   add_user?: ?User,
-  /** Reapplies config on the specified nodes */
-  config_force_reapply: $ElementType<Scalars, 'Boolean'>,
-  auth_params: UserManagementApi,
-  /** Edit cluster topology */
-  edit_topology?: ?EditTopologyResult,
   /** Edit an existing user */
   edit_user?: ?User,
-  edit_vshard_options: VshardGroup,
+  /** Edit cluster topology */
+  edit_topology?: ?EditTopologyResult,
   /** Promote the instance to the leader of replicaset */
   failover_promote: $ElementType<Scalars, 'Boolean'>,
-  /** Applies DDL schema on cluster */
-  schema: DdlSchema,
-  /** Disable listed servers by uuid */
-  disable_servers?: ?Array<?Server>,
+  /** Reapplies config on the specified nodes */
+  config_force_reapply: $ElementType<Scalars, 'Boolean'>,
+  /** Applies updated config on cluster */
+  config: Array<?ConfigSection>,
 |};
 
 
 /** Cluster management */
-export type MutationApiclusterRemove_UserArgs = {|
-  username: $ElementType<Scalars, 'String'>,
+export type MutationApiclusterDisable_ServersArgs = {|
+  uuids?: ?Array<$ElementType<Scalars, 'String'>>,
+|};
+
+
+/** Cluster management */
+export type MutationApiclusterSchemaArgs = {|
+  as_yaml: $ElementType<Scalars, 'String'>,
 |};
 
 
@@ -342,8 +350,8 @@ export type MutationApiclusterFailover_ParamsArgs = {|
 
 
 /** Cluster management */
-export type MutationApiclusterConfigArgs = {|
-  sections?: ?Array<?ConfigSectionInput>,
+export type MutationApiclusterRemove_UserArgs = {|
+  username: $ElementType<Scalars, 'String'>,
 |};
 
 
@@ -354,41 +362,8 @@ export type MutationApiclusterCheck_SchemaArgs = {|
 
 
 /** Cluster management */
-export type MutationApiclusterAdd_UserArgs = {|
-  password: $ElementType<Scalars, 'String'>,
-  username: $ElementType<Scalars, 'String'>,
-  fullname?: ?$ElementType<Scalars, 'String'>,
-  email?: ?$ElementType<Scalars, 'String'>,
-|};
-
-
-/** Cluster management */
-export type MutationApiclusterConfig_Force_ReapplyArgs = {|
-  uuids?: ?Array<?$ElementType<Scalars, 'String'>>,
-|};
-
-
-/** Cluster management */
-export type MutationApiclusterAuth_ParamsArgs = {|
-  cookie_max_age?: ?$ElementType<Scalars, 'Long'>,
-  enabled?: ?$ElementType<Scalars, 'Boolean'>,
-  cookie_renew_age?: ?$ElementType<Scalars, 'Long'>,
-|};
-
-
-/** Cluster management */
-export type MutationApiclusterEdit_TopologyArgs = {|
-  replicasets?: ?Array<?EditReplicasetInput>,
-  servers?: ?Array<?EditServerInput>,
-|};
-
-
-/** Cluster management */
-export type MutationApiclusterEdit_UserArgs = {|
-  password?: ?$ElementType<Scalars, 'String'>,
-  username: $ElementType<Scalars, 'String'>,
-  fullname?: ?$ElementType<Scalars, 'String'>,
-  email?: ?$ElementType<Scalars, 'String'>,
+export type MutationApiclusterRestart_ReplicationArgs = {|
+  uuids?: ?Array<$ElementType<Scalars, 'String'>>,
 |};
 
 
@@ -406,6 +381,39 @@ export type MutationApiclusterEdit_Vshard_OptionsArgs = {|
 
 
 /** Cluster management */
+export type MutationApiclusterAuth_ParamsArgs = {|
+  cookie_max_age?: ?$ElementType<Scalars, 'Long'>,
+  enabled?: ?$ElementType<Scalars, 'Boolean'>,
+  cookie_renew_age?: ?$ElementType<Scalars, 'Long'>,
+|};
+
+
+/** Cluster management */
+export type MutationApiclusterAdd_UserArgs = {|
+  password: $ElementType<Scalars, 'String'>,
+  username: $ElementType<Scalars, 'String'>,
+  fullname?: ?$ElementType<Scalars, 'String'>,
+  email?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+/** Cluster management */
+export type MutationApiclusterEdit_UserArgs = {|
+  password?: ?$ElementType<Scalars, 'String'>,
+  username: $ElementType<Scalars, 'String'>,
+  fullname?: ?$ElementType<Scalars, 'String'>,
+  email?: ?$ElementType<Scalars, 'String'>,
+|};
+
+
+/** Cluster management */
+export type MutationApiclusterEdit_TopologyArgs = {|
+  replicasets?: ?Array<?EditReplicasetInput>,
+  servers?: ?Array<?EditServerInput>,
+|};
+
+
+/** Cluster management */
 export type MutationApiclusterFailover_PromoteArgs = {|
   force_inconsistency?: ?$ElementType<Scalars, 'Boolean'>,
   replicaset_uuid: $ElementType<Scalars, 'String'>,
@@ -414,14 +422,14 @@ export type MutationApiclusterFailover_PromoteArgs = {|
 
 
 /** Cluster management */
-export type MutationApiclusterSchemaArgs = {|
-  as_yaml: $ElementType<Scalars, 'String'>,
+export type MutationApiclusterConfig_Force_ReapplyArgs = {|
+  uuids?: ?Array<?$ElementType<Scalars, 'String'>>,
 |};
 
 
 /** Cluster management */
-export type MutationApiclusterDisable_ServersArgs = {|
-  uuids?: ?Array<$ElementType<Scalars, 'String'>>,
+export type MutationApiclusterConfigArgs = {|
+  sections?: ?Array<?ConfigSectionInput>,
 |};
 
 export type Query = {|
@@ -488,6 +496,12 @@ export type ReplicaStatus = {|
   upstream_status?: ?$ElementType<Scalars, 'String'>,
   uuid: $ElementType<Scalars, 'String'>,
   downstream_message?: ?$ElementType<Scalars, 'String'>,
+|};
+
+/** A suggestion to restart malfunctioning replications */
+export type RestartReplicationSuggestion = {|
+  __typename?: 'RestartReplicationSuggestion',
+  uuid: $ElementType<Scalars, 'String'>,
 |};
 
 export type Role = {|
@@ -661,6 +675,7 @@ export type ServerStat = {|
 export type Suggestions = {|
   __typename?: 'Suggestions',
   force_apply?: ?Array<ForceApplySuggestion>,
+  restart_replication?: ?Array<RestartReplicationSuggestion>,
   refine_uri?: ?Array<RefineUriSuggestion>,
   disable_servers?: ?Array<DisableServerSuggestion>,
 |};


### PR DESCRIPTION
New `restart_replication` method in GraphQL API and corresponding suggestion

```
mutation {
    cluster {
        restart_replication(uuids: $uuids)
    }
}
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1418 
