### PR TITLE
Update ui kit to version 0.40.0

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -24,7 +24,7 @@
         "@graphql-codegen/typescript-compatibility": "2.1.0",
         "@tarantool.io/frontend-core": "7.10.0",
         "@tarantool.io/lua-bundler-webpack-plugin": "^1.0.1",
-        "@tarantool.io/ui-kit": "0.39.1",
+        "@tarantool.io/ui-kit": "0.40.0",
         "apollo-boost": "0.4.0",
         "apollo-link-http": "1.5.17",
         "apollo-link-state": "0.4.2",
@@ -8172,9 +8172,9 @@
       }
     },
     "node_modules/@tarantool.io/ui-kit": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@tarantool.io/ui-kit/-/ui-kit-0.39.1.tgz",
-      "integrity": "sha512-lBULzbI/ILnUaQGkNRM7BrIckVfBOXaJO0zt2cWoSOpNcHvJx2F8vwPGqBMGEEV5cvlEooWPBSzrtjibW0jTOw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@tarantool.io/ui-kit/-/ui-kit-0.40.0.tgz",
+      "integrity": "sha512-0tuJ3oHpbJfY8WfW2pv0cjAIeFal0sWVXKqF3rFNZm33w8gmPkKBxwZMxQc6wFkgpjNwOjysRTN4oLyTM4cOQA==",
       "dependencies": {
         "@types/react-table": "7.0.23",
         "babel-jest": "25.4.0",
@@ -40984,9 +40984,9 @@
       }
     },
     "@tarantool.io/ui-kit": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@tarantool.io/ui-kit/-/ui-kit-0.39.1.tgz",
-      "integrity": "sha512-lBULzbI/ILnUaQGkNRM7BrIckVfBOXaJO0zt2cWoSOpNcHvJx2F8vwPGqBMGEEV5cvlEooWPBSzrtjibW0jTOw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@tarantool.io/ui-kit/-/ui-kit-0.40.0.tgz",
+      "integrity": "sha512-0tuJ3oHpbJfY8WfW2pv0cjAIeFal0sWVXKqF3rFNZm33w8gmPkKBxwZMxQc6wFkgpjNwOjysRTN4oLyTM4cOQA==",
       "requires": {
         "@types/react-table": "7.0.23",
         "babel-jest": "25.4.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -19,7 +19,7 @@
     "@graphql-codegen/typescript-compatibility": "2.1.0",
     "@tarantool.io/frontend-core": "7.10.0",
     "@tarantool.io/lua-bundler-webpack-plugin": "^1.0.1",
-    "@tarantool.io/ui-kit": "0.39.1",
+    "@tarantool.io/ui-kit": "0.40.0",
     "apollo-boost": "0.4.0",
     "apollo-link-http": "1.5.17",
     "apollo-link-state": "0.4.2",

--- a/webui/src/app/App.js
+++ b/webui/src/app/App.js
@@ -6,7 +6,7 @@ import { isRestErrorResponse, isRestAccessDeniedError } from 'src/api/rest';
 import { getErrorMessage } from 'src/api';
 import ClusterPage from 'src/pages/Cluster';
 import {
-  SplashErrorFatal
+  SplashError
 } from '@tarantool.io/ui-kit';
 
 class App extends React.Component {
@@ -48,7 +48,7 @@ class App extends React.Component {
     const description = getErrorMessage(error);
 
     return (
-      <SplashErrorFatal
+      <SplashError
         title={title}
         description={description}
       />

--- a/webui/src/components/PageDataErrorMessage/PageDataErrorMessage.js
+++ b/webui/src/components/PageDataErrorMessage/PageDataErrorMessage.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { getErrorMessage, isNetworkError } from 'src/api';
 import {
-  SplashErrorNetwork,
-  SplashErrorFatal
+  SplashError
 } from '@tarantool.io/ui-kit';
 
 const style = css`
@@ -19,17 +18,10 @@ class PageDataErrorMessage extends React.PureComponent {
 
     return (
       <div className={style}>
-        {isNetworkError(error)
-          ?
-          <SplashErrorNetwork
-            description={errorMessage}
-          />
-          :
-          <SplashErrorFatal
-            title={errorMessage}
-            description=''
-          />
-        }
+        <SplashError
+          title={isNetworkError(error) ? 'Network problem' : errorMessage}
+          description={isNetworkError(error) ?  errorMessage : ''}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## [0.40.0](https://github.com/tarantool/front-ui-kit/blob/0.40.0/CHANGELOG.md) - 2021-07-29

- Remove components `SplashErrorFatal` and `SplashErrorNetwork`
- Update default icon component `SplashError`
- Update styles component `NonIdealState`. Remove `isError` prop
- Update component `UploadZone` use new icon

Close https://github.com/tarantool/ux_ui/issues/88
