### PR TITLE
Fix flaky integration.etcd2_client.test_event_cleared

### DIFF
--- a/test/integration/etcd2_client_test.lua
+++ b/test/integration/etcd2_client_test.lua
@@ -253,7 +253,7 @@ function g.test_event_cleared()
     -- Check that longpoll_index is updated despite leaders aren't modified
     local old_index = client2.session.longpoll_index
     httpc:put(URI .. '/v2/keys/foo?value=buzz')
-    t.assert_equals(client2:longpoll(0.1), {})
+    t.assert_equals(client2:longpoll(0.2), {})
     t.assert_equals(client2.session.longpoll_index, old_index + 1)
 end
 


### PR DESCRIPTION
Longpoll timeout in test wasn't enough, so I increase it. 

I didn't forget about

- [x] Tests

Close #1602 
