### PR TITLE
Restore nightly tests

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -1,0 +1,53 @@
+name: Nightly Test
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+env:
+  # Skip building frontend in tarantoolctl rocks make
+  CMAKE_DUMMY_WEBUI: true
+  # Prerequisite for some etcd-related tests
+  ETCD_PATH: etcd-v2.3.8/etcd
+
+jobs:
+  run-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-18.04]
+        tarantool: ['1.10', '2.7', '2.8', '2.9']
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
+          nightly-build: true
+
+      # Setup etcd
+      - name: Install etcd
+        uses: ./.github/actions/setup-etcd
+        if: runner.os == 'Linux'
+        with:
+          etcd-version: v2.3.8
+          install-prefix: etcd-v2.3.8
+
+      # Setup luatest
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-luatest-rocks
+        with:
+          path: .rocks/
+          key: cache-luatest-rocks-${{ matrix.runs-on }}-${{ hashFiles('cartridge-scm-1.rockspec') }}
+          restore-keys: cache-luatest-rocks-${{ matrix.runs-on }}
+      -
+        run: tarantoolctl rocks install luatest 0.5.2
+        if: steps.cache-luatest-rocks.outputs.cache-hit != 'true'
+
+      - run: tarantoolctl rocks make
+      - run: .rocks/bin/luatest -v
+
+      # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge


### PR DESCRIPTION
Run nightly tests on tarantool 1.10, 2.7, 2.8 and 2.9. They are scheduled at 4am every day.

I didn't forget about

- [x] Tests
- [ ] Changelog
- [ ] Documentation

Close #1507 
