### PR TITLE
Fix GraphQL query `auth_params.username`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ Fixed
 
 - Fix the incorrect number of total buckets on the replication server in webui.
 
+- Fix GraphQL query ``auth_params.username`` returns empty string instead of ``username``.
+
 -------------------------------------------------------------------------------
 [2.7.3] - 2021-10-27
 -------------------------------------------------------------------------------

--- a/cartridge/webui/api-auth.lua
+++ b/cartridge/webui/api-auth.lua
@@ -76,7 +76,7 @@ local function get_auth_params()
 
     local username = auth.get_session_username()
     local user = username and auth.get_user(username)
-    if user ~= nil and user.fullname ~= nil then
+    if user ~= nil and user.fullname ~= nil and #user.fullname > 0 then
         username = user.fullname
     end
     return {


### PR DESCRIPTION
* Fix GraphQL query ``auth_params.username`` returns empty string instead of ``username``.

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1633
