### PR TITLE
don't call fiber.info() in case of disabled hotreload

### DIFF
--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -14,6 +14,10 @@ vars:new('routes_count', nil)
 -- @function snap_fibers
 -- @treturn {string=true,...} Set of fiber names
 local function snap_fibers()
+    if not vars.fibers then
+        return {}
+    end
+
     local ret = {}
 
     for _, f in pairs(fiber.info()) do


### PR DESCRIPTION
It's workaround for https://github.com/tarantool/tarantool/issues/7171.
The call is not cheap so let's avoid redundant calls if possible
(hotreload is not enabled).
