### PR TITLE
Fix flaky etcd2 client quorum test

### DIFF
--- a/test/integration/etcd2_client_test.lua
+++ b/test/integration/etcd2_client_test.lua
@@ -537,5 +537,7 @@ function g.test_quorum()
     t.assert_equals(client:check_quorum(), false)
 
     g.etcd_a.process:kill('CONT')
-    t.assert_equals(client:check_quorum(), true)
+    t.helpers.retrying({}, function()
+        t.assert_equals(client:check_quorum(), true)
+    end)
 end


### PR DESCRIPTION
Fix etcd2_client.test_quorum

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] ~~Documentation~~

Close #1531 
