### PR TITLE
Fix flaky tarantool_upgrade_test

### DIFF
--- a/test/upgrade/tarantool_upgrade_test.lua
+++ b/test/upgrade/tarantool_upgrade_test.lua
@@ -82,6 +82,10 @@ function g.test_upgrade()
     local tuple = {1, 0.1, 'str', {a = 'a'}, {1, 2}}
     storage_1.space.test:insert(tuple)
 
-    local storage2_tuple = storage_2:eval('return box.space.test:get({1})')
-    t.assert_equals(storage2_tuple, tuple)
+    helpers.retrying({}, function()
+        t.assert_equals(
+            storage_2:eval('return box.space.test:get({1})'),
+            tuple
+        )
+    end)
 end


### PR DESCRIPTION
The replication is asynchronous. Select operations should be retried in
order to avoid test failures.

```log
=========================================================

Failed tests:
-------------

1) upgrade.tarantool_upgrade.test_upgrade
/opt/cartridge/test/upgrade/tarantool_upgrade_test.lua:86: expected: {1, 0.1, "str", {a = "a"}, {1, 2}}
actual: nil
stack traceback:
        /opt/cartridge/test/upgrade/tarantool_upgrade_test.lua:86: in function 'upgrade.tarantool_upgrade.test_upgrade'
        ...
        [C]: in function 'xpcall'

Ran 1 tests in 1.865 seconds, 0 successes, 1 fail

```

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~

