### PR TITLE
Remove the right menu from the Cartridge index page

### DIFF
--- a/rst/index.rst
+++ b/rst/index.rst
@@ -1,3 +1,6 @@
+:noindex:
+:fullwidth:
+
 .. _tarantool-cartridge:
 
 


### PR DESCRIPTION
Part of https://github.com/tarantool/doc/issues/2781
We don't need the search and anchor menu on pages representing tables of contents.