### PR TITLE
Correct function name

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -928,7 +928,7 @@ return {
 
     --- .
     -- @refer cartridge.lua-api.topology.restart_replication
-    -- @function admin_bootstrap_vshard
+    -- @function admin_restart_replication
     admin_restart_replication = lua_api_topology.restart_replication,
 
     --- .

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -430,7 +430,7 @@ end
 --
 -- Each option have a type: string, boolean, number.
 -- There is an ability to set multiple types for one option.
--- Types are split by separator ``|``,  e.g. ``string|number``.
+-- Types are split by separator `|`,  e.g. `string|number`.
 --
 -- @function get_opts
 -- @tparam {argname=type,...} filter

--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -279,7 +279,7 @@ local function pause()
     return true
 end
 
---- Starts failover across cluster at runtime after ``pause``.
+--- Starts failover across cluster at runtime after `pause`.
 -- Don't forget to resume your failover after pausing it.
 --
 -- @function resume


### PR DESCRIPTION
In the documentation, `admin_restart_replication()` was incorrectly named `admin_bootstrap_vshard()`. This fixes it.