### PR TITLE
Update membership. No false gossips during box.cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@ Added
   respectively.
 - New restart_replication method in GraphQL API and corresponding suggestion.
 
+- Instance will not produce suspects during ``RecoveringSnapshot`` and
+  ``BootstrappingBox``.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Changed
 - Update ``frontend-core`` dependency to 7.9.1.
 - Argparse throws an error when it encouters ``instance_name`` missing in
   instances.yml.
+- Update ``membership`` dependency to 2.4.0
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'checks == 3.1.0-1',
     'errors == 2.2.0-1',
     'vshard == 0.1.17-1',
-    'membership == 2.3.2-1',
+    'membership == 2.4.0-1',
     'frontend-core == 7.9.1-1',
     'graphql == 0.1.1-1',
 }

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -454,6 +454,9 @@ local function boot_instance(clusterwide_config)
     -- But imitate it is logged from the same fiber
     fiber.new(log_bootinfo):name(fiber.name())
 
+    -- There is no need in unnecessary suspicions
+    require('membership.options').SUSPICIOUSNESS = false
+
     log.warn('Calling box.cfg()...')
     -- This operation may be long
     -- It recovers snapshot
@@ -462,6 +465,8 @@ local function boot_instance(clusterwide_config)
     box.cfg(box_opts)
     local snap2 = hotreload.snap_fibers()
     hotreload.whitelist_fibers(hotreload.diff(snap1, snap2))
+
+    require('membership.options').SUSPICIOUSNESS = true
 
     local username = cluster_cookie.username()
     local password = cluster_cookie.cookie()


### PR DESCRIPTION
Membership is updated to 2.4.0. There will be no suspects produced during ``RecoveringSnapshot`` and ``BoostrappingBox``.

I didn't forget about

- [ ] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1460
