### PR TITLE
Fix flaky integration.reboot.test_advertise_change

### DIFF
--- a/test/integration/reboot_test.lua
+++ b/test/integration/reboot_test.lua
@@ -208,6 +208,6 @@ function g.test_advertise_change()
     master.net_box_uri = '127.0.0.1:13310'
     master:start()
 
-    helpers.wish_state(master, 'RolesConfigured', 1)
+    helpers.wish_state(master, 'RolesConfigured', 2)
     t.assert(master:call('box.sequence.test:next'))
 end


### PR DESCRIPTION
Seems that timeout wasn't enough. Increased it.

I didn't forget about

- [x] Tests

Close #1664 
