### PR TITLE
Update ddl to 1.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ Changed
 - Argparse throws an error when it encouters ``instance_name`` missing in
   instances.yml.
 - Update ``membership`` dependency to 2.4.0
+- Update ``ddl`` dependency to 1.5.0.
+  (`Changelog <https://github.com/tarantool/ddl/releases/tag/1.5.0>`__).
 - Update ``vshard`` to 0.1.18
   (`Changelog <https://github.com/tarantool/vshard/releases/tag/0.1.18>`__).
 

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,7 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
-    'ddl == 1.4.0-1',
+    'ddl == 1.5.0-1',
     'http == 1.1.0-1',
     'checks == 3.1.0-1',
     'errors == 2.2.0-1',

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -603,12 +603,10 @@ function g.test_operation_error()
         _G.apply_config_original = nil
     end)
 
-    t.assert_equals(
-        g.cluster.main_server:graphql({
-            query = '{cluster {config {filename content}}}'
-        }),
-        {data = {cluster = {config = {txt}}}}
-    )
+    local resp = g.cluster.main_server:graphql({
+        query = '{cluster {config {filename content}}}'
+    })
+    t.assert_items_include(resp.data.cluster.config, {txt})
 
     -- An attempt to reapply the same config shouldn't
     -- be skipped in the OperationError state

--- a/test/integration/config_test.lua
+++ b/test/integration/config_test.lua
@@ -27,6 +27,15 @@ g.before_all(function()
     })
     g.cluster:start()
 
+    -- Disable on_patch_trigger for the ddl-manager role
+    g.cluster.main_server.net_box:eval([[
+        require('cartridge.twophase').on_patch(nil,
+            _G._cluster_vars_values
+            ['cartridge.roles.ddl-manager']
+            .on_patch_trigger
+        )
+    ]])
+
     -- Make sure auth section exists in clusterwide config.
     -- It shouldn't be available for downloading via HTTP API
     g.cluster.main_server.net_box:eval([[

--- a/test/integration/force_reapply_test.lua
+++ b/test/integration/force_reapply_test.lua
@@ -83,7 +83,7 @@ function g.test_twophase_config_locked()
     t.assert_equals({ok, err}, {true, nil})
 
     t.assert_equals(helpers.list_cluster_issues(g.A1), {})
-    t.assert_equals(
+    t.assert_covers(
         g.cluster:download_config(),
         {['bye.txt'] = 'Goodbye, locks'}
     )

--- a/test/unit/helpers_test.lua
+++ b/test/unit/helpers_test.lua
@@ -53,10 +53,10 @@ end
 
 function g.test_config_management()
     g.cluster:upload_config({some_section = 'some_value'})
-    t.assert_equals(g.cluster:download_config(), {some_section = 'some_value'})
+    t.assert_covers(g.cluster:download_config(), {some_section = 'some_value'})
 
     g.cluster:upload_config(yaml.encode({another_section = 'some_value2'}))
-    t.assert_equals(g.cluster:download_config(), {another_section = 'some_value2'})
+    t.assert_covers(g.cluster:download_config(), {another_section = 'some_value2'})
 end
 
 function g.test_servers_access()

--- a/webui/cypress/integration/code-page.spec.js
+++ b/webui/cypress/integration/code-page.spec.js
@@ -271,7 +271,7 @@ describe('Code page', () => {
     cy.reload();
     cy.contains('Not loaded').should('not.exist');
     cy.get('.meta-test__Code__FileTree').contains('folder-in-folder').should('not.exist');
-    cy.get('.meta-test__Code__FileTree').contains('file-in-folder').should('exist');
+    cy.get('.meta-test__Code__FileTree').contains('file-in-folder').should('exist').click();
     cy.get('.meta-test__Code').contains('edited-folder-name / file-in-folder');
     cy.get('.monaco-editor textarea').should('have.value', 'new test code');
 


### PR DESCRIPTION
Subj: https://github.com/tarantool/ddl/pull/73

The tests are also updated: the ddl-manager role now puts an example schema in the clusterwide config.