### PR TITLE
disable schema fetch for cartridge.pool connections

### DIFF
--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -98,7 +98,7 @@ local function connect(uri, opts)
         end
 
         conn, err = NetboxConnectError:pcall(netbox.connect,
-            _uri, {wait_connected = false}
+            _uri, {wait_connected = false, fetch_schema = false}
         )
         if err ~= nil then
             return nil, err

--- a/test/integration/pool_connect_test.lua
+++ b/test/integration/pool_connect_test.lua
@@ -54,6 +54,7 @@ function g.test_identity()
         opts = {
             user = 'admin',
             wait_connected = false,
+            fetch_schema = false,
         },
     })
 
@@ -134,4 +135,10 @@ function g.test_async_call_remote()
 
     local future = conn:call('pcall', {'smth'}, {is_async = true})
     t.assert_equals({future:wait_result()}, {{false, 'attempt to call a string value'}})
+end
+
+function g.test_schema_fetch()
+    t.skip_if(not helpers.tarantool_version_ge('2.10.0'))
+    local conn = pool.connect('localhost:13301')
+    t.assert_equals(conn.space, nil)
 end


### PR DESCRIPTION
Cartridge uses only netbox.call and eval. So seems we could safety
disable schema fetching for netbox. New Tarantool versions allows
to disable schema fetching to avoid additional pressure that
schema fetching creates.

See also https://github.com/tarantool/doc/issues/2680