### PR TITLE
Fix Python version in CI

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -88,6 +88,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
       - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1
         with:

--- a/test/integration/requirements.txt
+++ b/test/integration/requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.2.3
+pytest==3.2.4
 pyyaml==5.4
 requests==2.20.0
 tarantool==0.7.1


### PR DESCRIPTION
Something is wrong with the compatibility of cached pytest and python 3.10. I've fixed Python version to 3.9 in tests and updated pytest requirement.

https://github.com/tarantool/cartridge/runs/4180543587?check_suite_focus=true
