### PR TITLE
fix fetch-schema script on macos

### DIFF
--- a/.graphqlconfig.yaml
+++ b/.graphqlconfig.yaml
@@ -3,4 +3,4 @@ projects:
     schemaPath: schema.graphql
     extensions:
       endpoints:
-        default: 'http://localhost:8081/admin/api'
+        default: 'http://127.0.0.1:8081/admin/api'

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,4 +1,4 @@
-# source: http://localhost:8081/admin/api
+# source: http://127.0.0.1:8081/admin/api
 # timestamp: Mon Oct 04 2021 17:36:12 GMT+0300 (Moscow Standard Time)
 
 """Cluster management"""


### PR DESCRIPTION
localhost on macos could be considered as IPv6 adress. It led to
following issue: "reason: connect ECONNREFUSED ::1:8081". Let's
replace it to 127.0.0.1 (that is IPv4 as expected) to solve an
issue.

Closes #1628
