### PR TITLE
Add checks if the red circle is before the name of the selected zone

### DIFF
--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -50,13 +50,13 @@ describe('Server details', () => {
 
   function checkRedCircleBeforeSelectedZone(itemName, color) {
     cy.get('.meta-test__ZoneListItem').contains(itemName)
-      .then($els => {
-        const win = $els[0].ownerDocument.defaultView
+      .then(($els) => {
+        const win = $els[0].ownerDocument.defaultView;
         // read the pseudo selector
-        const before = win.getComputedStyle($els[0], 'before')
+        const before = win.getComputedStyle($els[0], 'before');
         // read the value of the content CSS property
-        const contentValue = before.getPropertyValue('background-color')
-        expect(contentValue).to.eq(color)
+        const contentValue = before.getPropertyValue('background-color');
+        expect(contentValue).to.eq(color);
       })
   }
 

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -94,7 +94,7 @@ describe('Server details', () => {
     cy.get('div').contains('You have no any zone,').should('not.exist');
 
     //check red circle is not before not elected zone
-    checkRedCircleBeforeSelectedZone('Narnia','rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Narnia', 'rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Narnia)').click();
     checkRedCircleBeforeSelectedZone('Narnia', 'rgb(245, 34, 45)');
@@ -124,7 +124,7 @@ describe('Server details', () => {
     cy.get('button:contains(Add new zone)').should('be.enabled');
     cy.get('div').contains('Mordor');
     cy.get('div').contains('Narnia').should('not.exist');
-    checkRedCircleBeforeSelectedZone('Mordor','rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Mordor', 'rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
     openServerDetailsModal('dummy-2');
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Mordor)').click();

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -116,8 +116,8 @@ describe('Server details', () => {
     openServerDetailsModal('dummy-1');
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
     cy.get('div').contains('Mordor');
-    //checkRedCircleBeforeSelectedZone(1,'Narnia','rgb(245, 34, 45)');
-   // checkRedCircleBeforeSelectedZone(0,'Mordor','rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Mordor','rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Select zone)').click();
     cy.get('button:contains(Add new zone)').should('be.enabled');

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -49,7 +49,8 @@ describe('Server details', () => {
   }
 
   function checkRedCircleBeforeSelectedZone(itemName, color) {
-    cy.get('.meta-test__ZoneListItem').contains(itemName)
+    cy.get('.meta-test__ZoneListItem')
+      .contains(itemName)
       .then(($els) => {
         const win = $els[0].ownerDocument.defaultView;
         // read the pseudo selector
@@ -57,7 +58,7 @@ describe('Server details', () => {
         // read the value of the content CSS property
         const contentValue = before.getPropertyValue('background-color');
         expect(contentValue).to.eq(color);
-      })
+      });
   }
 
   it('Test: serever-details', () => {
@@ -82,7 +83,7 @@ describe('Server details', () => {
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)');
 
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Narnia)').click();
-    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Narnia', 'rgb(245, 34, 45)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
     cy.get('.meta-test__ServerDetailsModal').should('not.exist');
 
@@ -96,7 +97,7 @@ describe('Server details', () => {
     checkRedCircleBeforeSelectedZone('Narnia','rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Narnia)').click();
-    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Narnia', 'rgb(245, 34, 45)');
     // cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
 
     //add new zone Mordor
@@ -108,16 +109,16 @@ describe('Server details', () => {
 
     //check red circle is before new zone
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Mordor)').click();
-    checkRedCircleBeforeSelectedZone('Narnia','rgba(0, 0, 0, 0)');
-    checkRedCircleBeforeSelectedZone('Mordor','rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Narnia', 'rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Mordor', 'rgb(245, 34, 45)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
 
     //delete zone Narnia
     openServerDetailsModal('dummy-1');
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
     cy.get('div').contains('Mordor');
-    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
-    checkRedCircleBeforeSelectedZone('Mordor','rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Narnia', 'rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Mordor', 'rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Select zone)').click();
     cy.get('button:contains(Add new zone)').should('be.enabled');
@@ -128,7 +129,7 @@ describe('Server details', () => {
     openServerDetailsModal('dummy-2');
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Mordor)').click();
     cy.get('div').contains('Mordor');
-    checkRedCircleBeforeSelectedZone('Mordor','rgb(245, 34, 45)');
+    checkRedCircleBeforeSelectedZone('Mordor', 'rgb(245, 34, 45)');
     cy.get('div').contains('Narnia').should('not.exist');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
 

--- a/webui/cypress/integration/server-details.spec.js
+++ b/webui/cypress/integration/server-details.spec.js
@@ -48,6 +48,18 @@ describe('Server details', () => {
     cy.get('.meta-test__ServerDetailsModal button').contains('Issues 0').click();
   }
 
+  function checkRedCircleBeforeSelectedZone(itemName, color) {
+    cy.get('.meta-test__ZoneListItem').contains(itemName)
+      .then($els => {
+        const win = $els[0].ownerDocument.defaultView
+        // read the pseudo selector
+        const before = win.getComputedStyle($els[0], 'before')
+        // read the value of the content CSS property
+        const contentValue = before.getPropertyValue('background-color')
+        expect(contentValue).to.eq(color)
+      })
+  }
+
   it('Test: serever-details', () => {
     ////////////////////////////////////////////////////////////////////
     cy.log('Alive server');
@@ -68,15 +80,24 @@ describe('Server details', () => {
     cy.get('.meta-test__ZoneAddSubmitBtn').click();
     cy.get('.ZoneAddModal').should('not.exist');
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)');
+
+    cy.get('.meta-test__ServerDetailsModal button:contains(Zone Narnia)').click();
+    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
     cy.get('.meta-test__ServerDetailsModal').should('not.exist');
 
     //checks for dummy-2
+    cy.log('checks for dummy-2');
     openServerDetailsModal('dummy-2');
     cy.get('.meta-test__ServerDetailsModal button:contains(Select zone)').click();
     cy.get('div').contains('You have no any zone,').should('not.exist');
+
+    //check red circle is not before not elected zone
+    checkRedCircleBeforeSelectedZone('Narnia','rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
-    cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
+    cy.get('.meta-test__ServerDetailsModal button:contains(Zone Narnia)').click();
+    checkRedCircleBeforeSelectedZone('Narnia','rgb(245, 34, 45)');
+    // cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
 
     //add new zone Mordor
     cy.get('button:contains(Add new zone)').click();
@@ -84,21 +105,30 @@ describe('Server details', () => {
     cy.get('.meta-test__ZoneAddSubmitBtn').click();
     cy.get('.ZoneAddModal').should('not.exist');
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Mordor)');
+
+    //check red circle is before new zone
+    cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Mordor)').click();
+    checkRedCircleBeforeSelectedZone('Narnia','rgba(0, 0, 0, 0)');
+    checkRedCircleBeforeSelectedZone('Mordor','rgb(245, 34, 45)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
 
     //delete zone Narnia
     openServerDetailsModal('dummy-1');
     cy.get('.meta-test__ServerDetailsModal').find('button:contains(Zone Narnia)').click();
     cy.get('div').contains('Mordor');
+    //checkRedCircleBeforeSelectedZone(1,'Narnia','rgb(245, 34, 45)');
+   // checkRedCircleBeforeSelectedZone(0,'Mordor','rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ZoneListItem:contains(Narnia)').click();
     cy.get('.meta-test__ServerDetailsModal button:contains(Select zone)').click();
     cy.get('button:contains(Add new zone)').should('be.enabled');
     cy.get('div').contains('Mordor');
     cy.get('div').contains('Narnia').should('not.exist');
+    checkRedCircleBeforeSelectedZone('Mordor','rgba(0, 0, 0, 0)');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
     openServerDetailsModal('dummy-2');
     cy.get('.meta-test__ServerDetailsModal button:contains(Zone Mordor)').click();
     cy.get('div').contains('Mordor');
+    checkRedCircleBeforeSelectedZone('Mordor','rgb(245, 34, 45)');
     cy.get('div').contains('Narnia').should('not.exist');
     cy.get('.meta-test__ServerDetailsModal button').contains('Close').click();
 


### PR DESCRIPTION
Check that a small red circle indicator appears near the selected zone and is absent for not active ones.

Close #1471