### PR TITLE
add box.info.ro_reason and replication.downstream.lag to boxinfo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Added
 - Add setters ans getters for timeout options in ``twophase.lua``:
   ``netbox_call_timeout``, ``upload_config_timeout``, ``validate_config_timeout``, ``apply_config_timeout``.
 
+- box.info.ro_reason and box.info.replication.X.downstream.lag to boxinfo API.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/lua-api/boxinfo.lua
+++ b/cartridge/lua-api/boxinfo.lua
@@ -131,6 +131,7 @@ local function get_info(uri)
                 http_port = vars.http_port,
                 webui_prefix = vars.webui_prefix,
                 ro = box_info.ro,
+                ro_reason = box_info.ro_reason,
             },
             storage = {
                 -- wal
@@ -202,6 +203,7 @@ local function get_info(uri)
                 upstream_lag = replica.upstream and replica.upstream.lag,
                 downstream_status = replica.downstream and replica.downstream.status,
                 downstream_message = replica.downstream and replica.downstream.message,
+                downstream_lag = replica.downstream and replica.downstream.lag,
             } or box.NULL
         end
 

--- a/cartridge/webui/gql-boxinfo.lua
+++ b/cartridge/webui/gql-boxinfo.lua
@@ -24,6 +24,7 @@ local gql_replica_status = gql_types.object({
         upstream_lag = gql_types.float,
         downstream_status = gql_types.string,
         downstream_message = gql_types.string,
+        downstream_lag = gql_types.float,
     },
 })
 
@@ -134,6 +135,10 @@ local boxinfo_schema = {
                     ro = {
                         kind = gql_types.boolean.nonNull,
                         description = 'Current read-only state',
+                    },
+                    ro_reason = {
+                        kind = gql_types.string,
+                        description = 'Current read-only state reason',
                     },
                 }
             }).nonNull,

--- a/doc/schema.graphql
+++ b/doc/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://127.0.0.1:8081/admin/api
-# timestamp: Tue Dec 28 2021 15:43:30 GMT+0300 (Москва, стандартное время)
+# timestamp: Sun Jan 23 2022 18:13:12 GMT+0300 (Moscow Standard Time)
 
 """Custom scalar specification."""
 directive @specifiedBy(
@@ -551,10 +551,11 @@ type ReplicaStatus {
   upstream_idle: Float
   upstream_message: String
   lsn: Long
-  upstream_lag: Float
   upstream_status: String
+  upstream_lag: Float
   uuid: String!
   downstream_message: String
+  downstream_lag: Float
 }
 
 """A suggestion to restart malfunctioning replications"""
@@ -620,23 +621,14 @@ type ServerInfoCartridge {
 }
 
 type ServerInfoGeneral {
-  """Current working directory of a process"""
-  work_dir: String
-
-  """The number of seconds since the instance started"""
-  uptime: Float!
-
   """The Tarantool version"""
   version: String!
 
   """HTTP webui prefix"""
   webui_prefix: String
 
-  """HTTP host"""
-  http_host: String
-
-  """A globally unique identifier of the instance"""
-  instance_uuid: String!
+  """Current read-only state"""
+  ro: Boolean!
 
   """A directory where vinyl files or subdirectories will be stored"""
   vinyl_dir: String
@@ -650,14 +642,17 @@ type ServerInfoGeneral {
   """The Application version"""
   app_version: String
 
-  """A directory where memtx stores snapshot (.snap) files"""
-  memtx_dir: String
-
   """A directory where write-ahead log (.xlog) files are stored"""
   wal_dir: String
 
   """The binary protocol URI"""
   listen: String
+
+  """A globally unique identifier of the instance"""
+  instance_uuid: String!
+
+  """HTTP host"""
+  http_host: String
 
   """
   The maximum number of threads to use during execution of certain internal
@@ -665,11 +660,20 @@ type ServerInfoGeneral {
   """
   worker_pool_threads: Int
 
+  """Current read-only state reason"""
+  ro_reason: String
+
+  """The number of seconds since the instance started"""
+  uptime: Float!
+
+  """Current working directory of a process"""
+  work_dir: String
+
   """The UUID of the replica set"""
   replicaset_uuid: String!
 
-  """Current read-only state"""
-  ro: Boolean!
+  """A directory where memtx stores snapshot (.snap) files"""
+  memtx_dir: String
 }
 
 type ServerInfoMembership {

--- a/test/integration/api_edit_test.lua
+++ b/test/integration/api_edit_test.lua
@@ -266,7 +266,7 @@ local function test_all_rw(all_rw)
                 servers {
                     uuid
                     boxinfo {
-                        general { ro }
+                        general { ro ro_reason }
                     }
                 }
                 master {
@@ -285,8 +285,15 @@ local function test_all_rw(all_rw)
     for _, srv in pairs(replicaset['servers']) do
         if srv['uuid'] == replicaset['master']['uuid'] then
             t.assert_equals(srv['boxinfo']['general']['ro'], false)
+            -- https://github.com/tarantool/tarantool/issues/5568
+            if helpers.tarantool_version_ge('2.10.0') then
+                t.assert_equals(srv['boxinfo']['general']['ro_reason'], box.NULL)
+            end
         else
             t.assert_equals(srv['boxinfo']['general']['ro'], not all_rw)
+            if helpers.tarantool_version_ge('2.10.0') then
+                t.assert_equals(srv['boxinfo']['general']['ro_reason'], not all_rw and 'config' or box.NULL)
+            end
         end
     end
 end

--- a/test/integration/api_query_test.lua
+++ b/test/integration/api_query_test.lua
@@ -308,7 +308,7 @@ function g.test_server_info_schema()
             table.concat(field_name_membership, ' '))
             -- workaround composite graphql type
                 :gsub('error', 'error { message }')
-                :gsub('replication_info', 'replication_info { id }')
+                :gsub('replication_info', 'replication_info { id upstream_lag downstream_lag }')
 
     local resp = router:graphql({
         query = query,


### PR DESCRIPTION
This patch adds two new options into boxinfo graphql API.

  - ro_reason [1] - reason why instance is in read-only mode.
  - replication.downstream.lag [2] - lag between the main
node writes a certain transaction to it's own WAL and a moment it
receives an ack for this transaction from a replica.

Both fields are supported by Tarantools 2.10+.

  [1] https://github.com/tarantool/tarantool/issues/5568
  [2] https://github.com/tarantool/tarantool/issues/5447
