### PR TITLE
test: fix tests due to logger patching

### DIFF
--- a/test/integration/logger_test.lua
+++ b/test/integration/logger_test.lua
@@ -112,7 +112,9 @@ function g.test_content_bootstrapped()
 
     local messages = fun.iter(txt:split('\n'))
         :map(function(l) return l:match(' ([ECWI]> .+)$') end)
-        :drop_while(function(l) return not l:startswith('C> Tarantool') end)
+        :drop_while(function(l)
+            return not l:startswith('C> Tarantool') and not l:startswith('I> Tarantool')
+        end)
         :totable()
 
     t.assert_items_include(messages, {


### PR DESCRIPTION
Issue tarantool/tarantool#4675 proposes to move the tarantool information messages
from the critical to the info logging level, which requires changing the tests in
this repository to tests that will run at both logging levels.

Needed for tarantool/tarantool#4675
