### PR TITLE
Don't kill box.watchable system fiber on reload

### DIFF
--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -157,6 +157,7 @@ local function load_state()
         or f.name:startswith('applier/')
         or f.name:startswith('applierw/')
         or f.name:startswith('watchdog_')
+        or f.name:startswith('box.watchable')
         then
             -- Ignore system fibers
             log.debug('Preserving system fiber %q (%d)', f.name, f.fid)


### PR DESCRIPTION
It's a system fiber. Killing it might result in crashing Tarantool.

Integration tests would fail without this patch after https://github.com/tarantool/tarantool/pull/6813 is merged.