### PR TITLE
Remove unnecessary comments

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -31,7 +31,7 @@ jobs:
         id: cache-misc-venv
         with:
           path: ./venv
-          key: cache-misc-venv-${{ matrix.runs-on }}-02
+          key: cache-misc-venv-${{ matrix.runs-on }}-00
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate

--- a/webui/cypress/integration/force-apply-config.spec.js
+++ b/webui/cypress/integration/force-apply-config.spec.js
@@ -141,7 +141,6 @@ describe('Disable server', () => {
     ////////////////////////////////////////////////////////////////////
     cy.log('Close suggestion modal and save checkbox value');
     ////////////////////////////////////////////////////////////////////
-    //need to change next block after https://github.com/tarantool/cartridge/issues/1336
     cy.get('h2:contains(Force apply configuration)').next().click();
     cy.get('.meta-test__ForceApplySuggestionModal').should('not.exist');
     cy.get('.meta-test__ClusterSuggestionsPanel button').contains('Review').click();
@@ -175,7 +174,6 @@ describe('Disable server', () => {
 
     cy.get('.meta-test__ForceApplySuggestionModal').find('.meta-test__errorField').as('operErrorField');
     cy.get('@operErrorField').find('span').contains('Operation error');
-    //need to delete next 1 click after https://github.com/tarantool/cartridge/issues/1336
     cy.get('@operErrorField').contains('localhost:13301 (dummy-1)')
       .find('input[type="checkbox"]').click({ force: true });
     cy.get('@operErrorField').find('span button').contains('Deselect all');


### PR DESCRIPTION
A suggestion modal remembers checkboxes status even after the modal is
closed and re-opened. This behavior was intended. There's no need to fix
anything.

I didn't forget about

- [x] Tests
- [ ] ~~Changelog~~
- [ ] ~~Documentation~~

Close #1336
