### PR TITLE
Add an anchor link to refer to stateful failover

### DIFF
--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -92,6 +92,8 @@ that yet. So, both S1 and S2 consider themselves as leaders.
 Moreover, SWIM protocol isn't perfect and still can produce
 false-negative gossips (announce the instance is dead when it's not).
 
+..  _cartridge-stateful-failover:
+
 *******************************************************************************
 Stateful failover
 *******************************************************************************

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -92,7 +92,7 @@ that yet. So, both S1 and S2 consider themselves as leaders.
 Moreover, SWIM protocol isn't perfect and still can produce
 false-negative gossips (announce the instance is dead when it's not).
 
-..  _cartridge-stateful-failover:
+..  _cartridge-stateful_failover:
 
 *******************************************************************************
 Stateful failover


### PR DESCRIPTION
I need to create a reference from cartridge-cli docs, so that people can follow a link and read up on the stateboard concept.