### PR TITLE
Fix python version in CI

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.9.8'
       - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1
         with:


### PR DESCRIPTION
https://github.com/tarantool/cartridge/runs/4323896935?check_suite_focus=true

Python "3.9" now is "3.9.9", fix version to previous stable "3.9.8".