### PR TITLE
Run push-translations on workflow dispatch only

### DIFF
--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -1,7 +1,7 @@
 name: Push translation sources to a Crowdin branch
 
 on:
-  pull_request:
+  workflow_dispatch:
     paths:
       - 'rst/**.rst'
       - 'rst/conf.py'


### PR DESCRIPTION
Temporarily disable Crowdin CI/CD, making it available on click only.