### PR TITLE
Fix console syntax highlighting in docs

### DIFF
--- a/rst/cartridge_admin.rst
+++ b/rst/cartridge_admin.rst
@@ -38,7 +38,7 @@ Tarantool instances according to the desired cluster topology, for example:
 Then :ref:`start the instances <cartridge-run>`, for example using
 ``cartridge`` CLI:
 
-..  code-block:: console
+..  code-block:: shell
 
     $ cartridge start my_app --cfg demo.yml --run_dir ./tmp/run --foreground
 
@@ -622,7 +622,7 @@ Each Tarantool node (``router``/``storage``) provides an administrative console
 console acts as a Lua interpreter and displays the result in the human-readable
 YAML format. To connect to a Tarantool instance via the console, say:
 
-..  code-block:: console
+..  code-block:: shell
 
     $ tarantoolctl connect <instance_hostname>:<port>
 

--- a/rst/cartridge_admin.rst
+++ b/rst/cartridge_admin.rst
@@ -38,7 +38,7 @@ Tarantool instances according to the desired cluster topology, for example:
 Then :ref:`start the instances <cartridge-run>`, for example using
 ``cartridge`` CLI:
 
-..  code-block:: shell
+..  code-block:: bash
 
     $ cartridge start my_app --cfg demo.yml --run_dir ./tmp/run --foreground
 
@@ -622,7 +622,7 @@ Each Tarantool node (``router``/``storage``) provides an administrative console
 console acts as a Lua interpreter and displays the result in the human-readable
 YAML format. To connect to a Tarantool instance via the console, say:
 
-..  code-block:: shell
+..  code-block:: bash
 
     $ tarantoolctl connect <instance_hostname>:<port>
 

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -63,7 +63,7 @@ Creating a project
 To set up your development environment, create a project using the
 Tarantool Cartridge project template. In any directory, run:
 
-.. code-block:: console
+.. code-block:: shell
 
    $ cartridge create --name <app_name> /path/to/
 
@@ -827,7 +827,7 @@ For example, if your application has version 1.2.1, tag your current branch with
 
 To retrieve the current version from Git, run:
 
-..  code-block:: console
+..  code-block:: shell
 
     $ git describe --long --tags
     1.2.1-12-g74864f2
@@ -977,7 +977,7 @@ To deploy your Tarantool Cartridge application:
 
 #.  Pack the application into a deliverable:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ cartridge pack rpm [APP_PATH] [--use-docker]
         $ # -- OR --
@@ -1002,7 +1002,7 @@ To deploy your Tarantool Cartridge application:
 
 #.  Install the application:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ sudo yum install <APP_NAME>-<VERSION>.rpm
         $ # -- OR --
@@ -1043,7 +1043,7 @@ To deploy your Tarantool Cartridge application:
 
     For more details, see :ref:`cartridge-run-systemctl`.
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ sudo systemctl start my_app@router
         $ sudo systemctl start my_app@storage-master
@@ -1152,7 +1152,7 @@ Deploying as a tar+gz archive
 
 #.  Pack the application into a distributable:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ cartridge pack tgz APP_NAME
 
@@ -1163,7 +1163,7 @@ Deploying as a tar+gz archive
 
 #.  Extract the archive:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ tar -xzvf APP_NAME-VERSION.tgz
 
@@ -1190,13 +1190,13 @@ Deploying as a tar+gz archive
 
     *   :ref:`tarantool <cartridge-run-tarantool>`, for example:
 
-        ..  code-block:: console
+        ..  code-block:: shell
 
             $ tarantool init.lua # starts a single instance
 
     *   or :ref:`cartridge <cartridge-run-cartridge>`, for example:
 
-        ..  code-block:: console
+        ..  code-block:: shell
 
             $ # in application directory
             $ cartridge start # starts all instances
@@ -1231,7 +1231,7 @@ This deployment method is intended for local testing only.
 
 #.  Pull all dependencies to the ``.rocks`` directory:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ tarantoolctl rocks make
 
@@ -1258,13 +1258,13 @@ This deployment method is intended for local testing only.
 
     *   :ref:`tarantool <cartridge-run-tarantool>`, for example:
 
-        ..  code-block:: console
+        ..  code-block:: shell
 
             $ tarantool init.lua # starts a single instance
 
     *   or :ref:`cartridge <cartridge-run-cartridge>`, for example:
 
-        ..  code-block:: console
+        ..  code-block:: shell
 
             $ # in application directory
             $ cartridge start # starts all instances
@@ -1308,7 +1308,7 @@ Start/stop using tarantool
 
 With ``tarantool``, you can start only a single instance:
 
-..  code-block:: console
+..  code-block:: shell
 
     # the simplest command
     $ tarantool init.lua
@@ -1326,7 +1326,7 @@ Start/stop using cartridge CLI
 
 With ``cartridge`` CLI, you can start one or multiple instances:
 
-..  code-block:: console
+..  code-block:: shell
 
     $ cartridge start [APP_NAME[.INSTANCE_NAME]] [options]
 
@@ -1360,7 +1360,7 @@ The options are:
 
 For example:
 
-..  code-block:: console
+..  code-block:: shell
 
     $ cartridge start my_app --cfg demo.yml --run_dir ./tmp/run --foreground
 
@@ -1373,7 +1373,7 @@ filename.
 When ``INSTANCE_NAME`` is not provided, ``cartridge`` reads ``cfg`` file and
 starts all defined instances:
 
-.. code-block:: console
+.. code-block:: shell
 
     $ # in application directory
     $ cartridge start # starts all instances
@@ -1385,7 +1385,7 @@ starts all defined instances:
 
 To stop the instances, run:
 
-.. code-block:: console
+.. code-block:: shell
 
     $ cartridge stop [APP_NAME[.INSTANCE_NAME]] [options]
 
@@ -1402,7 +1402,7 @@ Start/stop using systemctl
 
 *   To run a single instance:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ systemctl start APP_NAME
 
@@ -1412,7 +1412,7 @@ Start/stop using systemctl
 
 *   To run multiple instances on one or multiple servers:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ systemctl start APP_NAME@INSTANCE_1
         $ systemctl start APP_NAME@INSTANCE_2
@@ -1427,7 +1427,7 @@ Start/stop using systemctl
 *   To stop all services on a server, use the ``systemctl stop`` command
     and specify instance names one by one. For example:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ systemctl stop APP_NAME@INSTANCE_1 APP_NAME@INSTANCE_2 ... APP_NAME@INSTANCE_<N>
 
@@ -1468,7 +1468,7 @@ When running instances with ``systemctl``, keep these practices in mind:
 *   The default tool for querying logs is `journalctl <https://www.freedesktop.org/software/systemd/man/journalctl.html>`_.
     For example:
 
-    ..  code-block:: console
+    ..  code-block:: shell
 
         $ # show log messages for a systemd unit named APP_NAME.INSTANCE_1
         $ journalctl -u APP_NAME.INSTANCE_1

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -1373,7 +1373,7 @@ filename.
 When ``INSTANCE_NAME`` is not provided, ``cartridge`` reads ``cfg`` file and
 starts all defined instances:
 
-.. code-block:: bash
+..  code-block:: bash
 
     $ # in application directory
     $ cartridge start # starts all instances

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -63,7 +63,7 @@ Creating a project
 To set up your development environment, create a project using the
 Tarantool Cartridge project template. In any directory, run:
 
-.. code-block:: shell
+.. code-block:: bash
 
    $ cartridge create --name <app_name> /path/to/
 
@@ -827,7 +827,7 @@ For example, if your application has version 1.2.1, tag your current branch with
 
 To retrieve the current version from Git, run:
 
-..  code-block:: shell
+..  code-block:: bash
 
     $ git describe --long --tags
     1.2.1-12-g74864f2
@@ -977,7 +977,7 @@ To deploy your Tarantool Cartridge application:
 
 #.  Pack the application into a deliverable:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ cartridge pack rpm [APP_PATH] [--use-docker]
         $ # -- OR --
@@ -1002,7 +1002,7 @@ To deploy your Tarantool Cartridge application:
 
 #.  Install the application:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ sudo yum install <APP_NAME>-<VERSION>.rpm
         $ # -- OR --
@@ -1043,7 +1043,7 @@ To deploy your Tarantool Cartridge application:
 
     For more details, see :ref:`cartridge-run-systemctl`.
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ sudo systemctl start my_app@router
         $ sudo systemctl start my_app@storage-master
@@ -1152,7 +1152,7 @@ Deploying as a tar+gz archive
 
 #.  Pack the application into a distributable:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ cartridge pack tgz APP_NAME
 
@@ -1163,7 +1163,7 @@ Deploying as a tar+gz archive
 
 #.  Extract the archive:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ tar -xzvf APP_NAME-VERSION.tgz
 
@@ -1190,13 +1190,13 @@ Deploying as a tar+gz archive
 
     *   :ref:`tarantool <cartridge-run-tarantool>`, for example:
 
-        ..  code-block:: shell
+        ..  code-block:: bash
 
             $ tarantool init.lua # starts a single instance
 
     *   or :ref:`cartridge <cartridge-run-cartridge>`, for example:
 
-        ..  code-block:: shell
+        ..  code-block:: bash
 
             $ # in application directory
             $ cartridge start # starts all instances
@@ -1231,7 +1231,7 @@ This deployment method is intended for local testing only.
 
 #.  Pull all dependencies to the ``.rocks`` directory:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ tarantoolctl rocks make
 
@@ -1258,13 +1258,13 @@ This deployment method is intended for local testing only.
 
     *   :ref:`tarantool <cartridge-run-tarantool>`, for example:
 
-        ..  code-block:: shell
+        ..  code-block:: bash
 
             $ tarantool init.lua # starts a single instance
 
     *   or :ref:`cartridge <cartridge-run-cartridge>`, for example:
 
-        ..  code-block:: shell
+        ..  code-block:: bash
 
             $ # in application directory
             $ cartridge start # starts all instances
@@ -1308,7 +1308,7 @@ Start/stop using tarantool
 
 With ``tarantool``, you can start only a single instance:
 
-..  code-block:: shell
+..  code-block:: bash
 
     # the simplest command
     $ tarantool init.lua
@@ -1326,7 +1326,7 @@ Start/stop using cartridge CLI
 
 With ``cartridge`` CLI, you can start one or multiple instances:
 
-..  code-block:: shell
+..  code-block:: bash
 
     $ cartridge start [APP_NAME[.INSTANCE_NAME]] [options]
 
@@ -1360,7 +1360,7 @@ The options are:
 
 For example:
 
-..  code-block:: shell
+..  code-block:: bash
 
     $ cartridge start my_app --cfg demo.yml --run_dir ./tmp/run --foreground
 
@@ -1373,7 +1373,7 @@ filename.
 When ``INSTANCE_NAME`` is not provided, ``cartridge`` reads ``cfg`` file and
 starts all defined instances:
 
-.. code-block:: shell
+.. code-block:: bash
 
     $ # in application directory
     $ cartridge start # starts all instances
@@ -1385,7 +1385,7 @@ starts all defined instances:
 
 To stop the instances, run:
 
-.. code-block:: shell
+.. code-block:: bash
 
     $ cartridge stop [APP_NAME[.INSTANCE_NAME]] [options]
 
@@ -1402,7 +1402,7 @@ Start/stop using systemctl
 
 *   To run a single instance:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ systemctl start APP_NAME
 
@@ -1412,7 +1412,7 @@ Start/stop using systemctl
 
 *   To run multiple instances on one or multiple servers:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ systemctl start APP_NAME@INSTANCE_1
         $ systemctl start APP_NAME@INSTANCE_2
@@ -1427,7 +1427,7 @@ Start/stop using systemctl
 *   To stop all services on a server, use the ``systemctl stop`` command
     and specify instance names one by one. For example:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ systemctl stop APP_NAME@INSTANCE_1 APP_NAME@INSTANCE_2 ... APP_NAME@INSTANCE_<N>
 
@@ -1468,7 +1468,7 @@ When running instances with ``systemctl``, keep these practices in mind:
 *   The default tool for querying logs is `journalctl <https://www.freedesktop.org/software/systemd/man/journalctl.html>`_.
     For example:
 
-    ..  code-block:: shell
+    ..  code-block:: bash
 
         $ # show log messages for a systemd unit named APP_NAME.INSTANCE_1
         $ journalctl -u APP_NAME.INSTANCE_1

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -63,9 +63,9 @@ Creating a project
 To set up your development environment, create a project using the
 Tarantool Cartridge project template. In any directory, run:
 
-.. code-block:: bash
+..  code-block:: bash
 
-   $ cartridge create --name <app_name> /path/to/
+    $ cartridge create --name <app_name> /path/to/
 
 This will automatically set up a Git repository in a new ``/path/to/<app_name>/``
 directory, tag it with :ref:`version <cartridge-versioning>` ``0.1.0``,

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -1385,7 +1385,7 @@ starts all defined instances:
 
 To stop the instances, run:
 
-.. code-block:: bash
+..  code-block:: bash
 
     $ cartridge stop [APP_NAME[.INSTANCE_NAME]] [options]
 

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -177,7 +177,7 @@ when there are only few sections needed.
 
 Example:
 
-.. code-block:: bash
+..  code-block:: bash
 
     cat > config.yml << CONFIG
     ---

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -83,7 +83,7 @@ If you start instances with ``tarantool init.lua``,
 you need to pass other configuration options as command-line parameters and
 environment variables, for example:
 
-.. code-block:: console
+.. code-block:: shell
 
     $ tarantool init.lua --alias router --memtx-memory 100 --workdir "~/db/3301" --advertise_uri "localhost:3301" --http_port "8080"
 
@@ -177,7 +177,7 @@ when there are only few sections needed.
 
 Example:
 
-.. code-block:: console
+.. code-block:: shell
 
     cat > config.yml << CONFIG
     ---
@@ -187,13 +187,13 @@ Example:
 
 Upload new config:
 
-.. code-block:: console
+.. code-block:: shell
 
     curl -v "localhost:8081/admin/config" -X PUT --data-binary @config.yml
 
 Download it:
 
-.. code-block:: console
+.. code-block:: shell
 
     curl -v "localhost:8081/admin/config" -o config.yml
 

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -187,7 +187,7 @@ Example:
 
 Upload new config:
 
-.. code-block:: bash
+..  code-block:: bash
 
     curl -v "localhost:8081/admin/config" -X PUT --data-binary @config.yml
 

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -193,7 +193,7 @@ Upload new config:
 
 Download it:
 
-.. code-block:: bash
+..  code-block:: bash
 
     curl -v "localhost:8081/admin/config" -o config.yml
 

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -83,7 +83,7 @@ If you start instances with ``tarantool init.lua``,
 you need to pass other configuration options as command-line parameters and
 environment variables, for example:
 
-.. code-block:: bash
+..  code-block:: bash
 
     $ tarantool init.lua --alias router --memtx-memory 100 --workdir "~/db/3301" --advertise_uri "localhost:3301" --http_port "8080"
 

--- a/rst/topics/clusterwide-config.rst
+++ b/rst/topics/clusterwide-config.rst
@@ -83,7 +83,7 @@ If you start instances with ``tarantool init.lua``,
 you need to pass other configuration options as command-line parameters and
 environment variables, for example:
 
-.. code-block:: shell
+.. code-block:: bash
 
     $ tarantool init.lua --alias router --memtx-memory 100 --workdir "~/db/3301" --advertise_uri "localhost:3301" --http_port "8080"
 
@@ -177,7 +177,7 @@ when there are only few sections needed.
 
 Example:
 
-.. code-block:: shell
+.. code-block:: bash
 
     cat > config.yml << CONFIG
     ---
@@ -187,13 +187,13 @@ Example:
 
 Upload new config:
 
-.. code-block:: shell
+.. code-block:: bash
 
     curl -v "localhost:8081/admin/config" -X PUT --data-binary @config.yml
 
 Download it:
 
-.. code-block:: shell
+.. code-block:: bash
 
     curl -v "localhost:8081/admin/config" -o config.yml
 

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -275,7 +275,7 @@ options:
 Similarly to other ``argparse`` options, they can be passed via
 command-line arguments or via environment variables, e.g.:
 
-.. code-block:: console
+.. code-block:: shell
 
     .rocks/bin/stateboard --workdir ./dev/stateboard --listen 4401 --password qwerty
 

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -275,7 +275,7 @@ options:
 Similarly to other ``argparse`` options, they can be passed via
 command-line arguments or via environment variables, e.g.:
 
-.. code-block:: bash
+..  code-block:: bash
 
     .rocks/bin/stateboard --workdir ./dev/stateboard --listen 4401 --password qwerty
 

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -275,7 +275,7 @@ options:
 Similarly to other ``argparse`` options, they can be passed via
 command-line arguments or via environment variables, e.g.:
 
-.. code-block:: shell
+.. code-block:: bash
 
     .rocks/bin/stateboard --workdir ./dev/stateboard --listen 4401 --password qwerty
 


### PR DESCRIPTION
I didn't forget about

- [x] Documentation

Close #885 
