### PR TITLE
Fix cookie_change test

### DIFF
--- a/test/integration/cookie_change_test.lua
+++ b/test/integration/cookie_change_test.lua
@@ -16,9 +16,15 @@ g.before_all(function()
         }},
     })
     g.cluster:start()
+    g.main = g.cluster.main_server
+
     for _, server in pairs(g.cluster.servers) do
         server.env['TARANTOOL_CLUSTER_COOKIE'] = nil
     end
+
+    h.retrying({}, function()
+        t.assert_equals(h.list_cluster_issues(g.main), {})
+    end)
 end)
 
 g.after_all(function()
@@ -53,10 +59,19 @@ local function set_cookie_clusterwide(cluster, cookie)
         set_cookie(server, cookie)
     end
     for _, server in pairs(cluster.servers) do
+        local ok, err = server.net_box:eval([[
+            local confapplier = require('cartridge.confapplier')
+            local clusterwide_config = confapplier.get_active_config()
+            return confapplier.apply_config(clusterwide_config)
+        ]])
+
+        t.assert_equals({ok, err}, {true, nil})
+    end
+    for _, server in pairs(cluster.servers) do
         local new_cookie = server.net_box:eval(q_get_cookie)
         t.assert_equals(new_cookie, cookie)
         h.retrying({}, function()
-            t.assert_equals(#h.list_cluster_issues(server), 0)
+            t.assert_equals(h.list_cluster_issues(server), {})
         end)
     end
 end
@@ -72,6 +87,9 @@ function g.test_cluster_restart()
         local cookie = server.net_box:eval(q_get_cookie)
         t.assert_equals(cookie, new_cookie)
     end
+    h.retrying({}, function()
+        t.assert_equals(h.list_cluster_issues(g.main), {})
+    end)
 end
 
 function g.test_server_restart()
@@ -86,8 +104,6 @@ function g.test_server_restart()
     t.assert_equals(cookie, new_cookie)
 
     h.retrying({}, function()
-        local issues = target.net_box:call('_G.__cartridge_issues_list_on_instance')
-        t.assert_equals(#issues, 0)
+        t.assert_equals(h.list_cluster_issues(g.main), {})
     end)
-
 end


### PR DESCRIPTION
Changing the cookie was incorrect. It didn't call `box.cfg` with a new replication credentials. Sometimes in the test the cookie was changed earlier than replication was established. It resulted in cartridge issues:

```log
/opt/cartridge/test/integration/cookie_change_test.lua:60: expected:                                                                                                                                       
{}                                                                                                                                                                                                         
actual:                                                                                                                                                                                                    
{                                                                                                                                                                                                          
    {                                                                                                                                                                                                      
        instance_uuid = "a6a494a4-fec2-45a1-81dc-bd4cb86367b8",                                                                                                                                            
        level = "critical",                                                                                                                                                                                
        message = "Replication from localhost:13302 (A-2) to localhost:13301 (A-1) state \"loading\" (Incorrect password supplied for user 'admin')",
        replicaset_uuid = "aaaaaaaa-0000-0000-0000-000000000000",
        topic = "replication",
    },
    {
        instance_uuid = "a6a494a4-fec2-45a1-81dc-bd4cb86367b8",
        level = "critical",
        message = "Replication from localhost:13303 (A-3) to localhost:13301 (A-1) state \"loading\" (Incorrect password supplied for user 'admin')",
        replicaset_uuid = "aaaaaaaa-0000-0000-0000-000000000000",
        topic = "replication",
    },
}
```

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~
