### PR TITLE
Add vshard issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Fixed
 - Eliminate unnecessary transactions after the restart before the replication
   sync. This reduces the chance the hardware restart leads to WAL corruption
   ([#1546](https://github.com/tarantool/cartridge/issues/1546)).
+- Extend GraphQL ``issues`` API with ``vshard`` topic which reflects vshard
+  router alerts.
 
 -------------------------------------------------------------------------------
 [2.7.1] - 2021-08-18

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -355,6 +355,35 @@ local function list_on_instance(opts)
         end
     end
 
+
+    -- Vshard issues
+    local vshard = package.loaded.vshard
+
+    if vshard then
+        local routers = vshard and vshard.router.internal.routers or {}
+        if next(routers) ~= nil then
+            for _, router in pairs(routers) do
+                local alerts = router:info().alerts
+                for _, alert in ipairs(alerts) do
+                    if alert[1] == 'UNKNOWN_BUCKETS'
+                    or alert[1] == 'INVALID_CFG'
+                    then
+                        local issue = {
+                            level = 'warning',
+                            topic = 'vshard',
+                            replicaset_uuid = replicaset_uuid,
+                            instance_uuid = instance_uuid,
+                            message = alert[2]
+                        }
+                        table.insert(ret, issue)
+                    end
+                end
+            end
+        end
+    end
+
+
+
     return ret
 end
 

--- a/cartridge/issues.lua
+++ b/cartridge/issues.lua
@@ -71,6 +71,7 @@ local topology = require('cartridge.topology')
 local failover = require('cartridge.failover')
 local confapplier = require('cartridge.confapplier')
 local lua_api_proxy = require('cartridge.lua-api.proxy')
+local vshard_utils = require('cartridge.vshard-utils')
 
 local ValidateConfigError = errors.new_class('ValidateConfigError')
 
@@ -369,6 +370,10 @@ local function list_on_instance(opts)
 
         local routers = vshard.router.internal.routers
         if routers == nil or next(routers) == nil then
+            goto continue
+        end
+
+        if not vshard_utils.is_bootstrapped() then
             goto continue
         end
 

--- a/cartridge/vshard-utils.lua
+++ b/cartridge/vshard-utils.lua
@@ -675,6 +675,24 @@ end
 
 twophase.on_patch(patch_zone_distances)
 
+local function is_bootstrapped()
+    if vars.bootstrapped ~= nil then
+        return vars.bootstrapped
+    end
+    if roles.get_role('vshard-router') == nil then
+        vars.bootstrapped = false
+        return false
+    end
+    local bootstrapped = true
+    for _, group in pairs(get_known_groups()) do
+        bootstrapped = bootstrapped and (group.bootstrapped == true)
+    end
+    if bootstrapped == true then
+        vars.bootstrapped = true
+    end
+    return vars.bootstrapped
+end
+
 return {
     validate_config = function(...)
         return ValidateConfigError:pcall(validate_config, ...)
@@ -685,6 +703,7 @@ return {
 
     get_vshard_config = get_vshard_config,
     can_bootstrap = can_bootstrap,
+    is_bootstrapped = is_bootstrapped,
     edit_vshard_options = edit_vshard_options,
     patch_zone_distances = patch_zone_distances,
 }

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -417,12 +417,14 @@ function g.test_vshard_buckets_invalid_cfg()
     ]])
 
     t.assert_covers(helpers.list_cluster_issues(g.master), {{
-        level = "warning",
-        message = "Invalid configuration: "..
-            "probably router's cfg.bucket_count is different from storages' one, difference is 500",
-        topic = "vshard",
+        level = 'warning',
+        topic = 'vshard',
         instance_uuid = g.cluster:server('router').instance_uuid,
         replicaset_uuid = g.cluster:server('router').replicaset_uuid,
+        message = 'VShard alert on localhost:13305 (router):' ..
+            " Invalid configuration:"..
+            " probably router's cfg.bucket_count is different" ..
+            " from storages' one, difference is 500",
     }})
 
 end
@@ -439,11 +441,12 @@ function g.test_vshard_buckets_not_discovered()
     ]], {g.cluster:server('master1').instance_uuid})
 
     t.assert_covers(helpers.list_cluster_issues(g.master), {{
-        level = "warning",
-        message = "3000 buckets are not discovered",
-        topic = "vshard",
+        level = 'warning',
+        topic = 'vshard',
         instance_uuid = g.cluster:server('router').instance_uuid,
         replicaset_uuid = g.cluster:server('router').replicaset_uuid,
+        message = 'VShard alert on localhost:13305 (router):' ..
+            ' 3000 buckets are not discovered',
     }})
 
 end


### PR DESCRIPTION
Introduce two new issues, forward them from vshard:

```
warning: VShard alert on localhost:13305 (router): 1000 buckets are not discovered
```

```
warning: VShard alert on localhost:13305 (router): Invalid configuration:
  probably router's cfg.bucket_count is different from storages' one, difference is 500"
```

Also, fix `api_query_test` which started to fail more intensively because of the discovery issue.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #941