### PR TITLE
Check config checksum mismatch during ``rpc.get_candidates``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,10 @@ Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Update ``http`` dependency to 1.1.1
+- ``config_checksum`` is added to membership payload. It is used to detect
+  config mismatch.
+- Members with config checksum mismatch are not returned as a result of
+  ``cartridge.rpc.get_candidates`` when ``opts.healthy_only`` is ``true``.
 
 -------------------------------------------------------------------------------
 [2.7.3] - 2021-10-27

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -239,9 +239,15 @@ clusterwide_config_mt = {
             end
         end,
 
-        get_checksum = function(self)
-            checks('ClusterwideConfig')
+        get_checksum = function(self, section_name)
+            checks('ClusterwideConfig', '?string')
             assert(self._plaintext ~= nil)
+
+            if section_name then
+                local checksum = digest.crc32.new()
+                checksum:update(self._plaintext[section_name] or '')
+                return checksum:result()
+            end
 
             if self._checksum == nil then
                 self:generate_checksum()

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -252,6 +252,10 @@ local function apply_config(clusterwide_config)
     )
 
     vars.clusterwide_config = clusterwide_config
+    membership.set_payload(
+        'topology_checksum',
+        vars.clusterwide_config:get_checksum('topology.yml')
+    )
     set_state('ConfiguringRoles')
 
     local topology_cfg = clusterwide_config:get_readonly('topology')
@@ -722,6 +726,22 @@ local function get_deepcopy(section)
     return vars.clusterwide_config:get_deepcopy(section)
 end
 
+--- Get a checksum of the clusterwide configuration.
+--
+-- Returns either checksum of specified section or entire configuration.
+-- Specified section must be present in configuration
+-- or it will result in assertion error.
+-- @function get_checksum
+-- @tparam[opt] string section_name
+-- @return number
+local function get_config_checksum(section)
+    checks('?string')
+    if vars.clusterwide_config == nil then
+        return nil
+    end
+    return vars.clusterwide_config:get_checksum(section)
+end
+
 _G.__cartridge_confapplier_restart_replication = restart_replication
 
 return {
@@ -735,6 +755,7 @@ return {
     get_active_config = get_active_config,
     get_readonly = get_readonly,
     get_deepcopy = get_deepcopy,
+    get_checksum = get_config_checksum,
 
     set_state = set_state,
     wish_state = wish_state,

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -60,7 +60,9 @@ local function member_has_same_topology(uri, local_checksum)
 end
 
 
---- List instances suitable for performing a remote call.
+--- List candidates suitable for performing a remote call.
+--  Candidates are deduced from a local config and membership, so there is a
+--  chance that some of them are not valid (e.g. during `patch_clusterwide`).
 --
 -- @function get_candidates
 --
@@ -76,7 +78,8 @@ end
 --   (default: **false**)
 -- @tparam ?boolean opts.healthy_only
 --   The member is considered healthy if
---   it reports either `ConfiguringRoles` or `RolesConfigured` state
+--   it reports either `ConfiguringRoles` or `RolesConfigured` state,
+--   its config checksum is equal to the local one
 --   and its SWIM status is either `alive` or `suspect`
 --   (added in v1.1.0-11, default: **true**)
 --
@@ -127,6 +130,8 @@ local function get_candidates(role_name, opts)
 end
 
 --- Connect to an instance with an enabled role.
+--  Candidates are deduced from a local config and membership, so there is a
+--  chance that some of them are not valid (e.g. during `patch_clusterwide`).
 --
 -- @function get_connection
 -- @local

--- a/test/integration/rpc_candidates_test.lua
+++ b/test/integration/rpc_candidates_test.lua
@@ -1,0 +1,99 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = 'secret',
+        swim_period = 0.05,
+        replicasets = {
+            {
+                alias = 'A',
+                uuid = helpers.uuid('a'),
+                roles = {},
+                servers = {{
+                    http_port = 8081,
+                    advertise_port = 13301,
+                    instance_uuid = helpers.uuid('a', 'a', 1)
+                }},
+            },
+            {
+                alias = 'B',
+                uuid = helpers.uuid('b'),
+                roles = {},
+                servers = {{
+                    http_port = 8082,
+                    advertise_port = 13302,
+                    instance_uuid = helpers.uuid('b', 'b', 1)
+                }},
+            }
+        },
+    })
+
+    g.A1 = g.cluster:server('A-1')
+    g.B1 = g.cluster:server('B-1')
+
+    g.cluster:start()
+
+    g.A1:eval([[
+        _G.commit_is_done = false
+        _G.old_commit = _G.__cartridge_clusterwide_config_commit_2pc
+        _G.__cartridge_clusterwide_config_commit_2pc = function(...)
+            local res, err = _G.old_commit(...)
+            _G.commit_is_done = true
+            return res, err
+        end
+    ]])
+
+    g.B1:eval([[
+        _G.old_commit = _G.__cartridge_clusterwide_config_commit_2pc
+        _G.__cartridge_clusterwide_config_commit_2pc = function(...)
+            package.loaded.fiber.sleep(1)
+            return _G.old_commit(...)
+        end
+    ]])
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+
+g.test_config_mismatch = function()
+    -- Assign role 'myrole' on B
+    g.A1:call(
+        'package.loaded.cartridge.admin_edit_topology',
+        {{
+            replicasets = {{
+                uuid = helpers.uuid('b'),
+                roles = {'myrole'}
+            }}
+        }},
+        {is_async = true}
+    )
+    -- A1 should commit config before B1
+    t.helpers.retrying({}, function()
+        local ready = g.A1:eval([[return _G.commit_is_done]])
+        t.assert(ready)
+    end)
+
+    -- A1 thinks that 'myrole' is active on B1 (it assumes judging from its
+    -- local config).
+    -- But commit_2pc is stuck on B1 and role isn't applied.
+    -- However A1 shouldn't return B1 as a candidate because there is a config
+    -- checksum mismatch deduced from membership.
+    local candidates, err = g.A1:eval([[
+        local rpc = require('cartridge.rpc')
+        local _, err = rpc.call('myrole', 'dog_goes', nil, {same_topology = true})
+        local candidates = rpc.get_candidates('myrole', {same_topology = true})
+        return candidates, err
+    ]])
+
+    t.assert_str_contains(err.err, 'No remotes with role \"myrole\" available')
+    t.assert_equals(candidates, {})
+end

--- a/test/unit/clusterwide_config_test.lua
+++ b/test/unit/clusterwide_config_test.lua
@@ -429,8 +429,12 @@ function g.test_checksum()
     -- checksum as well
     cfg1:set_plaintext('b', 'Hello there')
     t.assert_not_equals(cfg1:get_checksum(), cfg2:get_checksum())
+    t.assert_equals(cfg1:get_checksum('a'), cfg2:get_checksum('a'))
+    t.assert_not_equals(cfg1:get_checksum('b'), cfg2:get_checksum('b'))
     cfg2:set_plaintext('b', 'Hello there')
     t.assert_equals(cfg1:get_checksum(), cfg2:get_checksum())
+    t.assert_equals(cfg1:get_checksum('a'), cfg2:get_checksum('a'))
+    t.assert_equals(cfg1:get_checksum('b'), cfg2:get_checksum('b'))
 
     -- Sections and their content should be hashed separatly
     t.assert_not_equals(

--- a/test/unit/rpc_candidates_test.lua
+++ b/test/unit/rpc_candidates_test.lua
@@ -80,6 +80,7 @@ local function apply_mocks(topology_draft)
                     payload = {
                         uuid = srv.uuid,
                         state = srv.state,
+                        config_checksum = srv.config_checksum,
                     }
                 }
             end
@@ -104,6 +105,9 @@ local function apply_mocks(topology_draft)
 
     package.loaded['membership'].get_member = function(uri)
         return members[uri]
+    end
+    package.loaded['cartridge.confapplier'].get_checksum = function()
+        return '1'
     end
 end
 
@@ -141,11 +145,13 @@ local draft = {
             uuid = 'a1',
             status = 'alive',
             state = 'RolesConfigured',
+            config_checksum = '1',
         },
         [2] = {
             uuid = 'a2',
             status = 'alive',
             state = 'RolesConfigured',
+            config_checksum = '1',
         },
     },
     [2] = {
@@ -156,11 +162,13 @@ local draft = {
             uuid = 'b1',
             status = 'alive',
             state = 'RolesConfigured',
+            config_checksum = '1',
         },
         [2] = {
             uuid = 'b2',
             status = 'alive',
             state = 'RolesConfigured',
+            config_checksum = '1',
         },
     }
 }
@@ -183,6 +191,21 @@ test_candidates('+leader',
     draft, {'target-role', {leader_only = true}},
     {'a1'}
 )
+-------------------------------------------------------------------------------
+draft[1][1].config_checksum = '2'
+log.info('a1 leader config checksum mismatch')
+
+test_candidates('-leader +healthy',
+    draft, {'target-role'},
+    {'a2'}
+)
+
+test_candidates('+leader +healthy',
+    draft, {'target-role', {leader_only = true}},
+    {}
+)
+draft[1][1].config_checksum = '1'
+log.info('a1 leader restored')
 
 -------------------------------------------------------------------------------
 draft[1][1].status = 'suspect'

--- a/test/unit/rpc_candidates_test.lua
+++ b/test/unit/rpc_candidates_test.lua
@@ -1,340 +1,245 @@
-#!/usr/bin/env tarantool
-
 local fio = require('fio')
-local log = require('log')
-local rpc = require('cartridge.rpc')
-local checks = require('checks')
-local yaml = require('yaml')
 
 local helpers = require('test.helper')
 local t = require('luatest')
 local g = t.group()
 
-function g.setup()
-    g.server = t.Server:new({
+g.before_all(function()
+    g.server = helpers.Server:new({
+        alias = 'master',
+        cluster_cookie = 'oreo',
         command = helpers.entrypoint('srv_empty'),
         workdir = fio.tempdir(),
-        net_box_port = 13301,
+        advertise_port = 13301,
         http_port = 8082,
         net_box_credentials = {user = 'admin', password = ''},
     })
-
     g.server:start()
-    helpers.retrying({}, t.Server.connect_net_box, g.server)
-    g.server:eval([[
-        _G.test = require('test.unit.rpc_candidates_test')
-    ]])
-end
 
-function g.teardown()
-    g.server:stop()
-    fio.rmtree(g.server.workdir)
-end
-
-local M = {}
-local function test_remotely(fn_name, fn)
-    M[fn_name] = fn
-    g[fn_name] = function()
-        g.server:eval([[
-            local test = require('test.unit.rpc_candidates_test')
-            local ok, err = pcall(test[...])
-            if not ok then
-                error(err.message, 0)
-            end
-        ]], {fn_name})
-    end
-end
-
--------------------------------------------------------------------------------
-
-local function apply_mocks(topology_draft)
-    local members = {}
-    local topology_cfg = {
-        failover = topology_draft.failover,
-        replicasets = {},
-        servers = {},
-    }
-
-    for _, rpl in ipairs(topology_draft) do
-        topology_cfg.replicasets[rpl.uuid] = {
-            master = rpl[rpl.leader].uuid,
-            roles = {
-                [rpl.role] = true,
-            }
-        }
-
-        for _, srv in ipairs(rpl) do
-            local uri = srv.uuid
-            topology_cfg.servers[srv.uuid] = {
-                uri = uri,
-                disabled = srv.disabled or false,
-                replicaset_uuid = rpl.uuid,
+    g.server:exec(function()
+        rawset(_G, 'apply_mocks', function(topology_draft)
+            local yaml = require('yaml')
+            local members = {}
+            local topology_cfg = {
+                failover = topology_draft.failover,
+                replicasets = {},
+                servers = {},
             }
 
-            if srv.status == nil then
-                members[uri] = nil
-            else
-                members[uri] = {
-                    uri = uri,
-                    status = srv.status,
-                    payload = {
-                        uuid = srv.uuid,
-                        state = srv.state,
-                        config_checksum = srv.config_checksum,
+            for _, rpl in ipairs(topology_draft) do
+                topology_cfg.replicasets[rpl.uuid] = {
+                    master = rpl[rpl.leader].uuid,
+                    roles = {
+                        [rpl.role] = true,
                     }
                 }
+
+                for _, srv in ipairs(rpl) do
+                    local uri = srv.uuid
+                    topology_cfg.servers[srv.uuid] = {
+                        uri = uri,
+                        disabled = srv.disabled or false,
+                        replicaset_uuid = rpl.uuid,
+                    }
+
+                    if srv.status == nil then
+                        members[uri] = nil
+                    else
+                        members[uri] = {
+                            uri = uri,
+                            status = srv.status,
+                            payload = {
+                                uuid = srv.uuid,
+                                state = srv.state,
+                                topology_checksum = srv.topology_checksum,
+                            }
+                        }
+                    end
+                end
             end
-        end
-    end
 
-    local vars = require('cartridge.vars').new('cartridge.confapplier')
-    local ClusterwideConfig = require('cartridge.clusterwide-config')
-    vars.clusterwide_config = ClusterwideConfig.new({
-        ['topology.yml'] = yaml.encode(topology_cfg)
-    }):lock()
-    local failover = require('cartridge.failover')
-    _G.box = {
-        cfg = function() end,
-        error = box.error,
-        info = {
-            cluster = {uuid = 'A'},
-            uuid = 'a1',
-        },
-    }
-    failover.cfg(vars.clusterwide_config)
+            local vars = require('cartridge.vars').new('cartridge.confapplier')
+            local ClusterwideConfig = require('cartridge.clusterwide-config')
+            vars.clusterwide_config = ClusterwideConfig.new({
+                ['topology.yml'] = yaml.encode(topology_cfg)
+            }):lock()
+            local failover = require('cartridge.failover')
+            _G.box = {
+                cfg = function() end,
+                error = box.error,
+                info = {
+                    cluster = {uuid = 'A'},
+                    uuid = 'a1',
+                },
+            }
+            failover.cfg(vars.clusterwide_config)
 
-    package.loaded['membership'].get_member = function(uri)
-        return members[uri]
-    end
-    package.loaded['cartridge.confapplier'].get_checksum = function()
-        return '1'
-    end
-end
-
-local function values(array)
-    if array == nil then
-        return nil
-    end
-
-    local ret = {}
-    for _, v in pairs(array) do
-        ret[v] = true
-    end
-    return ret
-end
-
-local function test_candidates(test_name, replicasets, opts, expected)
-    checks('string', 'table', 'table', 'nil|table')
-    apply_mocks(replicasets)
-
-    t.assert_equals(
-        values(rpc.get_candidates(unpack(opts))),
-        values(expected),
-        test_name
-    )
-end
-
--------------------------------------------------------------------------------
-
-local draft = {
-    [1] = {
-        uuid = 'A',
-        role = 'target-role',
-        leader = 1,
-        [1] = {
-            uuid = 'a1',
-            status = 'alive',
-            state = 'RolesConfigured',
-            config_checksum = '1',
-        },
-        [2] = {
-            uuid = 'a2',
-            status = 'alive',
-            state = 'RolesConfigured',
-            config_checksum = '1',
-        },
-    },
-    [2] = {
-        uuid = 'B',
-        leader = 1,
-        role = 'some-other-role',
-        [1] = {
-            uuid = 'b1',
-            status = 'alive',
-            state = 'RolesConfigured',
-            config_checksum = '1',
-        },
-        [2] = {
-            uuid = 'b2',
-            status = 'alive',
-            state = 'RolesConfigured',
-            config_checksum = '1',
-        },
-    }
-}
-
-test_remotely('test_all', function()
--------------------------------------------------------------------------------
-log.info('all alive')
-
-test_candidates('invalid-role',
-    draft, {'invalid-role'},
-    {}
-)
-
-test_candidates('-leader',
-    draft, {'target-role'},
-    {'a1', 'a2'}
-)
-
-test_candidates('+leader',
-    draft, {'target-role', {leader_only = true}},
-    {'a1'}
-)
--------------------------------------------------------------------------------
-draft[1][1].config_checksum = '2'
-log.info('a1 leader config checksum mismatch')
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a2'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {}
-)
-draft[1][1].config_checksum = '1'
-log.info('a1 leader restored')
-
--------------------------------------------------------------------------------
-draft[1][1].status = 'suspect'
-log.info('a1 leader suspect')
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a1', 'a2'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {'a1'}
-)
-
--------------------------------------------------------------------------------
-draft[1][1].status = 'dead'
-log.info('a1 leader died')
-
-test_candidates('-leader -healthy',
-    draft, {'target-role', {healthy_only = false}},
-    {'a1', 'a2'}
-)
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a2'}
-)
-
-test_candidates('+leader -healthy',
-    draft, {'target-role', {leader_only = true, healthy_only = false}},
-    {'a1'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {}
-)
-
--------------------------------------------------------------------------------
-draft.failover = true
-log.info('failover enabled')
-
-test_candidates('-leader -healthy',
-    draft, {'target-role', {healthy_only = false}},
-    {'a1', 'a2'}
-)
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a2'}
-)
-
-test_candidates('+leader -healthy',
-    draft, {'target-role', {leader_only = true, healthy_only = false}},
-    {'a2'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {'a2'}
-)
-
--------------------------------------------------------------------------------
-draft.failover = false
-log.info('failover disabled')
-draft[1][1].status = 'alive'
-log.info('a1 leader restored')
-draft[2].role = 'target-role'
-log.info('B target-role enabled')
-
-test_candidates('-leader',
-    draft, {'target-role'},
-    {'a1', 'a2', 'b1', 'b2'}
-)
-
-test_candidates('+leader',
-    draft, {'target-role', {leader_only = true}},
-    {'a1', 'b1'}
-)
-
--------------------------------------------------------------------------------
-draft[2][1].state = 'BootError'
-log.info('b1 has an error')
-
-test_candidates('-leader -healthy',
-    draft, {'target-role', {healthy_only = false}},
-    {'a1', 'a2', 'b2', 'b1'}
-)
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a1', 'a2', 'b2'}
-)
-
-test_candidates('+leader -healthy',
-    draft, {'target-role', {leader_only = true, healthy_only = false}},
-    {'a1', 'b1'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {'a1'}
-)
-
--------------------------------------------------------------------------------
-draft[1][1].disabled = true
-log.info('a1 disabled')
-
-test_candidates('-leader -healthy',
-    draft, {'target-role', {healthy_only = false}},
-    {'a2', 'b2', 'b1'}
-)
-
-test_candidates('-leader +healthy',
-    draft, {'target-role'},
-    {'a2', 'b2'}
-)
-
-test_candidates('+leader -healthy',
-    draft, {'target-role', {leader_only = true, healthy_only = false}},
-    {'b1'}
-)
-
-test_candidates('+leader +healthy',
-    draft, {'target-role', {leader_only = true}},
-    {}
-)
-
+            package.loaded['membership'].get_member = function(uri)
+                return members[uri]
+            end
+            package.loaded['cartridge.confapplier'].get_checksum = function()
+                return '1'
+            end
+        end)
+    end)
 end)
 
-return M
+g.after_all(function()
+    g.server:stop()
+    fio.rmtree(g.server.workdir)
+end)
+
+local draft = {}
+g.before_each(function()
+    draft = {
+        [1] = {
+            uuid = 'A',
+            role = 'target-role',
+            leader = 1,
+            [1] = {
+                uuid = 'a1',
+                status = 'alive',
+                state = 'RolesConfigured',
+                topology_checksum = '1',
+            },
+            [2] = {
+                uuid = 'a2',
+                status = 'alive',
+                state = 'RolesConfigured',
+                topology_checksum = '1',
+            },
+        },
+        [2] = {
+            uuid = 'B',
+            leader = 1,
+            role = 'some-other-role',
+            [1] = {
+                uuid = 'b1',
+                status = 'alive',
+                state = 'RolesConfigured',
+                topology_checksum = '1',
+            },
+            [2] = {
+                uuid = 'b2',
+                status = 'alive',
+                state = 'RolesConfigured',
+                topology_checksum = '1',
+            },
+        }
+    }
+end)
+
+local function get_candidates(role, opts)
+    return g.server:eval([[
+        local rpc = require('cartridge.rpc')
+        return rpc.get_candidates(...)
+    ]], {role, opts})
+end
+
+local function apply_topology(topology_draft)
+    g.server:call('_G.apply_mocks', {topology_draft})
+end
+
+g.test_all_alive = function()
+    apply_topology(draft)
+
+    local candidates = get_candidates('invalid-role')
+    t.assert_items_equals(candidates, {})
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a1', 'a2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {'a1'})
+end
+
+g.test_config_mismatch = function()
+    draft[1][1].topology_checksum = '2'
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role', {same_topology = true})
+    t.assert_items_equals(candidates, {'a2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true, same_topology = true})
+    t.assert_items_equals(candidates, {})
+end
+
+g.test_failover = function()
+    draft[1][1].status = 'dead'
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role', {healthy_only = false})
+    t.assert_items_equals(candidates, {'a1', 'a2'})
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true, healthy_only = false})
+    t.assert_items_equals(candidates, {'a1'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {})
+
+    draft.failover = true
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role', {healthy_only = false})
+    t.assert_items_equals(candidates, {'a1', 'a2'})
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true, healthy_only = false})
+    t.assert_items_equals(candidates, {'a2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {'a2'})
+
+    draft.failover = false
+    draft[1][1].status = 'alive'
+    draft[2].role = 'target-role'
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a1', 'a2', 'b1', 'b2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {'a1', 'b1'})
+end
+
+g.test_error = function()
+    draft[2].role = 'target-role'
+    draft[2][1].state = 'BootError'
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role', {healthy_only = false})
+    t.assert_items_equals(candidates, {'a1', 'a2', 'b1', 'b2'})
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a1', 'a2', 'b2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true, healthy_only = false})
+    t.assert_items_equals(candidates, {'a1', 'b1'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {'a1'})
+end
+
+g.test_disabled = function()
+    draft[2].role = 'target-role'
+    draft[2][1].state = 'BootError'
+    draft[1][1].disabled = true
+    apply_topology(draft)
+
+    local candidates = get_candidates('target-role', {healthy_only = false})
+    t.assert_items_equals(candidates, {'a2', 'b1', 'b2'})
+
+    local candidates = get_candidates('target-role')
+    t.assert_items_equals(candidates, {'a2', 'b2'})
+
+    local candidates = get_candidates('target-role', {leader_only = true, healthy_only = false})
+    t.assert_items_equals(candidates, {'b1'})
+
+    local candidates = get_candidates('target-role', {leader_only = true})
+    t.assert_items_equals(candidates, {})
+end


### PR DESCRIPTION
New rpc option ``same_topology`` to filter replicas with topology checksum mismatch. Checksum to compare is obtained from membership.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1575 
