### PR TITLE
Fix remote-control greeting

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -29,7 +29,7 @@ jobs:
         id: cache-venv
         with:
           path: ./venv
-          key: misc-venv-${{ hashFiles('rst/requirements.txt') }}-02
+          key: misc-venv-${{ hashFiles('rst/requirements.txt') }}-03
       -
         run: |
           python -m venv ./venv && . ./venv/bin/activate
@@ -118,7 +118,7 @@ jobs:
         id: cache-pytest
         with:
           path: ./pytest-venv
-          key: test-venv-${{ hashFiles('test/integration/requirements.txt') }}-02
+          key: test-venv-${{ hashFiles('test/integration/requirements.txt') }}-03
       -
         run: |
           python -m venv ./pytest-venv && . ./pytest-venv/bin/activate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Fixed
   sync. This reduces the chance the hardware restart leads to WAL corruption
   ([#1546](https://github.com/tarantool/cartridge/issues/1546)).
 
+- Fix net.box clients compatibility with future tarantool 2.10 versions.
+
 -------------------------------------------------------------------------------
 [2.7.1] - 2021-08-18
 -------------------------------------------------------------------------------

--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -20,7 +20,6 @@ local errors = require('errors')
 local socket = require('socket')
 local digest = require('digest')
 local pickle = require('pickle')
-local uuid_lib = require('uuid')
 local msgpack = require('msgpack')
 local utils = require('cartridge.utils')
 local vars = require('cartridge.vars').new('cartridge.remote-control')
@@ -185,9 +184,8 @@ local function communicate(s)
     local sync = header[0x01]
 
     if iproto_code[code] == nil then
-        -- reply_err(s, sync or 0, box.error.UNKNOWN,
-        --     "Unknown iproto code 0x%02x", code
-        -- )
+        -- Don't talk to strangers, it may confuse them.
+        -- See https://github.com/tarantool/tarantool/issues/6451
         return false
 
     elseif iproto_code[code] == 'iproto_select' then
@@ -285,9 +283,8 @@ local function communicate(s)
         return true
 
     else
-        -- reply_err(s, sync, box.error.UNSUPPORTED,
-        --     "Remote Control doesn't support %s", iproto_code[code]
-        -- )
+        -- Don't talk to strangers, it may confuse them.
+        -- See https://github.com/tarantool/tarantool/issues/6451
         return false
     end
 end
@@ -295,13 +292,11 @@ end
 local function rc_handle(s)
     utils.fd_cloexec(s:fd())
 
-    local version = string.match(_TARANTOOL, "^([%d%.]+)") or '???'
     local salt = digest.urandom(32)
 
     local greeting = string.format(
         '%-63s\n%-63s\n',
-        'Tarantool ' .. version .. ' (Binary) ' .. uuid_lib.NULL:str(),
-        -- 'Tarantool 1.10.3 (Binary) f1f1ab41-eae1-475b-b4bd-3fa8dd067f4d',
+        'Tarantool 1.10.0 (Binary) 00000000-0000-0000-0000-000000000000',
         digest.base64_encode(salt)
     )
 


### PR DESCRIPTION
The greeting in iproto protocol is used mostly for the feature telling.
For the remote-control server, it's not correct to respond with a
version from the `_TARANTOOL` variable, because the `remote-control`
implementation is constant.

This patch locks the greeting on 1.10.0 as it corresponds to that
feature set.

This patch is necessary so that further tarantool versions could
preserve `net.box` compatibility with `remote-control` server.

See also https://github.com/tarantool/tarantool/issues/6253

I didn't forget about

- [x] Tests (preserved green)
- [x] Changelog
- [x] ~~Documentation~~
