### PR TITLE
Add app_version field to gql-query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Added
 
 - Add logging of configuration options on start and boot instance.
 
-- Add ``app_version`` to graphql.
+- Add ``app_version`` field to graphql. It filled from ``VERSION.lua`` file in the root of cartridge app. 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Added
 
 - Add logging of configuration options on start and boot instance.
 
+- Add ``app_version`` to graphql.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -108,9 +108,15 @@ local function get_info(uri)
             vars.http_port = srv_name.port
         end
 
+        local ok, app_version = pcall(require, 'VERSION')
+        if not ok then
+            app_version = box.NULL
+        end
+
         local ret = {
             general = {
                 version = box_info.version,
+                app_version = app_version,
                 pid = box_info.pid,
                 uptime = box_info.uptime,
                 instance_uuid = box_info.uuid,

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -69,6 +69,10 @@ local boxinfo_schema = {
                         kind = gql_types.string.nonNull,
                         description = 'The Tarantool version',
                     },
+                    app_version = {
+                        kind = gql_types.string,
+                        description = 'The Application version',
+                    },
                     pid = {
                         kind = gql_types.int.nonNull,
                         description = 'The process ID',

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://127.0.0.1:8081/admin/api
-# timestamp: Thu Dec 23 2021 18:51:13 GMT+0300 (Москва, стандартное время)
+# timestamp: Tue Dec 28 2021 15:43:30 GMT+0300 (Москва, стандартное время)
 
 """Custom scalar specification."""
 directive @specifiedBy(
@@ -623,17 +623,20 @@ type ServerInfoGeneral {
   """Current working directory of a process"""
   work_dir: String
 
-  """A globally unique identifier of the instance"""
-  instance_uuid: String!
+  """The number of seconds since the instance started"""
+  uptime: Float!
+
+  """The Tarantool version"""
+  version: String!
 
   """HTTP webui prefix"""
   webui_prefix: String
 
-  """Current read-only state"""
-  ro: Boolean!
+  """HTTP host"""
+  http_host: String
 
-  """The number of seconds since the instance started"""
-  uptime: Float!
+  """A globally unique identifier of the instance"""
+  instance_uuid: String!
 
   """A directory where vinyl files or subdirectories will be stored"""
   vinyl_dir: String
@@ -644,8 +647,8 @@ type ServerInfoGeneral {
   """HTTP port"""
   http_port: Int
 
-  """The Tarantool version"""
-  version: String!
+  """The Application version"""
+  app_version: String
 
   """A directory where memtx stores snapshot (.snap) files"""
   memtx_dir: String
@@ -665,8 +668,8 @@ type ServerInfoGeneral {
   """The UUID of the replica set"""
   replicaset_uuid: String!
 
-  """HTTP host"""
-  http_host: String
+  """Current read-only state"""
+  ro: Boolean!
 }
 
 type ServerInfoMembership {

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -20,6 +20,10 @@ if frontend and frontend.set_variable then
     frontend.set_variable('cartridge_hide_all_rw', false)
 end
 
+package.preload['VERSION'] = function()
+    return 'app_version_test_value'
+end
+
 package.preload['mymodule'] = function()
     local state = nil
     local master = nil

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -347,6 +347,7 @@ end
 
 function g.test_servers()
     local router = g.cluster:server('router')
+    local app_version = 'app_version_test_value'
 
     local resp = router:graphql({
         query = [[
@@ -366,6 +367,7 @@ function g.test_servers()
                         vshard_router { buckets_unreachable }
                         vshard_storage { buckets_active }
                         general {
+                            app_version
                             http_port
                             http_host
                             webui_prefix
@@ -390,7 +392,7 @@ function g.test_servers()
                 membership = {status = 'alive'},
                 vshard_router = {{ buckets_unreachable = 0 }},
                 vshard_storage = box.NULL,
-                general = { http_port = 8081, http_host = "0.0.0.0", webui_prefix = "" },
+                general = { app_version = app_version, http_port = 8081, http_host = "0.0.0.0", webui_prefix = "" },
             },
         }, {
             uri = 'localhost:13302',
@@ -406,7 +408,7 @@ function g.test_servers()
                 membership = {status = 'alive'},
                 vshard_router = box.NULL,
                 vshard_storage = {buckets_active = 3000},
-                general = { http_port = 8082, http_host = "0.0.0.0", webui_prefix = "" },
+                general = { app_version = app_version, http_port = 8082, http_host = "0.0.0.0", webui_prefix = "" },
             },
         }, {
             uri = 'localhost:13304',
@@ -422,7 +424,7 @@ function g.test_servers()
                 membership = {status = 'alive'},
                 vshard_router = box.NULL,
                 vshard_storage = {buckets_active = 3000},
-                general = { http_port = 8084, http_host = "0.0.0.0", webui_prefix = "" },
+                general = { app_version = app_version, http_port = 8084, http_host = "0.0.0.0", webui_prefix = "" },
             },
         }, {
             uri = 'localhost:13303',


### PR DESCRIPTION
Add field `boxinfo -> general -> app_version` to gql-query.
`app_version` value loads from `VERSION.lua`file.
`VERSION.lua` file generated by `cartridge pack` command.

- [X] Tests
- [x] Changelog

Close #1367 
