### PR TITLE
Add `Cluster:server_by_role` method

### DIFF
--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -9,6 +9,7 @@ local log = require('log')
 local uuid = require('uuid')
 
 local luatest = require('luatest')
+local utils = require('cartridge.utils')
 local Server = require('cartridge.test-helpers.server')
 local Stateboard = require('cartridge.test-helpers.stateboard')
 
@@ -159,15 +160,9 @@ end
 --- Return iterator for cluster server's with enabled role
 local function iter_servers_by_role(cluster, role_name)
     local replicasets_with_role = fun.iter(cluster.replicasets)
-    :filter(function(rs)
-        return fun.iter(rs.roles)
-            :filter(function(role)
-                return role == role_name
-            end)
-            :nth(1)
-    end)
-    :map(function(rs) return rs.uuid, true end)
-    :tomap()
+        :map(function(rs) return rs.uuid, rs.roles end)
+        :map(function(rs_uuid, roles) return rs_uuid, utils.table_find(roles, role_name) ~= nil end)
+        :tomap()
 
     return fun.iter(cluster.servers)
         :filter(function(server)

--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -156,6 +156,25 @@ function Cluster:server(alias)
     error('Server ' .. alias .. ' not found', 2)
 end
 
+function Cluster:server_by_role(role_name)
+    local replicasets_with_role = fun.iter(self.replicasets)
+        :filter(function(rs)
+            return fun.iter(rs.roles)
+                :filter(function(role)
+                    return role == role_name
+                end)
+                :nth(1)
+        end)
+        :map(function(rs) return rs.uuid, true end)
+        :tomap()
+
+    return fun.iter(self.servers)
+        :filter(function(server)
+            return replicasets_with_role[server.replicaset_uuid]
+        end)
+        :nth(1)
+end
+
 --- Execute `edit_topology` GraphQL request to setup replicasets, apply roles
 -- join servers to replicasets.
 function Cluster:apply_topology()

--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -156,6 +156,9 @@ function Cluster:server(alias)
     error('Server ' .. alias .. ' not found', 2)
 end
 
+--- Find server by role name.
+-- @string role_name
+-- @return @{cartridge.test-helpers.server}
 function Cluster:server_by_role(role_name)
     local replicasets_with_role = fun.iter(self.replicasets)
         :filter(function(rs)

--- a/test/unit/helpers_test.lua
+++ b/test/unit/helpers_test.lua
@@ -46,6 +46,20 @@ local function build_cluster(config)
     return helpers.Cluster:new(config)
 end
 
+function g.test_server_by_role()
+    local cluster = build_cluster({replicasets = {
+        {roles = {'vshard-router', 'vshard-storage'}, alias = 'vshard', servers = 1},
+        {roles = {'my-role'}, alias = 'myrole', servers = {
+            {alias = 'custom-alias'},
+            {},
+        }},
+    }})
+
+    t.assert_equals(cluster:server_by_role('vshard-router'), cluster.servers[1])
+    t.assert_equals(cluster:server_by_role('vshard-storage'), cluster.servers[1])
+    t.assert_equals(cluster:server_by_role('my-role'), cluster.servers[2])
+end
+
 function g.test_cluster_bootstrap()
     for i, server in ipairs(g.cluster.servers) do
         t.assert_equals(type(server.process.pid), 'number', 'Server ' .. i .. ' not started')

--- a/test/unit/helpers_test.lua
+++ b/test/unit/helpers_test.lua
@@ -60,6 +60,17 @@ function g.test_server_by_role()
     t.assert_equals(cluster:server_by_role('my-role'), cluster.servers[2])
 end
 
+function g.test_servers_by_role()
+    local cluster = build_cluster({replicasets = {
+        {roles = {'vshard-router', 'vshard-storage'}, alias = 'vshard', servers = 2},
+        {roles = {'my-role'}, alias = 'myrole', servers = 2},
+    }})
+
+    t.assert_equals(cluster:servers_by_role('vshard-router'), {cluster.servers[1], cluster.servers[2]})
+    t.assert_equals(cluster:servers_by_role('vshard-storage'), {cluster.servers[1], cluster.servers[2]})
+    t.assert_equals(cluster:servers_by_role('my-role'), {cluster.servers[3], cluster.servers[4]})
+end
+
 function g.test_cluster_bootstrap()
     for i, server in ipairs(g.cluster.servers) do
         t.assert_equals(type(server.process.pid), 'number', 'Server ' .. i .. ' not started')


### PR DESCRIPTION
## What has been done? Why? What problem is being solved?
Added a method that allows you to get a server from a test cluster by the name of the role that is applied on the server.

I didn't forget about

- [X] Tests
- [ ] Changelog
- [X] Documentation

Close #1615
