### PR TITLE
Check if syslog is available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ Fixed
 - Check user e-mail uniquness when editing.
 - Expelled instances are removed from ``_cluster`` space.
 - Fix ``get_enabled_roles`` to work w/o args
+- Don't default to syslog driver unless ``/dev/log`` or
+  ``/var/run/syslog`` are available.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26


### PR DESCRIPTION
Add additional check if `/dev/log` (for Linux) or `/var/run/syslog` (for Mac) is available for syslog driver.

I didn't forget about

- [ ] Tests
- [x] Changelog
- [ ] Documentation

Close #1361 
