### PR TITLE
Fix hotreload.vshard test in correct case

### DIFF
--- a/test/hotreload/vshard_test.lua
+++ b/test/hotreload/vshard_test.lua
@@ -191,7 +191,7 @@ function g.test_rebalancer()
 
     local ok, err = pcall(helpers.retrying, {}, function()
         rebalancer:call('vshard.storage.rebalancer_wakeup')
-        assert(g.SA1:call('vshard.storage.buckets_count') == 2000
+        return assert(g.SA1:call('vshard.storage.buckets_count') == 2000
             and g.SB1:call('vshard.storage.buckets_count') == 1000)
     end)
 


### PR DESCRIPTION
The test doesn't succeed in the correct case. 
I didn't forget about

- [x] Tests
