### PR TITLE
Fix the incorrect number of total buckets on the replication server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Fixed
 
 - Fix joining an instance when leader is not the first instance from leaders_order
 
+- Fix the incorrect number of total buckets on the replication server in webui.
+
 -------------------------------------------------------------------------------
 [2.7.3] - 2021-10-27
 -------------------------------------------------------------------------------

--- a/webui/src/models/cluster/server-list/selectors.ts
+++ b/webui/src/models/cluster/server-list/selectors.ts
@@ -31,6 +31,9 @@ export const serverRo = (server: ServerListServer): boolean | undefined => serve
 export const replicasetServerRo = (server: ServerListReplicasetServer): boolean | undefined =>
   server.boxinfo?.general?.ro;
 
+export const clusterVshardGroups = (cluster: Maybe<GetClusterCluster>): GetClusterVshardGroup[] =>
+  compact(cluster?.vshard_groups ?? []);
+
 // get-cluster
 export const cluster = (data: GetCluster): GetClusterCluster | undefined => data?.cluster ?? undefined;
 
@@ -41,7 +44,7 @@ export const clusterSelfUri = (data: GetCluster): string | undefined => clusterS
 
 export const knownRoles = (data: GetCluster): GetClusterRole[] => compact(data?.cluster?.knownRoles ?? []);
 
-export const vshardGroups = (data: GetCluster): GetClusterVshardGroup[] => compact(data?.cluster?.vshard_groups ?? []);
+export const vshardGroups = (data: GetCluster): GetClusterVshardGroup[] => clusterVshardGroups(data?.cluster);
 
 export const vshardGroupsNames = (data: GetCluster): string[] => vshardGroups(data).map(({ name }) => name);
 

--- a/webui/src/pages/Cluster/components/ReplicasetListPageSection/components/ReplicasetServerList/ReplicasetServerList.tsx
+++ b/webui/src/pages/Cluster/components/ReplicasetListPageSection/components/ReplicasetServerList/ReplicasetServerList.tsx
@@ -21,6 +21,10 @@ const ReplicasetServerList = (props: ReplicasetServerListProps) => {
   const { cluster, clusterSelf, replicaset, serverStat, failoverParamsMode } = props;
 
   const servers = useMemo(() => {
+    const vshardGroupBucketsCount = selectors
+      .clusterVshardGroups(cluster)
+      .find(({ name }) => name === replicaset.vshard_group)?.bucket_count;
+
     return replicaset.servers.map((server): Pick<ReplicasetServerListItemProps, 'server' | 'additional'> => {
       const stat = serverStat.find(({ uuid }) => server.uuid === uuid);
       return {
@@ -32,7 +36,7 @@ const ReplicasetServerList = (props: ReplicasetServerListProps) => {
           selfURI: clusterSelf?.uri ?? undefined,
           ro: selectors.replicasetServerRo(server),
           statistics: stat?.statistics,
-          totalBucketsCount: cluster?.vshard_bucket_count ?? undefined,
+          vshardGroupBucketsCount,
         },
       };
     });

--- a/webui/src/pages/Cluster/components/ReplicasetListPageSection/components/ReplicasetServerListItem/ReplicasetServerListItem.tsx
+++ b/webui/src/pages/Cluster/components/ReplicasetListPageSection/components/ReplicasetServerListItem/ReplicasetServerListItem.tsx
@@ -39,7 +39,7 @@ export interface ReplicasetServerListItemServerAdditional {
   activeMaster: boolean;
   replicasetUUID: string;
   selfURI?: string;
-  totalBucketsCount?: number;
+  vshardGroupBucketsCount?: number;
   ro?: boolean;
   statistics?: Maybe<ReplicasetServerListItemStatistic>;
 }
@@ -53,7 +53,7 @@ export interface ReplicasetServerListItemProps {
 const ReplicasetServerListItem = (props: ReplicasetServerListItemProps) => {
   const {
     server: { uuid, uri, alias, status, disabled = false, message },
-    additional: { master, activeMaster, selfURI, totalBucketsCount, ro, statistics },
+    additional: { master, activeMaster, selfURI, vshardGroupBucketsCount, ro, statistics },
     showFailoverPromote,
   } = props;
 
@@ -99,7 +99,7 @@ const ReplicasetServerListItem = (props: ReplicasetServerListItemProps) => {
         </div>
         <div className={styles.div} />
         <div className={styles.buckets}>
-          <ReplicasetListBuckets count={statistics?.bucketsCount} total={totalBucketsCount} />
+          <ReplicasetListBuckets count={statistics?.bucketsCount} total={vshardGroupBucketsCount} />
         </div>
         <div className={styles.div} />
         <div className={styles.mem}>{statistics && <ReplicasetListMemStat {...statistics} />}</div>


### PR DESCRIPTION
* Fix the incorrect number of total buckets on the replication server in webui.

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1176
