### PR TITLE
Adjust tests for tarantool >2.8

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -175,4 +175,27 @@ function helpers.run_remotely(srv, fn)
     return ret
 end
 
+function helpers.tarantool_version_ge(version)
+    local function parse_version(version)
+        local version = version:split('-')[1]:split('.')
+        for ind, val in ipairs(version) do
+            version[ind] = tonumber(val)
+        end
+        return version
+    end
+
+    local tarantool_version = parse_version(_G._TARANTOOL)
+    local requested_version = parse_version(version)
+
+    for ind=1,3 do
+        if tarantool_version[ind] > requested_version[ind] then
+            return true
+        elseif tarantool_version[ind] < requested_version[ind] then
+            return false
+        end
+    end
+
+    return true
+end
+
 return helpers

--- a/test/integration/stateboard_test.lua
+++ b/test/integration/stateboard_test.lua
@@ -133,11 +133,14 @@ function g.test_appointments()
 
     local ok, err = c:set_leaders({{'A', 'a2'}, {'A', 'a3'}})
     t.assert_equals(ok, nil)
-    t.assert_covers(err, {
-        class_name = 'NetboxCallError',
-        err = '"localhost:13301": Duplicate key exists' ..
-        " in unique index 'ordinal' in space 'leader_audit'"
-    })
+    t.assert_equals(err.class_name, 'NetboxCallError')
+    if helpers.tarantool_version_ge('2.8.0') then
+        t.assert_str_contains(err.err, '"localhost:13301": Duplicate key exists' ..
+            ' in unique index "ordinal" in space "leader_audit"')
+    else
+        t.assert_str_contains(err.err, "\"localhost:13301\": Duplicate key exists" ..
+            " in unique index 'ordinal' in space 'leader_audit'")
+    end
 end
 
 function g.test_longpolling()


### PR DESCRIPTION
Take into account the tarantool version when asserting the "duplicate key" message (it's changed since 2.8).

Also, fix flaky `expel_test`.

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~

Close #1526
Close #1525 
