### PR TITLE
ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable-backend-test.yml
+++ b/.github/workflows/reusable-backend-test.yml
@@ -1,0 +1,86 @@
+name: Reusable Backend Test
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: 'The name of the tarantool build artifact'
+        default: ubuntu-focal
+        required: false
+        type: string
+
+env:
+  # Skip building frontend in `tarantoolctl rocks make`.
+  CMAKE_DUMMY_WEBUI: true
+  # Prerequisite for some etcd-related tests.
+  ETCD_PATH: etcd-v2.3.8/etcd
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Clone the cartridge module'
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/cartridge
+
+      # Setup tarantool
+      - name: 'Download the tarantool build artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+      # TODO(ylobankov): Just in case remove tarantool that could be previously
+      # installed on the runner. Relevant to self-hosted runners. Remove this
+      # step when only GitHub-hosted runners are used for integration testing.
+      - run: sudo apt-get -y purge 'tarantool*'
+      - name: 'Install tarantool'
+        # TODO(ylobankov): Install package dependencies. Now we're lucky: all
+        # dependencies are already there.
+        run: sudo dpkg -i tarantool*.deb
+
+      # Setup etcd
+      - name: 'Install etcd'
+        uses: ./.github/actions/setup-etcd
+        with:
+          etcd-version: v2.3.8
+          install-prefix: etcd-v2.3.8
+
+      # Setup luatest
+      - name: 'Install luatest'
+        run: tarantoolctl rocks install luatest 0.5.6
+
+      # Setup pytest
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: 'Install pytest'
+        run: |
+          python -m venv ./pytest-venv && . ./pytest-venv/bin/activate
+          pip install -r test/integration/requirements.txt
+
+      # Setup cartridge
+      - name: 'Install cartridge'
+        run: tarantoolctl rocks make
+
+      # Stop Mono server. This server starts and listen to 8084 port that is
+      # used for tests.
+      - name: 'Stop Mono server'
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
+      # Run tests
+      - name: 'Run luatest'
+        run: .rocks/bin/luatest -v -b
+      - name: 'Run pytest'
+        run: |
+          source ./pytest-venv/bin/activate
+          pytest -v
+
+      # TODO(ylobankov): Relevant to self-hosted runners. Remove this step
+      # when only GitHub-hosted runners are used for integration testing.
+      - if: always()
+        run: rm -rf .rocks pytest-venv
+
+      # TODO(ylobankov): Relevant to self-hosted runners. Remove this step
+      # when only GitHub-hosted runners are used for integration testing.
+      - if: always()
+        run: sudo apt-get -y purge 'tarantool*'


### PR DESCRIPTION
The idea of this workflow is to be a part of the `integration.yml`
workflow from the tarantool repo to verify the integration of the
cartridge module with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the `workflow_call` trigger. This workflow
will be included in the tarantool development cycle and called by the
`integration.yml` workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
cartridge.

Part of tarantool/tarantool#6512
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056