### PR TITLE
Add range checks for issue_limits values

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -706,6 +706,11 @@ local function cfg(opts, box_opts)
         return nil, err
     end
 
+    local ok, err = issues.validate_limits(issue_limits)
+    if not ok then
+        return nil, err
+    end
+
     issues.set_limits(issue_limits)
 
     if opts.upload_prefix ~= nil then

--- a/test/integration/issues_test.lua
+++ b/test/integration/issues_test.lua
@@ -25,9 +25,9 @@ g.before_all(function()
             }},
         }},
         env = {
-            TARANTOOL_CLOCK_DELTA_THRESHOLD_WARNING = 5,
-            TARANTOOL_FRAGMENTATION_THRESHOLD_WARNING = .6,
-            TARANTOOL_FRAGMENTATION_THRESHOLD_CRITICAL = .9,
+            TARANTOOL_CLOCK_DELTA_THRESHOLD_WARNING = math.huge,
+            TARANTOOL_FRAGMENTATION_THRESHOLD_WARNING = 1,
+            TARANTOOL_FRAGMENTATION_THRESHOLD_CRITICAL = 1,
         }
     })
     g.cluster:start()
@@ -64,66 +64,26 @@ end)
 function g.test_issues_limits()
     local server = g.cluster:server('master')
 
-    local set_limits = function(limits)
-        server:eval([[
-            local limits = ...
-            require('cartridge.issues').set_limits(limits)
-        ]], {limits})
-    end
-
-    -- Check ranges
-    t.assert_error_msg_contains(
-        'Error setting limits.clock_delta_threshold_warning',
-        set_limits,
-        {clock_delta_threshold_warning = 0 - 1e-7}
+    t.assert_equals(
+        server:eval("return require('cartridge.vars').new('cartridge.issues').limits"),
+        {
+            clock_delta_threshold_warning = math.huge,
+            fragmentation_threshold_warning = 1,
+            fragmentation_threshold_critical = 1,
+        }
     )
 
-    t.assert_error_msg_contains(
-        'Error setting limits.fragmentation_threshold_warning',
-        set_limits,
-        {fragmentation_threshold_warning = 1 + 1e-7}
-    )
-
-    t.assert_error_msg_contains(
-        'Error setting limits.fragmentation_threshold_warning',
-        set_limits,
-        {fragmentation_threshold_warning = 0 - 1e-7}
-    )
-
-    t.assert_error_msg_contains(
-        'Error setting limits.fragmentation_threshold_critical',
-        set_limits,
-        {fragmentation_threshold_critical = 1 + 1e-7}
-    )
-
-    t.assert_error_msg_contains(
-        'Error setting limits.fragmentation_threshold_critical',
-        set_limits,
-        {fragmentation_threshold_critical = 0 - 1e-7}
-    )
-
-    -- load valid config and check it has been applied
-    local valid_config = {
-        clock_delta_threshold_warning = 5,
-        fragmentation_threshold_warning = .4,
-        fragmentation_threshold_critical = .8,
-    }
-
-    set_limits(valid_config)
-    local applied_limits = server:eval([[
-        return require('cartridge.vars').new('cartridge.issues').limits
-    ]])
-    t.assert_equals(valid_config, applied_limits)
-
-
-    -- restore to defaults by calling set_limits
     server:eval([[
         local cartridge_issues = require("cartridge.issues")
         cartridge_issues.set_limits(cartridge_issues.default_limits)
     ]])
     t.assert_equals(
         server:eval("return require('cartridge.vars').new('cartridge.issues').limits"),
-        server:eval("return require('cartridge.issues').default_limits")
+        {
+            clock_delta_threshold_warning = 5,
+            fragmentation_threshold_warning = 0.6,
+            fragmentation_threshold_critical = 0.9
+        }
     )
 
     t.assert_equals(helpers.list_cluster_issues(server), {})

--- a/test/unit/cfg_errors_test.lua
+++ b/test/unit/cfg_errors_test.lua
@@ -197,6 +197,35 @@ g.test_http = function()
     end)
 end
 
+-- issues_limits --------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+g.test_issues_limits = function()
+    helpers.run_remotely(g.server, function()
+        local t = require('luatest')
+        os.setenv('TARANTOOL_CLOCK_DELTA_THRESHOLD_WARNING', '-1')
+
+        local ok, err = require('cartridge').cfg({
+            swim_broadcast = false,
+            advertise_uri = 'localhost:13301',
+            http_enabled = false,
+            workdir = os.getenv('TARANTOOL_WORKDIR'),
+            roles = {},
+        })
+
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = 'ValidateConfigError',
+            err = 'limits.clock_delta_threshold_warning must be in range [0, inf]',
+        })
+    end)
+end
+g.after_test('test_issues_limits', function()
+    helpers.run_remotely(g.server, function()
+        os.setenv('TARANTOOL_CLOCK_DELTA_THRESHOLD_WARNING', nil)
+    end)
+end)
+
 -- roles ----------------------------------------------------------------------
 -------------------------------------------------------------------------------
 g.test_roles = function()

--- a/test/unit/issues_limits_test.lua
+++ b/test/unit/issues_limits_test.lua
@@ -1,0 +1,88 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local g = t.group()
+
+local issues = require("cartridge.issues")
+
+function g.test_positive()
+    local function check_ok(limits)
+        return t.assert_equals(
+            {issues.validate_limits(limits)},
+            {true, nil}
+        )
+    end
+
+    check_ok({})
+    check_ok(issues.default_limits)
+
+    check_ok({clock_delta_threshold_warning = 0})
+    check_ok({clock_delta_threshold_warning = math.huge})
+
+    check_ok({fragmentation_threshold_warning = 0})
+    check_ok({fragmentation_threshold_warning = 1})
+
+    check_ok({fragmentation_threshold_critical = 0})
+    check_ok({fragmentation_threshold_critical = 1})
+end
+
+function g.test_negative()
+    local function check_error(limits, err_expected)
+        local ok, err = issues.validate_limits(limits)
+        t.assert_equals(ok, nil)
+        t.assert_covers(err, {
+            class_name = "ValidateConfigError",
+            err = err_expected,
+        })
+    end
+
+    local nan = 0/0
+    assert(nan ~= nan)
+
+    check_error(0,        'limits must be a table, got number')
+    check_error(nil,      'limits must be a table, got nil')
+    check_error(box.NULL, 'limits must be a table, got cdata')
+
+    check_error({{}},       'limits table keys must be string, got number')
+    check_error({[{}] = 1}, 'limits table keys must be string, got table')
+
+    check_error({unknown_limit = 0}, 'unknown limits key "unknown_limit"')
+
+    -- clock_delta_threshold_warning
+    check_error(
+        {clock_delta_threshold_warning = 'yes'},
+        'limits.clock_delta_threshold_warning must be a number, got string'
+    )
+    check_error(
+        {clock_delta_threshold_warning = 12ULL},
+        'limits.clock_delta_threshold_warning must be a number, got cdata'
+    )
+    check_error(
+        {clock_delta_threshold_warning = -1e-7},
+        'limits.clock_delta_threshold_warning must be in range [0, inf]'
+    )
+    check_error(
+        {clock_delta_threshold_warning = nan},
+        'limits.clock_delta_threshold_warning must be in range [0, inf]'
+    )
+
+    -- fragmentation_threshold_warning
+    check_error(
+        {fragmentation_threshold_warning = 0 - 1e-7},
+        'limits.fragmentation_threshold_warning must be in range [0, 1]'
+    )
+    check_error(
+        {fragmentation_threshold_warning = 1 + 1e-7},
+        'limits.fragmentation_threshold_warning must be in range [0, 1]'
+    )
+
+    -- fragmentation_threshold_critical
+    check_error(
+        {fragmentation_threshold_critical = 0 - 1e-7},
+        'limits.fragmentation_threshold_critical must be in range [0, 1]'
+    )
+    check_error(
+        {fragmentation_threshold_critical = 1 + 1e-7},
+        'limits.fragmentation_threshold_critical must be in range [0, 1]'
+    )
+end


### PR DESCRIPTION
Before that only types were checked when calling issues.set_limits.
However there are some restrictions for these values (e.g. clock_delta_threshold_warning cannot be negative).
This patch adds missing checks

What has been done? Why? What problem is being solved?

I didn't forget about

- [x] Tests
- [x] ~~Changelog~~
- [x] Documentation (ldoc)

Required by [TDG2 patch](https://github.com/tarantool/tdg2/pull/1208)

Close #1542 
