### PR TITLE
Add audit_log param to argparse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,6 +72,8 @@ Fixed
 - Don't default to syslog driver unless ``/dev/log`` or
   ``/var/run/syslog`` are available.
 - Fix inappropriate consistency timeout.
+- Support automatic parsing of Tarantool Enterprise box options `audit_log` and
+  `audit_nonblock`.
 
 -------------------------------------------------------------------------------
 [2.6.0] - 2021-04-26

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -126,7 +126,9 @@ local box_opts = {
     vinyl_bloom_fpr          = 'number', -- **number**
 
     log                      = 'string', -- **string**
+    audit_log                = 'string', -- **string**
     log_nonblock             = 'boolean', -- **boolean**
+    audit_nonblock           = 'boolean', -- **boolean**
     log_level                = 'number', -- **number**
     log_format               = 'string', -- **string**
     io_collect_interval      = 'number', -- **number**


### PR DESCRIPTION
It's necessary for the Tarantool Enterprise.

I didn't forget about

- [x] ~~Tests~~
- [x] Changelog
- [x] Documentation

Close #1508 
