### PR TITLE
Add option to disable admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Added
 - 'Make all instances writeable' configuration field can be hidden via
   frontend-core's ``set_variable`` feature or at runtime.
 
+- New ``admin_disabled`` option to disable admin user in the built-in auth module.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -281,6 +281,7 @@ local function cfg(opts, box_opts)
         roles = 'table',
         auth_backend_name = '?string',
         auth_enabled = '?boolean',
+        admin_disabled = '?boolean',
         vshard_groups = '?table',
         console_sock = '?string',
         webui_blacklist = '?table',
@@ -657,7 +658,8 @@ local function cfg(opts, box_opts)
         end
 
         local ok, err = CartridgeCfgError:pcall(auth.init, httpd, {
-            prefix = opts.webui_prefix
+            prefix = opts.webui_prefix,
+            admin_disabled = opts.admin_disabled or false,
         })
         if not ok then
             return nil, err

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -92,6 +92,7 @@ local cluster_opts = {
     cluster_cookie = 'string', -- **string**
     console_sock = 'string', -- **string**
     auth_enabled = 'boolean', -- **boolean**
+    admin_disabled = 'boolean', -- **boolean**
     bucket_count = 'number', -- **number**
     upgrade_schema = 'boolean', -- **boolean**
     swim_broadcast = 'boolean', -- **boolean**

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -34,6 +34,10 @@ local gql_type_userapi = gql_types.object({
             kind = gql_types.long.nonNull,
             description = "Update provided cookie if it's older then this age.",
         },
+        admin_disabled = {
+            kind = gql_types.boolean.nonNull,
+            description = 'Whether admin access is disabled.',
+        },
 
         implements_add_user = gql_types.boolean.nonNull,
         implements_get_user = gql_types.boolean.nonNull,
@@ -85,6 +89,7 @@ local function get_auth_params()
         enabled = params.enabled,
         cookie_max_age = params.cookie_max_age,
         cookie_renew_age = params.cookie_renew_age,
+        admin_disabled = params.admin_disabled,
 
         implements_add_user = callbacks.add_user ~= nil,
         implements_get_user = callbacks.get_user ~= nil,
@@ -127,6 +132,7 @@ local function init(graphql)
             enabled = gql_types.boolean,
             cookie_max_age = gql_types.long,
             cookie_renew_age = gql_types.long,
+            admin_disabled = gql_types.boolean,
         },
         kind = gql_type_userapi.nonNull,
         callback = module_name .. '.set_auth_params',

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8081/admin/api
-# timestamp: Thu Aug 05 2021 14:38:50 GMT+0300 (Moscow Standard Time)
+# timestamp: Mon Sep 20 2021 06:11:11 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""
 type Apicluster {
@@ -250,7 +250,7 @@ type MutationApicluster {
   """Restart replication on specified by uuid servers"""
   restart_replication(uuids: [String!]): Boolean
   edit_vshard_options(rebalancer_max_receiving: Int, collect_bucket_garbage_interval: Float, collect_lua_garbage: Boolean, sched_ref_quota: Long, rebalancer_max_sending: Int, sync_timeout: Float, rebalancer_disbalance_threshold: Float, name: String!, sched_move_quota: Long): VshardGroup!
-  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long): UserManagementAPI!
+  auth_params(cookie_max_age: Long, enabled: Boolean, cookie_renew_age: Long, admin_disabled: Boolean): UserManagementAPI!
 
   """Create a new user"""
   add_user(password: String!, username: String!, fullname: String, email: String): User
@@ -623,6 +623,9 @@ type UserManagementAPI {
 
   """Update provided cookie if it's older then this age."""
   cookie_renew_age: Long!
+
+  """Whether admin access is disabled."""
+  admin_disabled: Boolean!
   implements_list_users: Boolean!
 
   """Whether authentication is enabled."""

--- a/test/integration/auth_test.lua
+++ b/test/integration/auth_test.lua
@@ -12,6 +12,7 @@ g.before_all = function()
         datadir = fio.tempdir(),
         server_command = helpers.entrypoint('srv_basic'),
         cookie = require('digest').urandom(6):hex(),
+        env = {TARANTOOL_ADMIN_DISABLED = 'true'},
         replicasets = {
             {
                 uuid = helpers.uuid('a'),
@@ -44,20 +45,20 @@ g.before_all = function()
         cluster_cookie = 'cluster-cookies-for-the-cluster-monster',
         advertise_port = 13303,
         env = {
-            ['TARANTOOL_AUTH_ENABLED'] = 'true'
+            ['TARANTOOL_AUTH_ENABLED'] = 'true',
         }
     })
     g.server:start()
 
     g.server_user = 'admin'
-    local auth_b64 = digest.base64_encode(
+    g.server.auth_b64 = digest.base64_encode(
         g.server_user .. ':' .. g.server.cluster_cookie
     )
 
     t.helpers.retrying({timeout = 5}, function()
         g.server:graphql(
             {query = '{ servers { uri } }'},
-            {http = {headers = {authorization = 'Basic ' .. auth_b64}}}
+            {http = {headers = {authorization = 'Basic ' .. g.server.auth_b64}}}
         )
     end)
 end
@@ -598,6 +599,7 @@ function g.test_set_params_graphql()
                         username
                         enabled
                         cookie_max_age
+                        admin_disabled
                     }
                 }
             }]]}, {
@@ -606,25 +608,29 @@ function g.test_set_params_graphql()
         )['data']['cluster']['auth_params']
     end
 
-    local function set_auth_params(enabled, cookie_max_age)
+    local function set_auth_params(enabled, cookie_max_age, admin_disabled)
         return g.cluster.main_server:graphql({query = [[
             mutation(
                 $enabled: Boolean
                 $cookie_max_age: Long
+                $admin_disabled: Boolean
             ) {
                 cluster {
                     auth_params(
                         enabled: $enabled
                         cookie_max_age: $cookie_max_age
+                        admin_disabled: $admin_disabled
                     ){
                         enabled
                         cookie_max_age
+                        admin_disabled
                     }
                 }
             }]],
             variables = {
                 enabled = enabled,
                 cookie_max_age = cookie_max_age,
+                admin_disabled = admin_disabled,
             }},
             {http = {headers = {cookie = cookie_lsid}}}
         )['data']['cluster']['auth_params']
@@ -684,6 +690,46 @@ function g.test_set_params_graphql()
     t.assert_equals(
         get_auth_params(g.cluster:server('replica'))['username'],
         FULLNAME
+    )
+    t.assert_equals(
+        get_auth_params(g.cluster:server('master'))['admin_disabled'],
+        true
+    )
+    t.assert_equals(
+        _login(g.cluster:server('master'), 'admin', g.cluster.cookie).status,
+        403
+    )
+    t.assert_equals(
+        _login(g.cluster:server('replica'), 'admin', g.cluster.cookie).status,
+        403
+    )
+    t.assert_equals(
+        set_auth_params(nil, nil, false)['admin_disabled'],
+        false
+    )
+    t.assert_equals(
+        get_auth_params(g.cluster:server('master'))['admin_disabled'],
+        false
+    )
+    t.assert_equals(
+        get_auth_params(g.cluster:server('replica'))['admin_disabled'],
+        false
+    )
+    t.assert_equals(
+        _login(g.cluster:server('master'), 'admin', g.cluster.cookie).status,
+        200
+    )
+    t.assert_equals(
+        _login(g.cluster:server('replica'), 'admin', g.cluster.cookie).status,
+        200
+    )
+    t.assert_equals(
+        set_auth_params(nil, nil, true)['admin_disabled'],
+        true
+    )
+    t.assert_equals(
+        _login(g.cluster:server('master'), 'admin', g.cluster.cookie).status,
+        403
     )
 
     local function login(alias)
@@ -818,3 +864,32 @@ function g.test_invalidate_cookie_on_password_change()
     local cookie = resp.headers['set-cookie']
     check_200(server, {headers = {cookie = cookie}})
 end
+
+g.before_test('test_admin_disabled', function()
+    g.server:stop()
+    g.server.env['TARANTOOL_ADMIN_DISABLED'] = 'true'
+end)
+
+g.test_admin_disabled = function()
+    g.server:start()
+
+    t.helpers.retrying({}, function()
+        t.assert_error_msg_contains('Unauthorized', function()
+            g.server:graphql(
+                {query = '{ servers { uri } }'},
+                {http = {headers = {authorization = 'Basic ' .. g.server.auth_b64}}}
+            )
+        end)
+    end)
+
+    t.assert_equals(
+        _login(g.server, 'admin', g.server.cluster_cookie).status,
+        403
+    )
+end
+
+g.after_test('test_admin_disabled', function()
+    g.server:stop()
+    g.server.env['TARANTOOL_ADMIN_DISABLED'] = 'false'
+    g.server:start()
+end)


### PR DESCRIPTION
New ``admin_disabled`` option to disable admin user in the built-in ``auth`` module.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1316 
