### PR TITLE
allow to extract filename from http request body

### DIFF
--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -34,3 +34,42 @@ function g.test_randomize_path()
 
     digest.urandom = urandom_original
 end
+
+function g.test_http_read_body()
+    local body = '--c187dde3e9318fcc6509f45f76a89424\r\n'..
+    'Content-Disposition: form-data; name="file"; filename="sample.txt"\r\n' ..
+    'Content-Type: text/plain\r\n' ..
+    '\r\n' ..
+    'Content file\r\n' ..
+    '--c187dde3e9318fcc6509f45f76a89424--'
+    local req = {
+        read = function()
+            return body
+        end,
+        headers = {
+            ['content-type'] = 'multipart/form-data; boundary=c187dde3e9318fcc6509f45f76a89424',
+        }
+    }
+    local payload, err, meta = utils.http_read_body(req)
+    t.assert_equals(payload, 'Content file')
+    t.assert_not(err)
+    t.assert_equals(meta, {filename = 'sample.txt'})
+
+    local body = '--c187dde3e9318fcc6509f45f76a89424\r\n'..
+    '\r\n' ..
+    '\r\n' ..
+    'Content file\r\n' ..
+    '--c187dde3e9318fcc6509f45f76a89424--'
+    local req = {
+        read = function()
+            return body
+        end,
+        headers = {
+            ['content-type'] = 'multipart/form-data; boundary=c187dde3e9318fcc6509f45f76a89424',
+        }
+    }
+    local payload, err, meta = utils.http_read_body(req)
+    t.assert_equals(payload, 'Content file')
+    t.assert_not(err)
+    t.assert_equals(meta, {})
+end


### PR DESCRIPTION
This patch introduces the third argument for metadata of http
request parsing (the second is reserved for an error). Before this
patch function http_read_body returned only file content. However
some of our customers want to know filename as well. It's not so
hard to implement because body headers have such info and the main
goal of this patch is to implement needed logic for header
extraction.

---
Need for https://github.com/tarantool/tdg2/issues/1207
