### PR TITLE
Adjust consistency timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,7 @@ Fixed
 - Fix ``get_enabled_roles`` to work w/o args
 - Don't default to syslog driver unless ``/dev/log`` or
   ``/var/run/syslog`` are available.
+- Fix inappropriate consistency timeout.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -444,7 +444,7 @@ local function constitute_oneself(active_leaders, opts)
         local vclockkeeper_info, err = errors.netbox_call(
             pool.connect(vclockkeeper_uri, {wait_connected = false}),
             '__cartridge_failover_get_lsn', {timeout},
-            {timeout = timeout + vars.options.NETBOX_CALL_TIMEOUT}
+            {timeout = vars.options.NETBOX_CALL_TIMEOUT}
         )
         fiber.testcancel()
 

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -71,7 +71,7 @@ do
 end
 vars:new('options', {
     WAITLSN_PAUSE = 0.2,
-    WAITLSN_TIMEOUT = 3,
+    WAITLSN_TIMEOUT = 3, -- One may treat it as WAIT_CONSISTENCY_TIMEOUT
     LONGPOLL_TIMEOUT = 30,
     NETBOX_CALL_TIMEOUT = 1,
 })
@@ -443,8 +443,10 @@ local function constitute_oneself(active_leaders, opts)
         -- WARNING: implicit yield
         local vclockkeeper_info, err = errors.netbox_call(
             pool.connect(vclockkeeper_uri, {wait_connected = false}),
-            '__cartridge_failover_get_lsn', {timeout},
-            {timeout = vars.options.NETBOX_CALL_TIMEOUT}
+            -- get_lsn timeout may be negative. It's ok.
+            '__cartridge_failover_get_lsn', {timeout - vars.options.NETBOX_CALL_TIMEOUT},
+            -- wake up strictly before the deadline.
+            {timeout = timeout}
         )
         fiber.testcancel()
 


### PR DESCRIPTION
Failover may sleep waiting for a vclockkeeper. If an old vclockkeeper
was stopped and the current instance was promoted consistently, it'll
attempt to get old vclockkeepers info and subsequently fail. However,
it should react fast enough to the change of the vclockkeeper
(e.g. `force_inconsistency = true`).
```
    ## Before the patch

                               reconfigure_all():
    [------ 4 sec ------]        constitute_oneself():
    |                              get_vsckockkeeper
    [===================]          get_lsn
    
    0----1----2----3----4----5---- (t)
                      ^
      [---- 3 sec ----]        promote({force_inconsistency = true}):
      |                          get_coordinator (~0 sec)
      |                          force_inconsistency (~0 sec)
      [===============]          wait_rw (3 sec)
                      X          "WaitRwError: timed out"
```
    
In the example above the vclockkeeper is unresponsive. Before the fix,
it would wait for ~7 seconds before fetching the correct vclockkeeper.
However, if during this wait user initiates inconsistent promotion with
a timeout of 3 seconds, `wait_rw` will fail with this timeout.
That's why `constitute_oneself + fiber_sleep` should have the same
period/timeout as `wait_rw`, which is `WAITLSN_TIMEOUT=3`.
```    
    ## After the patch (change get_lsn timeout calculus)
    
                               reconfigure_all():
    
    [---- 3 sec ---]             constitute_oneself():
    []                             get_vsckockkeeper (~0 sec)
     [=============]               get_lsn (till the deadline)
    
                   [-]           constitute_oneself()
                   []              get_vsckockkeeper (~0 sec)
                    []             set_vclockkeeper (~0 sec)
                     ^             become rw
    
    0----1----2----3----4----5---- (t)
    
      [---- 3 sec ----]        promote({force_inconsistency = true}):
      |                          get_coordinator (~0 sec)
      |                          force_inconsistency (~0 sec)
      [===============]          wait_rw (3 sec)
                     ^           "ok"
```

When `constitute_oneself + fiber_sleep` has a 3s period the gap when
instance deals with two different vclockkeepers is less than 3s. As a
result, `wait_rw` won't fail anymore since `constitute_oneself` gets
the actual vclockkeeper and sets instance to rw.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (unnecessary)

Close #1398 
