### PR TITLE
Fix rebalancer death upon roles reload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Fixed
 
 - Fix net.box clients compatibility with future tarantool 2.10 versions.
 
+- Fix vshard rebalancer broken by roles reload.
+
 -------------------------------------------------------------------------------
 [2.7.1] - 2021-08-18
 -------------------------------------------------------------------------------

--- a/cartridge/roles/vshard-storage.lua
+++ b/cartridge/roles/vshard-storage.lua
@@ -67,6 +67,11 @@ local function stop()
             }},
         }}
     }, instance_uuid)
+
+    -- Fake empty config drops all replicas except the current one.
+    -- We have to clean it up manually.
+    vshard.storage.internal.this_replica:detach_conn()
+
     vars.vshard_cfg = nil
     rawset(_G, 'vshard', _G_vshard_backup)
     _G_vshard_backup = nil


### PR DESCRIPTION
Stopping the vshard-storage role still isn't implemented (see https://github.com/tarantool/vshard/issues/121). So we use nasty workarounds to simulate it.

One of the internal netbox connections wasn't closed. It was reused by the rebalancer, but roles reload had corrupted it by killing a control fiber, so the rebalancer got stuck. 

This patch enhances the cleanup and fixes the rebalancer.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] ~~Documentation~~

Close #1562 
