### PR TITLE
Added membership and vshard tabs to server details

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,9 @@ Added
 
 - New script ``rst/BuildUML.cmake`` for rendering UML diagrams from the doc.
 
-- New vshard option ``rebalancer_max_sending``
+- New vshard option ``rebalancer_max_sending``.
+
+- More server details in WebUI: membership, vshard-router and vshard-storage.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -42,10 +42,9 @@ local function get_info(uri)
         local membership_myself = require('membership').myself()
         local membership_options = require('membership.options')
 
-        local vshard = require('vshard')
+        local vshard = package.loaded.vshard
 
-        local ok, router_info = pcall(vshard.router.info)
-
+        local ok, router_info = pcall(vshard and vshard.router.info)
         if ok then
             router_info = {
                 buckets_unreachable = router_info.bucket.unreachable,
@@ -57,7 +56,7 @@ local function get_info(uri)
             router_info = box.NULL
         end
 
-        local ok, storage_info = pcall(vshard.storage.info)
+        local ok, storage_info = pcall(vshard and vshard.storage.info)
 
         if ok then
             storage_info = {

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -48,13 +48,12 @@ local function get_info(uri)
         local routers = vshard and vshard.router.internal.routers or {}
         local router_info = {}
         if next(routers) ~= nil then
-            router_info.routers = {}
             for group, router in pairs(routers) do
                 local info = router:info()
                 if group == '_static_router' then
                     group = 'default'
                 end
-                table.insert(router_info.routers, {
+                table.insert(router_info, {
                     vshard_group = group,
                     buckets_unreachable = info.bucket.unreachable,
                     buckets_available_ro = info.bucket.available_ro,

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -48,8 +48,8 @@ local function get_info(uri)
         local routers = vshard and vshard.router.internal.routers or {}
         local router_info = {}
         if next(routers) ~= nil then
+            router_info.routers = {}
             for group, router in pairs(routers) do
-                router_info.routers = {}
                 local info = router:info()
                 if group == '_static_router' then
                     group = 'default'
@@ -61,6 +61,7 @@ local function get_info(uri)
                     buckets_unknown = info.bucket.unknown,
                     buckets_available_rw = info.bucket.available_rw,
                 })
+
             end
         else
             router_info = box.NULL

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -47,10 +47,11 @@ local function get_info(uri)
 
         local routers = vshard and vshard.router.internal.routers or {}
         local router_info = {}
-        if next(routers) then
+        if next(routers) ~= nil then
             for group, router in pairs(routers) do
+                router_info.routers = {}
                 local info = router:info()
-                table.insert(router_info, {
+                table.insert(router_info.routers, {
                     vshard_group = group,
                     buckets_unreachable = info.bucket.unreachable,
                     buckets_available_ro = info.bucket.available_ro,
@@ -152,9 +153,7 @@ local function get_info(uri)
                 SUSPECT_TIMEOUT_SECONDS = membership_options.SUSPECT_TIMEOUT_SECONDS,
                 NUM_FAILURE_DETECTION_SUBGROUPS = membership_options.NUM_FAILURE_DETECTION_SUBGROUPS,
             },
-            vshard_router = {
-                routers = router_info
-            },
+            vshard_router = router_info,
             vshard_storage = storage_info,
         }
 

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -55,10 +55,10 @@ local function get_info(uri)
                 end
                 table.insert(router_info, {
                     vshard_group = group,
-                    buckets_unreachable = info.bucket.unreachable,
                     buckets_available_ro = info.bucket.available_ro,
-                    buckets_unknown = info.bucket.unknown,
                     buckets_available_rw = info.bucket.available_rw,
+                    buckets_unreachable = info.bucket.unreachable,
+                    buckets_unknown = info.bucket.unknown,
                 })
 
             end

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -51,6 +51,9 @@ local function get_info(uri)
             for group, router in pairs(routers) do
                 router_info.routers = {}
                 local info = router:info()
+                if group == '_static_router' then
+                    group = 'default'
+                end
                 table.insert(router_info.routers, {
                     vshard_group = group,
                     buckets_unreachable = info.bucket.unreachable,
@@ -58,9 +61,6 @@ local function get_info(uri)
                     buckets_unknown = info.bucket.unknown,
                     buckets_available_rw = info.bucket.available_rw,
                 })
-                if #router_info == 1 then
-                    router_info[1].vshard_group = 'default'
-                end
             end
         else
             router_info = box.NULL

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -267,12 +267,10 @@ local boxinfo_schema = {
                     },
                 }
             }).nonNull,
-            vshard_router = gql_types.object({
-                name = 'ServerInfoVshardRouter',
-                fields = {
-                    routers = gql_types.list(gql_vshard_router),
-                }
-            }),
+            vshard_router = {
+                kind = gql_types.list(gql_vshard_router),
+                description = 'List of vshard router parameters',
+            },
             vshard_storage = gql_types.object({
                 name = 'ServerInfoVshardStorage',
                 fields = {

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -30,11 +30,30 @@ local gql_replica_status = gql_types.object({
 local gql_vshard_router = gql_types.object({
     name = 'VshardRouter',
     fields = {
-        vshard_group = gql_types.string,
-        buckets_unreachable = gql_types.int,
-        buckets_available_ro = gql_types.int,
-        buckets_unknown = gql_types.int,
-        buckets_available_rw = gql_types.int,
+        vshard_group = {
+            kind = gql_types.string,
+            description = 'Vshard group',
+        },
+        buckets_available_ro = {
+            kind = gql_types.int,
+            description = 'The number of buckets known to the router' ..
+                ' and available for read requests',
+        },
+        buckets_available_rw = {
+            kind = gql_types.int,
+            description = 'The number of buckets known to the router' ..
+                ' and available for read and write requests',
+        },
+        buckets_unreachable = {
+            kind = gql_types.int,
+            description = 'The number of buckets known to the router' ..
+                ' but unavailable for any requests',
+        },
+        buckets_unknown = {
+            kind = gql_types.int,
+            description = 'The number of buckets whose replica' ..
+                ' sets are not known to the router',
+        },
     }
 })
 

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -222,6 +222,92 @@ local boxinfo_schema = {
                     }
                 }
             }).nonNull,
+            membership = gql_types.object({
+                name = 'ServerInfoMembership',
+                fields = {
+                    status = {
+                        kind = gql_types.string,
+                        description = 'Status of the instance',
+                    },
+                    incarnation = {
+                        kind = gql_types.int,
+                        description = 'Value incremented every time the instance ' ..
+                            'became a suspect, dead, or updates its payload',
+                    },
+                    PROTOCOL_PERIOD_SECONDS = {
+                        kind = gql_types.float,
+                        description = 'Direct ping period',
+                    },
+                    ACK_TIMEOUT_SECONDS = {
+                        kind = gql_types.float,
+                        description = 'ACK message wait time',
+                    },
+                    ANTI_ENTROPY_PERIOD_SECONDS = {
+                        kind = gql_types.float,
+                        description = 'Anti-entropy synchronization period',
+                    },
+                    SUSPECT_TIMEOUT_SECONDS = {
+                        kind = gql_types.float,
+                        description = 'Timeout to mark a suspect dead',
+                    },
+                    NUM_FAILURE_DETECTION_SUBGROUPS = {
+                        kind = gql_types.int,
+                        description = 'Number of members to ping a suspect indirectly',
+                    },
+                }
+            }).nonNull,
+            vshard_router = gql_types.object({
+                name = 'ServerInfoVshardRouter',
+                fields = {
+                    buckets_unreachable = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets whose replica sets are not known to the router',
+                    },
+                    buckets_available_ro = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets known to the router and available ' ..
+                            'for read requests',
+                    },
+                    buckets_unknown = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets unknown to the router',
+                    },
+                    buckets_available_rw = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets known to the router and available ' ..
+                            'for read and write requests',
+                    },
+                }
+            }),
+            vshard_storage = gql_types.object({
+                name = 'ServerInfoVshardStorage',
+                fields = {
+                    buckets_receiving = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets that are receiving at this time',
+                    },
+                    buckets_active = {
+                        kind = gql_types.int,
+                        description = 'The number of active buckets on the storage',
+                    },
+                    buckets_total = {
+                        kind = gql_types.int,
+                        description = 'Total number of buckets on the storage',
+                    },
+                    buckets_garbage = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets that are waiting to be collected by GC',
+                    },
+                    buckets_pinned = {
+                        kind = gql_types.int,
+                        description = 'The number of pinned buckets on the storage',
+                    },
+                    buckets_sending = {
+                        kind = gql_types.int,
+                        description = 'The number of buckets that are sending at this time',
+                    },
+                }
+            }),
         }
     }),
     arguments = {},

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -27,6 +27,17 @@ local gql_replica_status = gql_types.object({
     },
 })
 
+local gql_vshard_router = gql_types.object({
+    name = 'VshardRouter',
+    fields = {
+        vshard_group = gql_types.string,
+        buckets_unreachable = gql_types.int,
+        buckets_available_ro = gql_types.int,
+        buckets_unknown = gql_types.int,
+        buckets_available_rw = gql_types.int,
+    }
+})
+
 local boxinfo_schema = {
     kind = gql_types.object({
         name = 'ServerInfo',
@@ -259,29 +270,16 @@ local boxinfo_schema = {
             vshard_router = gql_types.object({
                 name = 'ServerInfoVshardRouter',
                 fields = {
-                    buckets_unreachable = {
-                        kind = gql_types.int,
-                        description = 'The number of buckets whose replica sets are not known to the router',
-                    },
-                    buckets_available_ro = {
-                        kind = gql_types.int,
-                        description = 'The number of buckets known to the router and available ' ..
-                            'for read requests',
-                    },
-                    buckets_unknown = {
-                        kind = gql_types.int,
-                        description = 'The number of buckets unknown to the router',
-                    },
-                    buckets_available_rw = {
-                        kind = gql_types.int,
-                        description = 'The number of buckets known to the router and available ' ..
-                            'for read and write requests',
-                    },
+                    routers = gql_types.list(gql_vshard_router),
                 }
             }),
             vshard_storage = gql_types.object({
                 name = 'ServerInfoVshardStorage',
                 fields = {
+                    vshard_group = {
+                        kind = gql_types.string,
+                        description = 'Vshard group',
+                    },
                     buckets_receiving = {
                         kind = gql_types.int,
                         description = 'The number of buckets that are receiving at this time',

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Mon Aug 02 2021 16:34:34 GMT+0300 (Москва, стандартное время)
+# timestamp: Tue Aug 03 2021 16:33:22 GMT+0300 (Москва, стандартное время)
 
 """Cluster management"""
 type Apicluster {
@@ -388,7 +388,9 @@ type ServerInfo {
   network: ServerInfoNetwork!
   general: ServerInfoGeneral!
   vshard_storage: ServerInfoVshardStorage
-  vshard_router: ServerInfoVshardRouter
+
+  """List of vshard router parameters"""
+  vshard_router: [VshardRouter]
 }
 
 type ServerInfoCartridge {
@@ -511,10 +513,6 @@ type ServerInfoStorage {
   vinyl_write_threads: Int
   vinyl_read_threads: Int
   wal_dir_rescan_delay: Float
-}
-
-type ServerInfoVshardRouter {
-  routers: [VshardRouter]
 }
 
 type ServerInfoVshardStorage {

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Mon Jul 26 2021 16:55:54 GMT+0300 (Москва, стандартное время)
+# timestamp: Fri Jul 30 2021 15:57:49 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -381,11 +381,14 @@ type Server {
 
 """Server information and configuration."""
 type ServerInfo {
+  membership: ServerInfoMembership!
   cartridge: ServerInfoCartridge!
+  replication: ServerInfoReplication!
   storage: ServerInfoStorage!
   network: ServerInfoNetwork!
   general: ServerInfoGeneral!
-  replication: ServerInfoReplication!
+  vshard_storage: ServerInfoVshardStorage
+  vshard_router: ServerInfoVshardRouter
 }
 
 type ServerInfoCartridge {
@@ -440,6 +443,31 @@ type ServerInfoGeneral {
   memtx_dir: String
 }
 
+type ServerInfoMembership {
+  """Direct ping period"""
+  PROTOCOL_PERIOD_SECONDS: Float
+
+  """Number of members to ping a suspect indirectly"""
+  NUM_FAILURE_DETECTION_SUBGROUPS: Int
+
+  """
+  Value incremented every time the instance became a suspect, dead, or updates its payload
+  """
+  incarnation: Int
+
+  """Status of the instance"""
+  status: String
+
+  """ACK message wait time"""
+  ACK_TIMEOUT_SECONDS: Float
+
+  """Timeout to mark a suspect dead"""
+  SUSPECT_TIMEOUT_SECONDS: Float
+
+  """Anti-entropy synchronization period"""
+  ANTI_ENTROPY_PERIOD_SECONDS: Float
+}
+
 type ServerInfoNetwork {
   io_collect_interval: Float
   readahead: Long
@@ -483,6 +511,44 @@ type ServerInfoStorage {
   vinyl_write_threads: Int
   vinyl_read_threads: Int
   wal_dir_rescan_delay: Float
+}
+
+type ServerInfoVshardRouter {
+  """The number of buckets unknown to the router"""
+  buckets_unknown: Int
+
+  """
+  The number of buckets known to the router and available for read and write requests
+  """
+  buckets_available_rw: Int
+
+  """
+  The number of buckets known to the router and available for read requests
+  """
+  buckets_available_ro: Int
+
+  """The number of buckets whose replica sets are not known to the router"""
+  buckets_unreachable: Int
+}
+
+type ServerInfoVshardStorage {
+  """The number of buckets that are sending at this time"""
+  buckets_sending: Int
+
+  """The number of buckets that are waiting to be collected by GC"""
+  buckets_garbage: Int
+
+  """Total number of buckets on the storage"""
+  buckets_total: Int
+
+  """The number of active buckets on the storage"""
+  buckets_active: Int
+
+  """The number of pinned buckets on the storage"""
+  buckets_pinned: Int
+
+  """The number of buckets that are receiving at this time"""
+  buckets_receiving: Int
 }
 
 """A short server information"""

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Fri Jul 30 2021 15:57:49 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Aug 02 2021 16:34:34 GMT+0300 (Москва, стандартное время)
 
 """Cluster management"""
 type Apicluster {
@@ -514,21 +514,7 @@ type ServerInfoStorage {
 }
 
 type ServerInfoVshardRouter {
-  """The number of buckets unknown to the router"""
-  buckets_unknown: Int
-
-  """
-  The number of buckets known to the router and available for read and write requests
-  """
-  buckets_available_rw: Int
-
-  """
-  The number of buckets known to the router and available for read requests
-  """
-  buckets_available_ro: Int
-
-  """The number of buckets whose replica sets are not known to the router"""
-  buckets_unreachable: Int
+  routers: [VshardRouter]
 }
 
 type ServerInfoVshardStorage {
@@ -541,11 +527,14 @@ type ServerInfoVshardStorage {
   """Total number of buckets on the storage"""
   buckets_total: Int
 
-  """The number of active buckets on the storage"""
-  buckets_active: Int
+  """Vshard group"""
+  vshard_group: String
 
   """The number of pinned buckets on the storage"""
   buckets_pinned: Int
+
+  """The number of active buckets on the storage"""
+  buckets_active: Int
 
   """The number of buckets that are receiving at this time"""
   buckets_receiving: Int
@@ -692,4 +681,12 @@ type VshardGroup {
 
   """Scheduler bucket move quota"""
   sched_move_quota: Long!
+}
+
+type VshardRouter {
+  buckets_unknown: Int
+  buckets_available_rw: Int
+  vshard_group: String
+  buckets_available_ro: Int
+  buckets_unreachable: Int
 }

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Tue Aug 03 2021 16:33:22 GMT+0300 (Москва, стандартное время)
+# timestamp: Thu Aug 05 2021 14:38:50 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -682,9 +682,24 @@ type VshardGroup {
 }
 
 type VshardRouter {
+  """The number of buckets whose replica sets are not known to the router"""
   buckets_unknown: Int
+
+  """
+  The number of buckets known to the router and available for read and write requests
+  """
   buckets_available_rw: Int
+
+  """Vshard group"""
   vshard_group: String
-  buckets_available_ro: Int
+
+  """
+  The number of buckets known to the router but unavailable for any requests
+  """
   buckets_unreachable: Int
+
+  """
+  The number of buckets known to the router and available for read requests
+  """
+  buckets_available_ro: Int
 }

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -259,6 +259,15 @@ function g.test_server_info_schema()
             cartridge_fields: __type(name: "ServerInfoCartridge") {
                 fields { name }
             }
+            vshard_router_fields: __type(name: "ServerInfoVshardRouter") {
+                fields { name }
+            }
+            vshard_storage_fields: __type(name: "ServerInfoVshardStorage") {
+                fields { name }
+            }
+            membership_fields: __type(name: "ServerInfoMembership") {
+                fields { name }
+            }
         }]]
     })
 
@@ -268,6 +277,9 @@ function g.test_server_info_schema()
     local field_name_network = fields_from_map(data['network_fields'], 'name')
     local field_name_replica = fields_from_map(data['replication_fields'], 'name')
     local field_name_cartridge = fields_from_map(data['cartridge_fields'], 'name')
+    local field_name_vshard_router = fields_from_map(data['vshard_router_fields'], 'name')
+    local field_name_vshard_storage = fields_from_map(data['vshard_storage_fields'], 'name')
+    local field_name_membership = fields_from_map(data['membership_fields'], 'name')
 
     local query = string.format(
             [[
@@ -279,6 +291,9 @@ function g.test_server_info_schema()
                             network { %s }
                             replication { %s }
                             cartridge { %s }
+                            vshard_router { %s }
+                            vshard_storage { %s }
+                            membership { %s }
                         }
                     }
                 }
@@ -287,7 +302,10 @@ function g.test_server_info_schema()
             table.concat(field_name_storage, ' '),
             table.concat(field_name_network, ' '),
             table.concat(field_name_replica, ' '),
-            table.concat(field_name_cartridge, ' '))
+            table.concat(field_name_cartridge, ' '),
+            table.concat(field_name_vshard_router, ' '),
+            table.concat(field_name_vshard_storage, ' '),
+            table.concat(field_name_membership, ' '))
             -- workaround composite graphql type
                 :gsub('error', 'error { message }')
                 :gsub('replication_info', 'replication_info { id }')

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -277,7 +277,6 @@ function g.test_server_info_schema()
     local field_name_network = fields_from_map(data['network_fields'], 'name')
     local field_name_replica = fields_from_map(data['replication_fields'], 'name')
     local field_name_cartridge = fields_from_map(data['cartridge_fields'], 'name')
-    local field_name_vshard_router = fields_from_map(data['vshard_router_fields'], 'name')
     local field_name_vshard_storage = fields_from_map(data['vshard_storage_fields'], 'name')
     local field_name_membership = fields_from_map(data['membership_fields'], 'name')
 
@@ -291,7 +290,6 @@ function g.test_server_info_schema()
                             network { %s }
                             replication { %s }
                             cartridge { %s }
-                            vshard_router { %s }
                             vshard_storage { %s }
                             membership { %s }
                         }
@@ -303,7 +301,6 @@ function g.test_server_info_schema()
             table.concat(field_name_network, ' '),
             table.concat(field_name_replica, ' '),
             table.concat(field_name_cartridge, ' '),
-            table.concat(field_name_vshard_router, ' '),
             table.concat(field_name_vshard_storage, ' '),
             table.concat(field_name_membership, ' '))
             -- workaround composite graphql type

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -392,7 +392,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = {routers = box.NULL},
+                vshard_router = box.NULL,
                 vshard_storage = {buckets_active = 3000},
             },
         }, {
@@ -407,7 +407,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = {routers = box.NULL},
+                vshard_router = box.NULL,
                 vshard_storage = {buckets_active = 3000},
             },
         }, {

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -360,7 +360,12 @@ function g.test_servers()
                     priority
                     replicaset { roles }
                     statistics { vshard_buckets_count }
-                    boxinfo { cartridge { state error { message class_name } } }
+                    boxinfo {
+                        cartridge { state error { message class_name } }
+                        membership { status }
+                        vshard_router { buckets_unreachable }
+                        vshard_storage { buckets_active }
+                    }
                 }
             }
         ]]
@@ -375,7 +380,12 @@ function g.test_servers()
             disabled = false,
             statistics = {vshard_buckets_count = box.NULL},
             replicaset = {roles = {'vshard-router'}},
-            boxinfo = {cartridge = {error = box.NULL, state = "RolesConfigured"}},
+            boxinfo = {
+                cartridge = {error = box.NULL, state = "RolesConfigured"},
+                membership = {status = 'alive'},
+                vshard_router = {buckets_unreachable = 0},
+                vshard_storage = box.NULL,
+            },
         }, {
             uri = 'localhost:13302',
             uuid = helpers.uuid('b', 'b', 1),
@@ -385,7 +395,12 @@ function g.test_servers()
             disabled = false,
             statistics = {vshard_buckets_count = 3000},
             replicaset = {roles = {'vshard-storage'}},
-            boxinfo = {cartridge = {error = box.NULL, state = "RolesConfigured"}},
+            boxinfo = {
+                cartridge = {error = box.NULL, state = "RolesConfigured"},
+                membership = {status = 'alive'},
+                vshard_router = box.NULL,
+                vshard_storage = {buckets_active = 3000},
+            },
         }, {
             uri = 'localhost:13304',
             uuid = helpers.uuid('b', 'b', 2),
@@ -395,7 +410,12 @@ function g.test_servers()
             disabled = false,
             statistics = {vshard_buckets_count = 3000},
             replicaset = {roles = {'vshard-storage'}},
-            boxinfo = {cartridge = {error = box.NULL, state = "RolesConfigured"}},
+            boxinfo = {
+                cartridge = {error = box.NULL, state = "RolesConfigured"},
+                membership = {status = 'alive'},
+                vshard_router = box.NULL,
+                vshard_storage = {buckets_active = 3000},
+            },
         }, {
             uri = 'localhost:13303',
             uuid = '',

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -357,7 +357,7 @@ function g.test_servers()
                     boxinfo {
                         cartridge { state error { message class_name } }
                         membership { status }
-                        vshard_router { routers { buckets_unreachable } }
+                        vshard_router { buckets_unreachable }
                         vshard_storage { buckets_active }
                     }
                 }
@@ -377,7 +377,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = {routers = {{buckets_unreachable = 0}}},
+                vshard_router = {{ buckets_unreachable = 0 }},
                 vshard_storage = box.NULL,
             },
         }, {

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -259,9 +259,6 @@ function g.test_server_info_schema()
             cartridge_fields: __type(name: "ServerInfoCartridge") {
                 fields { name }
             }
-            vshard_router_fields: __type(name: "ServerInfoVshardRouter") {
-                fields { name }
-            }
             vshard_storage_fields: __type(name: "ServerInfoVshardStorage") {
                 fields { name }
             }
@@ -360,7 +357,7 @@ function g.test_servers()
                     boxinfo {
                         cartridge { state error { message class_name } }
                         membership { status }
-                        vshard_router { buckets_unreachable }
+                        vshard_router { routers { buckets_unreachable } }
                         vshard_storage { buckets_active }
                     }
                 }
@@ -380,7 +377,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = {buckets_unreachable = 0},
+                vshard_router = {routers = {{buckets_unreachable = 0}}},
                 vshard_storage = box.NULL,
             },
         }, {
@@ -395,7 +392,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = box.NULL,
+                vshard_router = {routers = box.NULL},
                 vshard_storage = {buckets_active = 3000},
             },
         }, {
@@ -410,7 +407,7 @@ function g.test_servers()
             boxinfo = {
                 cartridge = {error = box.NULL, state = "RolesConfigured"},
                 membership = {status = 'alive'},
-                vshard_router = box.NULL,
+                vshard_router = {routers = box.NULL},
                 vshard_storage = {buckets_active = 3000},
             },
         }, {

--- a/test/integration/multisharding_two_test.lua
+++ b/test/integration/multisharding_two_test.lua
@@ -152,6 +152,12 @@ function g.test_api()
                 rebalancer_disbalance_threshold
             }
         }
+        servers {
+            alias
+            boxinfo {
+                vshard_router { routers {vshard_group}}
+            }
+        }
     }]]}
 
     local res = g.cluster:server('router-1'):graphql(request)
@@ -161,6 +167,16 @@ function g.test_api()
     t.assert_equals(data['vshard_bucket_count'], 32000)
     t.assert_equals(data['vshard_known_groups'], {'cold', 'hot'})
     t.assert_equals(#data['vshard_groups'], 2)
+
+    local groups = res['data']['servers']
+    t.assert_equals(groups, {
+        {alias = 'storage-hot-1', boxinfo = {vshard_router = box.NULL}},
+        {alias = 'storage-cold-1', boxinfo = {vshard_router = box.NULL}},
+        {
+            alias = 'router-1',
+            boxinfo = {vshard_router = {routers = {{vshard_group = "cold"}, {vshard_group = "hot"}}}},
+        },
+    })
 
     local expected_map = {
         ['name'] = 'cold',
@@ -206,7 +222,6 @@ function g.test_api()
         }
     })
 end
-
 
 function g.test_mutations()
     local ruuid_cold = g.cluster:server('storage-cold-1').replicaset_uuid

--- a/test/integration/multisharding_two_test.lua
+++ b/test/integration/multisharding_two_test.lua
@@ -155,7 +155,7 @@ function g.test_api()
         servers {
             alias
             boxinfo {
-                vshard_router { routers {vshard_group}}
+                vshard_router { vshard_group }
             }
         }
     }]]}
@@ -174,7 +174,7 @@ function g.test_api()
         {alias = 'storage-cold-1', boxinfo = {vshard_router = box.NULL}},
         {
             alias = 'router-1',
-            boxinfo = {vshard_router = {routers = {{vshard_group = "cold"}, {vshard_group = "hot"}}}},
+            boxinfo = {vshard_router = {{vshard_group = "cold"}, {vshard_group = "hot"}}},
         },
     })
 

--- a/test/integration/vshardless_test.lua
+++ b/test/integration/vshardless_test.lua
@@ -106,8 +106,8 @@ function g.test_api()
                 uuid
                 boxinfo {
                     general {instance_uuid}
-                    vshard_router { routers {buckets_unreachable}}
-                    vshard_storage {buckets_total}
+                    vshard_router { buckets_unreachable }
+                    vshard_storage { buckets_total }
                 }
             }
         }]]

--- a/test/integration/vshardless_test.lua
+++ b/test/integration/vshardless_test.lua
@@ -17,7 +17,7 @@ g.before_all = function()
         }},
     })
     g.cluster:start()
-    g.cluster.main_server:eval([[
+    g.cluster.main_server.net_box:eval([[
         package.preload['vshard'] = function()
             error('Requiring vshard is prohibited in this test', 0)
         end
@@ -106,7 +106,7 @@ function g.test_api()
                 uuid
                 boxinfo {
                     general {instance_uuid}
-                    vshard_router {buckets_unreachable}
+                    vshard_router { routers {buckets_unreachable}}
                     vshard_storage {buckets_total}
                 }
             }
@@ -123,7 +123,7 @@ function g.test_api()
         uuid = g.cluster.main_server.instance_uuid,
         boxinfo = {
             general = {instance_uuid = g.cluster.main_server.instance_uuid},
-            vshard_router = box.NULL,
+            vshard_router = { routers = box.NULL },
             vshard_storage = box.NULL,
         }
     }})

--- a/test/integration/vshardless_test.lua
+++ b/test/integration/vshardless_test.lua
@@ -123,7 +123,7 @@ function g.test_api()
         uuid = g.cluster.main_server.instance_uuid,
         boxinfo = {
             general = {instance_uuid = g.cluster.main_server.instance_uuid},
-            vshard_router = { routers = box.NULL },
+            vshard_router = box.NULL,
             vshard_storage = box.NULL,
         }
     }})

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -45,6 +45,9 @@ describe('Server details', () => {
     cy.get('.meta-test__ServerDetailsModal button').contains('Storage').click();
     cy.get('.meta-test__ServerDetailsModal button').contains('Network').click();
     cy.get('.meta-test__ServerDetailsModal button').contains('General').click();
+    cy.get('.meta-test__ServerDetailsModal button').contains('Membership').click();
+    cy.get('.meta-test__ServerDetailsModal button').contains('Vshard-Router').click();
+    cy.get('.meta-test__ServerDetailsModal button').contains('Vshard-Storage').click();
     cy.get('.meta-test__ServerDetailsModal button').contains('Issues 0').click();
   };
 

--- a/webui/src/components/ServerDetailsModal/ServerDetailsModalStatTab.js
+++ b/webui/src/components/ServerDetailsModal/ServerDetailsModalStatTab.js
@@ -16,7 +16,7 @@ const styles = {
     padding: 8px 20px;
 
     &:nth-child(2n) {
-      background-color: #fafafa; 
+      background-color: #fafafa;
     }
   `,
   leftCol: css`

--- a/webui/src/components/ServerDetailsModal/ServerDetailsModalStatTab.js
+++ b/webui/src/components/ServerDetailsModal/ServerDetailsModalStatTab.js
@@ -38,7 +38,8 @@ const styles = {
 const fieldsDisplayTypes = {
   replication_info: 'json',
   ro: 'boolean',
-  replication_skip_conflict: 'boolean'
+  replication_skip_conflict: 'boolean',
+  routers: 'json',
 };
 
 const renderers = {

--- a/webui/src/components/ServerDetailsModal/ServerDetailsModalVshardRouterTab.js
+++ b/webui/src/components/ServerDetailsModal/ServerDetailsModalVshardRouterTab.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Text, colors } from '@tarantool.io/ui-kit';
+import CollapsibleJSONRenderer from './CollapsibleJSONRenderer';
+import { css } from '@emotion/css';
+
+const styles = {
+  wrap: css`
+    padding: 20px 0;
+  `,
+  subtitle: css`
+    margin-bottom: 7px;
+  `,
+  listItem: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    padding: 8px 20px;
+
+    &:nth-child(2n) {
+      background-color: #fafafa;
+    }
+  `,
+  leftCol: css`
+    display: flex;
+    flex-direction: column;
+    max-width: 50%;
+  `,
+  rightCol: css`
+    max-width: 50%;
+  `,
+  subColumnContent: css`
+    width: 100%;
+  `,
+  description: css`
+    color: ${colors.dark40};
+  `
+};
+
+const renderers = value => (
+  <div className={styles.rightCol}>
+    <Text variant='basic'>
+      {value instanceof Array ? `[${value.join(', ')}]` : value}
+    </Text>
+  </div>
+);
+
+const ServerDetailsModalStatTab = ({ descriptions = {}, paramsArr = [] }) => {
+  return (
+    <div className={styles.wrap}>
+      {paramsArr.map(({ name, params }) => (
+        <div>
+          <Text className={styles.subtitle} variant='h5'>vshard group: {name}</Text>
+          <div>
+            {params.map(({ name, value }) => (
+              <div className={styles.listItem}>
+                <div className={styles.leftCol}>
+                  <Text variant='basic'>{name}</Text>
+                  {descriptions[name]
+                    ? (
+                      <Text variant='basic' className={styles.description}>
+                        {descriptions[name]}
+                      </Text>
+                    )
+                    : null}
+                </div>
+                {renderers(value)}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const mapStateToProps = (
+  {
+    clusterInstancePage: {
+      boxinfo,
+      descriptions
+    }
+  },
+  { sectionName }
+) => {
+  const section = (boxinfo && boxinfo[sectionName]) || [];
+
+  return {
+    descriptions: descriptions[sectionName],
+    paramsArr: Object.entries(section)
+      .map(([ _, sec ]) => {
+        return {
+          name: sec.vshard_group,
+          params: Object.entries(sec)
+            .filter(([ name ]) => name !== 'vshard_group')
+            .map(([name, value]) => ({ name, value }))
+        }
+      })
+  }
+};
+
+export default connect(mapStateToProps)(ServerDetailsModalStatTab);
+

--- a/webui/src/components/ServerDetailsModal/index.js
+++ b/webui/src/components/ServerDetailsModal/index.js
@@ -30,6 +30,7 @@ import {
 import store from 'src/store/instance';
 import { failoverPromoteLeader } from 'src/store/actions/clusterPage.actions';
 import ServerDetailsModalStatTab from './ServerDetailsModalStatTab'
+import ServerDetailsModalVshardRouterTab from './ServerDetailsModalVshardRouterTab'
 import { ServerDetailsModalIssues } from './ServerDetailsModalIssues'
 import { HealthStatus } from '../HealthStatus';
 import { ServerDropdown } from '../ServerDropdown';
@@ -43,6 +44,9 @@ const styles = {
     display: flex;
     justify-content: space-between;
     margin-bottom: 21px;
+  `,
+  modal: css`
+    max-width: 1050px;
   `,
   flag: css`
     margin-left: 20px;
@@ -183,7 +187,7 @@ class ServerDetailsModal extends React.Component<
 
     return (
       <Modal
-        className='meta-test__ServerDetailsModal'
+        className={cx('meta-test__ServerDetailsModal', styles.modal)}
         title={<>
           <span className={styles.headingWidthLimit}>{alias || instanceUUID}</span>
           {(master || activeMaster) && (
@@ -301,7 +305,7 @@ class ServerDetailsModal extends React.Component<
               })),
               {
                 label: 'Vshard-Router',
-                content: (<ServerDetailsModalStatTab sectionName={'vshard_router'} />)
+                content: (<ServerDetailsModalVshardRouterTab sectionName={'vshard_router'} />)
               },
               {
                 label: 'Vshard-Storage',

--- a/webui/src/components/ServerDetailsModal/index.js
+++ b/webui/src/components/ServerDetailsModal/index.js
@@ -118,7 +118,7 @@ type ServerDetailsModalProps = {
   history: History,
   ro?: boolean,
   zone: ?string,
-  zoneList: string[]
+  zoneList: string[],
 }
 
 type ServerDetailsModalState = {
@@ -138,7 +138,10 @@ class ServerDetailsModal extends React.Component<
     'cartridge',
     'replication',
     'storage',
-    'network'
+    'network',
+    'membership',
+    // 'vshard_router',
+    // 'vshard_storage',
   ];
 
   componentDidMount() {
@@ -172,7 +175,7 @@ class ServerDetailsModal extends React.Component<
       uri,
       ro,
       zone,
-      zoneList
+      zoneList,
     } = this.props
 
     const activeMaster = instanceUUID === activeMasterUUID;
@@ -299,9 +302,17 @@ class ServerDetailsModal extends React.Component<
                 content: (<ServerDetailsModalStatTab sectionName={section}/>)
               })),
               {
+                label: 'Vshard-Router',
+                content: (<ServerDetailsModalStatTab sectionName={'vshard_router'} />)
+              },
+              {
+                label: 'Vshard-Storage',
+                content: (<ServerDetailsModalStatTab sectionName={'vshard_storage'} />)
+              },
+              {
                 label: 'Issues ' + issues.length,
                 content: <ServerDetailsModalIssues issues={issues} />
-              }
+              },
             ]
           }
         />

--- a/webui/src/components/ServerDetailsModal/index.js
+++ b/webui/src/components/ServerDetailsModal/index.js
@@ -140,8 +140,6 @@ class ServerDetailsModal extends React.Component<
     'storage',
     'network',
     'membership',
-    // 'vshard_router',
-    // 'vshard_storage',
   ];
 
   componentDidMount() {

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -782,11 +782,16 @@ export type VshardGroup = {|
 
 export type VshardRouter = {|
   __typename?: 'VshardRouter',
+  /** The number of buckets whose replica sets are not known to the router */
   buckets_unknown?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets known to the router and available for read and write requests */
   buckets_available_rw?: ?$ElementType<Scalars, 'Int'>,
+  /** Vshard group */
   vshard_group?: ?$ElementType<Scalars, 'String'>,
-  buckets_available_ro?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets known to the router but unavailable for any requests */
   buckets_unreachable?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets known to the router and available for read requests */
+  buckets_available_ro?: ?$ElementType<Scalars, 'Int'>,
 |};
 
 type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;
@@ -888,6 +893,15 @@ export type ServerDetailsFieldsFragment = ({
     ...{| cartridge: ({
         ...{ __typename?: 'ServerInfoCartridge' },
       ...$Pick<ServerInfoCartridge, {| version: * |}>
+    }), membership: ({
+        ...{ __typename?: 'ServerInfoMembership' },
+      ...$Pick<ServerInfoMembership, {| status?: *, incarnation?: *, PROTOCOL_PERIOD_SECONDS?: *, ACK_TIMEOUT_SECONDS?: *, ANTI_ENTROPY_PERIOD_SECONDS?: *, SUSPECT_TIMEOUT_SECONDS?: *, NUM_FAILURE_DETECTION_SUBGROUPS?: * |}>
+    }), vshard_router?: ?Array<?({
+        ...{ __typename?: 'VshardRouter' },
+      ...$Pick<VshardRouter, {| vshard_group?: *, buckets_unreachable?: *, buckets_available_ro?: *, buckets_unknown?: *, buckets_available_rw?: * |}>
+    })>, vshard_storage?: ?({
+        ...{ __typename?: 'ServerInfoVshardStorage' },
+      ...$Pick<ServerInfoVshardStorage, {| vshard_group?: *, buckets_receiving?: *, buckets_active?: *, buckets_total?: *, buckets_garbage?: *, buckets_pinned?: *, buckets_sending?: * |}>
     }), network: ({
         ...{ __typename?: 'ServerInfoNetwork' },
       ...$Pick<ServerInfoNetwork, {| io_collect_interval?: *, net_msg_max?: *, readahead?: * |}>

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -540,11 +540,14 @@ export type Server = {|
 /** Server information and configuration. */
 export type ServerInfo = {|
   __typename?: 'ServerInfo',
+  membership: ServerInfoMembership,
   cartridge: ServerInfoCartridge,
+  replication: ServerInfoReplication,
   storage: ServerInfoStorage,
   network: ServerInfoNetwork,
   general: ServerInfoGeneral,
-  replication: ServerInfoReplication,
+  vshard_storage?: ?ServerInfoVshardStorage,
+  vshard_router?: ?ServerInfoVshardRouter,
 |};
 
 export type ServerInfoCartridge = {|
@@ -586,6 +589,24 @@ export type ServerInfoGeneral = {|
   replicaset_uuid: $ElementType<Scalars, 'String'>,
   /** A directory where memtx stores snapshot (.snap) files */
   memtx_dir?: ?$ElementType<Scalars, 'String'>,
+|};
+
+export type ServerInfoMembership = {|
+  __typename?: 'ServerInfoMembership',
+  /** Direct ping period */
+  PROTOCOL_PERIOD_SECONDS?: ?$ElementType<Scalars, 'Float'>,
+  /** Number of members to ping a suspect indirectly */
+  NUM_FAILURE_DETECTION_SUBGROUPS?: ?$ElementType<Scalars, 'Int'>,
+  /** Value incremented every time the instance became a suspect, dead, or updates its payload */
+  incarnation?: ?$ElementType<Scalars, 'Int'>,
+  /** Status of the instance */
+  status?: ?$ElementType<Scalars, 'String'>,
+  /** ACK message wait time */
+  ACK_TIMEOUT_SECONDS?: ?$ElementType<Scalars, 'Float'>,
+  /** Timeout to mark a suspect dead */
+  SUSPECT_TIMEOUT_SECONDS?: ?$ElementType<Scalars, 'Float'>,
+  /** Anti-entropy synchronization period */
+  ANTI_ENTROPY_PERIOD_SECONDS?: ?$ElementType<Scalars, 'Float'>,
 |};
 
 export type ServerInfoNetwork = {|
@@ -630,6 +651,34 @@ export type ServerInfoStorage = {|
   vinyl_write_threads?: ?$ElementType<Scalars, 'Int'>,
   vinyl_read_threads?: ?$ElementType<Scalars, 'Int'>,
   wal_dir_rescan_delay?: ?$ElementType<Scalars, 'Float'>,
+|};
+
+export type ServerInfoVshardRouter = {|
+  __typename?: 'ServerInfoVshardRouter',
+  /** The number of buckets unknown to the router */
+  buckets_unknown?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets known to the router and available for read and write requests */
+  buckets_available_rw?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets known to the router and available for read requests */
+  buckets_available_ro?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets whose replica sets are not known to the router */
+  buckets_unreachable?: ?$ElementType<Scalars, 'Int'>,
+|};
+
+export type ServerInfoVshardStorage = {|
+  __typename?: 'ServerInfoVshardStorage',
+  /** The number of buckets that are sending at this time */
+  buckets_sending?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets that are waiting to be collected by GC */
+  buckets_garbage?: ?$ElementType<Scalars, 'Int'>,
+  /** Total number of buckets on the storage */
+  buckets_total?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of active buckets on the storage */
+  buckets_active?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of pinned buckets on the storage */
+  buckets_pinned?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of buckets that are receiving at this time */
+  buckets_receiving?: ?$ElementType<Scalars, 'Int'>,
 |};
 
 /** A short server information */
@@ -870,6 +919,24 @@ export type InstanceDataQuery = ({
       ...{ __typename?: 'Server' },
     ...ServerDetailsFieldsFragment
   })>, descriptionCartridge?: ?({
+      ...{ __typename?: '__Type' },
+    ...{| fields?: ?Array<({
+        ...{ __typename?: '__Field' },
+      ...$Pick<__Field, {| name: *, description?: * |}>
+    })> |}
+  }), descriptionMembership?: ?({
+      ...{ __typename?: '__Type' },
+    ...{| fields?: ?Array<({
+        ...{ __typename?: '__Field' },
+      ...$Pick<__Field, {| name: *, description?: * |}>
+    })> |}
+  }), descriptionVshardRouter?: ?({
+      ...{ __typename?: '__Type' },
+    ...{| fields?: ?Array<({
+        ...{ __typename?: '__Field' },
+      ...$Pick<__Field, {| name: *, description?: * |}>
+    })> |}
+  }), descriptionVshardStorage?: ?({
       ...{ __typename?: '__Type' },
     ...{| fields?: ?Array<({
         ...{ __typename?: '__Field' },

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -655,14 +655,7 @@ export type ServerInfoStorage = {|
 
 export type ServerInfoVshardRouter = {|
   __typename?: 'ServerInfoVshardRouter',
-  /** The number of buckets unknown to the router */
-  buckets_unknown?: ?$ElementType<Scalars, 'Int'>,
-  /** The number of buckets known to the router and available for read and write requests */
-  buckets_available_rw?: ?$ElementType<Scalars, 'Int'>,
-  /** The number of buckets known to the router and available for read requests */
-  buckets_available_ro?: ?$ElementType<Scalars, 'Int'>,
-  /** The number of buckets whose replica sets are not known to the router */
-  buckets_unreachable?: ?$ElementType<Scalars, 'Int'>,
+  routers?: ?Array<?VshardRouter>,
 |};
 
 export type ServerInfoVshardStorage = {|
@@ -673,10 +666,12 @@ export type ServerInfoVshardStorage = {|
   buckets_garbage?: ?$ElementType<Scalars, 'Int'>,
   /** Total number of buckets on the storage */
   buckets_total?: ?$ElementType<Scalars, 'Int'>,
-  /** The number of active buckets on the storage */
-  buckets_active?: ?$ElementType<Scalars, 'Int'>,
+  /** Vshard group */
+  vshard_group?: ?$ElementType<Scalars, 'String'>,
   /** The number of pinned buckets on the storage */
   buckets_pinned?: ?$ElementType<Scalars, 'Int'>,
+  /** The number of active buckets on the storage */
+  buckets_active?: ?$ElementType<Scalars, 'Int'>,
   /** The number of buckets that are receiving at this time */
   buckets_receiving?: ?$ElementType<Scalars, 'Int'>,
 |};
@@ -787,6 +782,15 @@ export type VshardGroup = {|
   name: $ElementType<Scalars, 'String'>,
   /** Scheduler bucket move quota */
   sched_move_quota: $ElementType<Scalars, 'Long'>,
+|};
+
+export type VshardRouter = {|
+  __typename?: 'VshardRouter',
+  buckets_unknown?: ?$ElementType<Scalars, 'Int'>,
+  buckets_available_rw?: ?$ElementType<Scalars, 'Int'>,
+  vshard_group?: ?$ElementType<Scalars, 'String'>,
+  buckets_available_ro?: ?$ElementType<Scalars, 'Int'>,
+  buckets_unreachable?: ?$ElementType<Scalars, 'Int'>,
 |};
 
 type $Pick<Origin: Object, Keys: Object> = $ObjMapi<Keys, <Key>(k: Key) => $ElementType<Origin, Key>>;

--- a/webui/src/generated/graphql-typing.js
+++ b/webui/src/generated/graphql-typing.js
@@ -547,7 +547,8 @@ export type ServerInfo = {|
   network: ServerInfoNetwork,
   general: ServerInfoGeneral,
   vshard_storage?: ?ServerInfoVshardStorage,
-  vshard_router?: ?ServerInfoVshardRouter,
+  /** List of vshard router parameters */
+  vshard_router?: ?Array<?VshardRouter>,
 |};
 
 export type ServerInfoCartridge = {|
@@ -651,11 +652,6 @@ export type ServerInfoStorage = {|
   vinyl_write_threads?: ?$ElementType<Scalars, 'Int'>,
   vinyl_read_threads?: ?$ElementType<Scalars, 'Int'>,
   wal_dir_rescan_delay?: ?$ElementType<Scalars, 'Float'>,
-|};
-
-export type ServerInfoVshardRouter = {|
-  __typename?: 'ServerInfoVshardRouter',
-  routers?: ?Array<?VshardRouter>,
 |};
 
 export type ServerInfoVshardStorage = {|

--- a/webui/src/store/request/clusterInstancePage.requests.js
+++ b/webui/src/store/request/clusterInstancePage.requests.js
@@ -15,7 +15,10 @@ export function getInstanceData({ instanceUUID }) {
       descriptionGeneral,
       descriptionNetwork,
       descriptionReplication,
-      descriptionStorage
+      descriptionStorage,
+      descriptionMembership,
+      descriptionVshardRouter,
+      descriptionVshardStorage,
     }) => {
       const {
         alias,
@@ -50,7 +53,10 @@ export function getInstanceData({ instanceUUID }) {
           general: descriptionsByName(descriptionGeneral),
           network: descriptionsByName(descriptionNetwork),
           replication: descriptionsByName(descriptionReplication),
-          storage: descriptionsByName(descriptionStorage)
+          storage: descriptionsByName(descriptionStorage),
+          membership: descriptionsByName(descriptionMembership),
+          vshard_router: descriptionsByName(descriptionVshardRouter),
+          vshard_storage: descriptionsByName(descriptionVshardStorage),
         }
       }
     });

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -127,12 +127,16 @@ export const serverDetailsFields = gql`
           NUM_FAILURE_DETECTION_SUBGROUPS
         }
         vshard_router {
-          buckets_unreachable
-          buckets_available_ro
-          buckets_unknown
-          buckets_available_rw
+          routers {
+            vshard_group
+            buckets_unreachable
+            buckets_available_ro
+            buckets_unknown
+            buckets_available_rw
+          }
         }
         vshard_storage {
+          vshard_group
           buckets_receiving
           buckets_active
           buckets_total

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -217,7 +217,7 @@ export const firstServerDetailsQuery = gql`
         description
       }
     }
-    descriptionVshardRouter: __type(name: "ServerInfoVshardRouter") {
+    descriptionVshardRouter: __type(name: "VshardRouter") {
       fields {
         name
         description

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -117,6 +117,29 @@ export const serverDetailsFields = gql`
         cartridge {
           version
         }
+        membership {
+          status
+          incarnation
+          PROTOCOL_PERIOD_SECONDS
+          ACK_TIMEOUT_SECONDS
+          ANTI_ENTROPY_PERIOD_SECONDS
+          SUSPECT_TIMEOUT_SECONDS
+          NUM_FAILURE_DETECTION_SUBGROUPS
+        }
+        vshard_router {
+          buckets_unreachable
+          buckets_available_ro
+          buckets_unknown
+          buckets_available_rw
+        }
+        vshard_storage {
+          buckets_receiving
+          buckets_active
+          buckets_total
+          buckets_garbage
+          buckets_pinned
+          buckets_sending
+        }
         network {
           io_collect_interval
           net_msg_max
@@ -179,8 +202,26 @@ export const firstServerDetailsQuery = gql`
     servers(uuid: $uuid) {
       ...serverDetailsFields
     }
-    
+
     descriptionCartridge: __type(name: "ServerInfoCartridge") {
+      fields {
+        name
+        description
+      }
+    }
+    descriptionMembership: __type(name: "ServerInfoMembership") {
+      fields {
+        name
+        description
+      }
+    }
+    descriptionVshardRouter: __type(name: "ServerInfoVshardRouter") {
+      fields {
+        name
+        description
+      }
+    }
+    descriptionVshardStorage: __type(name: "ServerInfoVshardStorage") {
       fields {
         name
         description
@@ -291,7 +332,7 @@ query serverList ($withStats: Boolean!) {
         config_locked
         uuid
         operation_error
-      } 
+      }
       refine_uri {
         uuid
         uri_old
@@ -461,7 +502,7 @@ export const setFilesMutation = gql`
         filename
         content
       }
-    }  
+    }
   }
 `;
 
@@ -479,7 +520,7 @@ export const disableServersMutation = gql`
 export const restartReplicationMutation = gql`
   mutation restart_replication($uuids: [String!]) {
     cluster {
-      restart_replication(uuids: $uuids) 
+      restart_replication(uuids: $uuids)
     }
   }
 `;

--- a/webui/src/store/request/queries.graphql.js
+++ b/webui/src/store/request/queries.graphql.js
@@ -127,13 +127,11 @@ export const serverDetailsFields = gql`
           NUM_FAILURE_DETECTION_SUBGROUPS
         }
         vshard_router {
-          routers {
-            vshard_group
-            buckets_unreachable
-            buckets_available_ro
-            buckets_unknown
-            buckets_available_rw
-          }
+          vshard_group
+          buckets_unreachable
+          buckets_available_ro
+          buckets_unknown
+          buckets_available_rw
         }
         vshard_storage {
           vshard_group


### PR DESCRIPTION
Introduce 3 new tabs in server details dialog:

## membership
![image](https://user-images.githubusercontent.com/2205188/128366005-e52afd52-724e-460c-8986-1218230e38c9.png)

## vshard-router
![image](https://user-images.githubusercontent.com/2205188/128365943-e2ed8b00-82c9-4fd0-a8c1-d041c8c4a133.png)

## vshard-storage
![image](https://user-images.githubusercontent.com/2205188/128366066-0704bb4e-5aba-4fb3-b87c-8c5a4455f1d4.png)

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] ~~Documentation~~

Close #1196
