### PR TITLE
Support cartridge_hide_all_rw in tarantool_variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ and this project adheres to
 [Unreleased]
 -------------------------------------------------------------------------------
 
+- 'Make all instances writeable' configuration field can be hidden via
+  frontend-core's ``set_variable`` feature or at runtime.
+
 -------------------------------------------------------------------------------
 [2.7.1] - 2021-08-18
 -------------------------------------------------------------------------------

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -17,6 +17,7 @@ if frontend and frontend.set_variable then
     -- which doesn't support it yet.
     frontend.set_variable('cartridge_refresh_interval', 500)
     frontend.set_variable('cartridge_stat_period', 2)
+    frontend.set_variable('cartridge_hide_all_rw', false)
 end
 
 package.preload['mymodule'] = function()

--- a/webui/README.md
+++ b/webui/README.md
@@ -7,11 +7,14 @@
 `cartridge_stat_period` - Refresh period for all cluster stats
 (includes issues, suggestions and server stats).
 
+`cartridge_hide_all_rw` - Hide 'Make all instances writeable' configuration field
+('Create replica set' and 'Edit replica set' forms).
+
 ## Emittable frontend core events
 
 Events dispatchable by module `cartridge`:
 
-`cluster:login:done` - Emits after succesful authorization.
+`cluster:login:done` - Emits after successful authorization.
 Provides object describing auth state and username.
 
-`cluster:logout:done` - Emits after succesful logging out.
+`cluster:logout:done` - Emits after successful logging out.

--- a/webui/cypress/integration/hide-all-rw-variable.spec.js
+++ b/webui/cypress/integration/hide-all-rw-variable.spec.js
@@ -53,7 +53,9 @@ describe('Test the cartridge_hide_all_rw frontend core variable', () => {
   function hideAllRW(value) {
     cy.get('@main_server').then(srv => {
       cy.task('tarantool', {
-        host: 'unix/', port: srv.sock, code: `
+        host: 'unix/',
+        port: srv.sock,
+        code: `
         local frontend = package.loaded['frontend-core']
         frontend.set_variable("cartridge_hide_all_rw", ${value})
         return true
@@ -88,7 +90,7 @@ describe('Test the cartridge_hide_all_rw frontend core variable', () => {
   });
 
   it('Test: EditReplicasetForm', function () {
-    cy.task('tarantool', {code: '_G.cluster:bootstrap()'});
+    cy.task('tarantool', { code: '_G.cluster:bootstrap()' });
 
     ////////////////////////////////////////////////////////////////////
     cy.log('cartridge_hide_all_rw is unset');

--- a/webui/cypress/integration/hide-all-rw-variable.spec.js
+++ b/webui/cypress/integration/hide-all-rw-variable.spec.js
@@ -1,0 +1,146 @@
+describe('Test the cartridge_hide_all_rw frontend core variable', () => {
+  before(() => {
+    cy.task('tarantool', {
+      code: `
+      cleanup()
+
+      _G.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        use_vshard = false,
+        cookie = helpers.random_cookie(),
+        env = {},
+        replicasets = {{
+          uuid = helpers.uuid('a'),
+          alias = 'dummy',
+          roles = {},
+          servers = {{http_port = 8080}, {}, {}},
+        }}
+      })
+
+      for _, server in ipairs(_G.cluster.servers) do
+        server.env.TARANTOOL_INSTANCE_NAME = server.alias
+        server.env.TARANTOOL_CONSOLE_SOCK =
+          _G.cluster.datadir .. '/' .. server.alias .. '.control'
+        server:start()
+      end
+
+      return true
+    `
+    }).should('deep.eq', [true]);
+  });
+
+  after(() => {
+    cy.task('tarantool', { code: `cleanup()` });
+  });
+
+  it('Test: cartridge_hide_all_rw is unset', () => {
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open WebUI');
+    cy.visit('/admin/cluster/dashboard');
+    cy.title().should('eq', 'dummy-1: Cluster');
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open configure server dialog');
+    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
+    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').first().should('exist');
+
+    cy.log('Create replica set');
+    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
+      .should('be.focused')
+      .type('replica-name');
+
+    cy.get('.meta-test__CreateReplicaSetBtn').click();
+    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
+    cy.get('#root').contains('replica-name');
+    ////////////////////////////////////////////////////////////////
+    cy.log('Open edit replica set dialog');
+    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
+    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').first().should('exist');
+    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
+    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
+  });
+
+  it('Test: cartridge_hide_all_rw is FALSE', () => {
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Setup cartridge_hide_all_rw=false');
+    cy.task('tarantool', {
+      code: `
+      _G.cluster:server('dummy-1').env.TARANTOOL_CONSOLE_SOCK
+    `
+    }).then(([sock]) => {
+      expect(sock).to.be.a('string');
+      cy.task('tarantool', {
+        host: 'unix/', port: sock, code: `
+        local frontend = package.loaded['frontend-core']
+        frontend.set_variable('cartridge_hide_all_rw', false)
+        return true
+      `
+      }).should('deep.eq', [true]);
+    });
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open WebUI');
+    cy.visit('/admin/cluster/dashboard');
+    cy.title().should('eq', 'dummy-1: Cluster');
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open configure server dialog');
+    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
+    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').first().should('exist');
+
+    cy.log('Create replica set');
+    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
+      .should('be.focused')
+      .type('replica-name');
+
+    cy.get('.meta-test__CreateReplicaSetBtn').click();
+    cy.get('#root').contains('replica-name');
+    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
+    ////////////////////////////////////////////////////////////////
+    cy.log('Open edit replica set dialog');
+    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
+    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').first().should('exist');
+    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
+    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
+  });
+
+  it('Test: cartridge_hide_all_rw is TRUE', () => {
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Setup cartridge_hide_all_rw=true');
+    cy.task('tarantool', {
+      code: `
+      _G.cluster:server('dummy-1').env.TARANTOOL_CONSOLE_SOCK
+    `
+    }).then(([sock]) => {
+      expect(sock).to.be.a('string');
+      cy.task('tarantool', {
+        host: 'unix/', port: sock, code: `
+        local frontend = package.loaded['frontend-core']
+        frontend.set_variable('cartridge_hide_all_rw', true)
+        return true
+      `
+      }).should('deep.eq', [true]);
+    });
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open WebUI');
+    cy.visit('/admin/cluster/dashboard');
+    cy.title().should('eq', 'dummy-1: Cluster');
+    ////////////////////////////////////////////////////////////////////
+    cy.log('Open configure server dialog');
+    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
+    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').should('not.exist');
+
+    cy.log('Create replica set');
+    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
+      .should('be.focused')
+      .type('replica-name');
+
+    cy.get('.meta-test__CreateReplicaSetBtn').click();
+    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
+    cy.get('#root').contains('replica-name');
+    ////////////////////////////////////////////////////////////////
+    cy.log('Open edit replica set dialog');
+    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
+    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').should('not.exist');
+    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
+    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
+  });
+});

--- a/webui/cypress/integration/hide-all-rw-variable.spec.js
+++ b/webui/cypress/integration/hide-all-rw-variable.spec.js
@@ -14,133 +14,102 @@ describe('Test the cartridge_hide_all_rw frontend core variable', () => {
           uuid = helpers.uuid('a'),
           alias = 'dummy',
           roles = {},
-          servers = {{http_port = 8080}, {}, {}},
+          servers = {{http_port = 8080}},
         }}
       })
 
-      for _, server in ipairs(_G.cluster.servers) do
-        server.env.TARANTOOL_INSTANCE_NAME = server.alias
-        server.env.TARANTOOL_CONSOLE_SOCK =
-          _G.cluster.datadir .. '/' .. server.alias .. '.control'
-        server:start()
-      end
+      local server = _G.cluster:server('dummy-1')
+      server.env.TARANTOOL_CONSOLE_SOCK =
+        _G.cluster.datadir .. '/' .. server.alias .. '.control'
+      server:start()
 
       return true
     `
     }).should('deep.eq', [true]);
   });
 
+  beforeEach(() => {
+    cy.task('tarantool', {
+      code: `
+      local server = _G.cluster:server('dummy-1')
+      return {
+        sock = server.env.TARANTOOL_CONSOLE_SOCK,
+        advertise_uri = server.advertise_uri,
+        replicaset_uuid = server.replicaset_uuid,
+      }
+    `
+    }).then(([ret]) => {
+      expect(ret.sock).to.be.a('string');
+      expect(ret.advertise_uri).to.be.a('string');
+      expect(ret.replicaset_uuid).to.be.a('string');
+      cy.wrap(ret).as('main_server');
+    });
+  })
+
   after(() => {
     cy.task('tarantool', { code: `cleanup()` });
   });
 
-  it('Test: cartridge_hide_all_rw is unset', () => {
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open WebUI');
-    cy.visit('/admin/cluster/dashboard');
-    cy.title().should('eq', 'dummy-1: Cluster');
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open configure server dialog');
-    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
-    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').first().should('exist');
-
-    cy.log('Create replica set');
-    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
-      .should('be.focused')
-      .type('replica-name');
-
-    cy.get('.meta-test__CreateReplicaSetBtn').click();
-    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
-    cy.get('#root').contains('replica-name');
-    ////////////////////////////////////////////////////////////////
-    cy.log('Open edit replica set dialog');
-    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
-    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').first().should('exist');
-    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
-    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
-  });
-
-  it('Test: cartridge_hide_all_rw is FALSE', () => {
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Setup cartridge_hide_all_rw=false');
-    cy.task('tarantool', {
-      code: `
-      _G.cluster:server('dummy-1').env.TARANTOOL_CONSOLE_SOCK
-    `
-    }).then(([sock]) => {
-      expect(sock).to.be.a('string');
+  function hideAllRW(value) {
+    cy.get('@main_server').then(srv => {
       cy.task('tarantool', {
-        host: 'unix/', port: sock, code: `
+        host: 'unix/', port: srv.sock, code: `
         local frontend = package.loaded['frontend-core']
-        frontend.set_variable('cartridge_hide_all_rw', false)
+        frontend.set_variable("cartridge_hide_all_rw", ${value})
         return true
       `
       }).should('deep.eq', [true]);
-    });
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open WebUI');
-    cy.visit('/admin/cluster/dashboard');
-    cy.title().should('eq', 'dummy-1: Cluster');
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open configure server dialog');
-    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
-    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').first().should('exist');
+    })
+  }
 
-    cy.log('Create replica set');
-    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
-      .should('be.focused')
-      .type('replica-name');
+  it('Test CreateReplicasetForm', function () {
+    ////////////////////////////////////////////////////////////////////
+    cy.log('cartridge_hide_all_rw is unset');
+    hideAllRW('nil');
+    cy.visit(`/admin/cluster/dashboard?s=${this.main_server.advertise_uri}`);
 
-    cy.get('.meta-test__CreateReplicaSetBtn').click();
-    cy.get('#root').contains('replica-name');
-    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
-    ////////////////////////////////////////////////////////////////
-    cy.log('Open edit replica set dialog');
-    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
-    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').first().should('exist');
-    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
-    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
-  });
+    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').should('exist');
 
-  it('Test: cartridge_hide_all_rw is TRUE', () => {
     ////////////////////////////////////////////////////////////////////
-    cy.log('Setup cartridge_hide_all_rw=true');
-    cy.task('tarantool', {
-      code: `
-      _G.cluster:server('dummy-1').env.TARANTOOL_CONSOLE_SOCK
-    `
-    }).then(([sock]) => {
-      expect(sock).to.be.a('string');
-      cy.task('tarantool', {
-        host: 'unix/', port: sock, code: `
-        local frontend = package.loaded['frontend-core']
-        frontend.set_variable('cartridge_hide_all_rw', true)
-        return true
-      `
-      }).should('deep.eq', [true]);
-    });
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open WebUI');
-    cy.visit('/admin/cluster/dashboard');
-    cy.title().should('eq', 'dummy-1: Cluster');
-    ////////////////////////////////////////////////////////////////////
-    cy.log('Open configure server dialog');
-    cy.get('.meta-test__UnconfiguredServerList .meta-test__configureBtn').first().click();
+    cy.log('cartridge_hide_all_rw is true');
+    hideAllRW('true')
+    cy.reload()
+
+    cy.get('.meta-test__ConfigureServerModal').contains('dummy-1');
     cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').should('not.exist');
 
-    cy.log('Create replica set');
-    cy.get('.meta-test__ConfigureServerModal form input[name="alias"]')
-      .should('be.focused')
-      .type('replica-name');
+    ////////////////////////////////////////////////////////////////////
+    cy.log('cartridge_hide_all_rw is false');
+    hideAllRW('false');
+    cy.reload()
 
-    cy.get('.meta-test__CreateReplicaSetBtn').click();
-    cy.get('.meta-test__ConfigureServerModal').should('not.exist');
-    cy.get('#root').contains('replica-name');
-    ////////////////////////////////////////////////////////////////
-    cy.log('Open edit replica set dialog');
-    cy.get('[data-cy=meta-test__replicaSetSection] [data-cy="meta-test__editBtn"]').first().click();
+    cy.get('.meta-test__ConfigureServerModal input[name="all_rw"]').should('exist');
+
+  });
+
+  it('Test: EditReplicasetForm', function () {
+    cy.task('tarantool', {code: '_G.cluster:bootstrap()'});
+
+    ////////////////////////////////////////////////////////////////////
+    cy.log('cartridge_hide_all_rw is unset');
+    hideAllRW('nil');
+    cy.visit(`/admin/cluster/dashboard?r=${this.main_server.replicaset_uuid}`);
+
+    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').should('exist');
+
+    ////////////////////////////////////////////////////////////////////
+    cy.log('cartridge_hide_all_rw is true');
+    hideAllRW('true')
+    cy.reload()
+
+    cy.get('.meta-test__EditReplicasetModal').contains('dummy');
     cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').should('not.exist');
-    cy.get('.meta-test__EditReplicasetModal h2~svg').first().click(); // click close icon
-    cy.get('.meta-test__EditReplicasetModal').should('not.exist');
+
+    ////////////////////////////////////////////////////////////////////
+    cy.log('cartridge_hide_all_rw is false');
+    hideAllRW('false');
+    cy.reload()
+
+    cy.get('.meta-test__EditReplicasetModal input[name="all_rw"]').should('exist');
   });
 });

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -39447,8 +39447,7 @@
               "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
               "requires": {
                 "@babel/runtime": "^7.2.0",
-                "invariant": "^2.2.4",
-                "prop-types": "^15.5.7"
+                "invariant": "^2.2.4"
               }
             },
             "react-test-renderer": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -118,8 +118,7 @@
     "lint": "eslint ./src",
     "lint-fix": "eslint --fix ./src",
     "lint:test": "eslint ./cypress",
-    "lint:test-fix": "eslint --fix ./cypress",
-    "cy:dev": "CYPRESS_baseUrl=http://localhost:3000 cypress open"
+    "lint:test-fix": "eslint --fix ./cypress"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/webui/src/components/CreateReplicasetForm.js
+++ b/webui/src/components/CreateReplicasetForm.js
@@ -116,6 +116,7 @@ CreateReplicasetFormProps) => (
       const activeDependencies = getRolesDependencies(values.roles, knownRoles)
       const VShardGroupInputDisabled = isVShardGroupInputDisabled(values.roles);
       const rolesColumns = (knownRoles && knownRoles.length > 6) ? 3 : 2;
+      const { cartridge_hide_all_rw } = (window.__tarantool_variables || {});
 
       return (
         <form onSubmit={handleSubmit}>
@@ -247,19 +248,21 @@ CreateReplicasetFormProps) => (
                 </FormField>
               )}
             </Field>
-            <Field name='all_rw'>
-              {({ input: { name: fieldName, value, onChange } }) => (
-                <FormField className={styles.field} label='All writable' info={allRwTooltipInfo}>
-                  <Checkbox
-                    onChange={onChange}
-                    name={fieldName}
-                    checked={value}
-                  >
-                    Make all instances writeable
-                  </Checkbox>
-                </FormField>
-              )}
-            </Field>
+            {cartridge_hide_all_rw !== true && (
+              <Field name='all_rw'>
+                {({ input: { name: fieldName, value, onChange } }) => (
+                  <FormField className={styles.field} label='All writable' info={allRwTooltipInfo}>
+                    <Checkbox
+                      onChange={onChange}
+                      name={fieldName}
+                      checked={value}
+                    >
+                      Make all instances writeable
+                    </Checkbox>
+                  </FormField>
+                )}
+              </Field>
+            )}
           </div>
           <PopupFooter
             controls={([

--- a/webui/src/components/EditReplicasetForm.js
+++ b/webui/src/components/EditReplicasetForm.js
@@ -138,6 +138,7 @@ EditReplicasetFormProps) => {
         const activeDependencies = getRolesDependencies(values.roles, knownRoles)
         const VShardGroupInputDisabled = isVShardGroupInputDisabled(values.roles, replicaset);
         const rolesColumns = (knownRoles && knownRoles.length > 6) ? 3 : 2;
+        const { cartridge_hide_all_rw } = (window.__tarantool_variables || {});
 
         return (
           <form onSubmit={handleSubmit}>
@@ -281,24 +282,26 @@ EditReplicasetFormProps) => {
                   </FormField>
                 )}
               </Field>
-              <Field name='all_rw'>
-                {({ input: { name: fieldName, value, onChange } }) => (
-                  <FormField
-                    className={styles.field}
-                    label='All writable'
-                    info={allRwTooltipInfo}
-                    largeMargins
-                  >
-                    <Checkbox
-                      onChange={onChange}
-                      name={fieldName}
-                      checked={value}
+              {cartridge_hide_all_rw !== true && (
+                <Field name='all_rw'>
+                  {({ input: { name: fieldName, value, onChange } }) => (
+                    <FormField
+                      className={styles.field}
+                      label='All writable'
+                      info={allRwTooltipInfo}
+                      largeMargins
                     >
-                      Make all instances writeable
-                    </Checkbox>
-                  </FormField>
-                )}
-              </Field>
+                      <Checkbox
+                        onChange={onChange}
+                        name={fieldName}
+                        checked={value}
+                      >
+                        Make all instances writeable
+                      </Checkbox>
+                    </FormField>
+                  )}
+                </Field>
+              )}
               <Field name='master'>
                 {({ input: { name, value, onChange }, meta: { error } }) => (
                   <LabeledInput

--- a/webui/src/components/ReplicasetList/ReplicasetList.js
+++ b/webui/src/components/ReplicasetList/ReplicasetList.js
@@ -226,6 +226,7 @@ class ReplicasetList extends React.PureComponent {
                   intent='secondary'
                   onClick={() => this.handleEditReplicasetRequest(replicaset)}
                   text='Edit'
+                  data-cy='meta-test__editBtn'
                 />
               </div>
               <ReplicasetRoles className={styles.roles} roles={replicaset.roles}/>


### PR DESCRIPTION
Variables:

* `cartridge_hide_all_rw` - hide 'Make all instances writeable' configuration field 

Example for browser runtime:

```js
if (!window.__tarantool_variables) window.__tarantool_variables = {};
window.__tarantool_variables.cartridge_hide_all_rw = true;
```

Example to fine-tune in from backend:

```lua
local frontend = require('frontend-core')
frontend.set_variable('cartridge_hide_all_rw', true)
```

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1079
