### PR TITLE
disable backtraces for fiber.info() calls

### DIFF
--- a/cartridge/hotreload.lua
+++ b/cartridge/hotreload.lua
@@ -20,7 +20,8 @@ local function snap_fibers()
 
     local ret = {}
 
-    for _, f in pairs(fiber.info()) do
+    local fiber_info = fiber.info({backtrace = false})
+    for _, f in pairs(fiber_info) do
         ret[f.name] = true
     end
 

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -421,16 +421,16 @@ end
 -- @treturn number csw
 local fiber_csw
 
-if fiber.self().info ~= nil then
+if fiber.self().csw ~= nil then
     -- Fast way available since 2.10
     -- See https://github.com/tarantool/tarantool/issues/5799
     fiber_csw = function()
-        return fiber.self().info().csw
+        return fiber.self().csw()
     end
 else
     -- For versions that doesn't have fiber.self().info()
     fiber_csw = function()
-        return fiber.info()[fiber.id()].csw
+        return fiber.info({backtrace = false})[fiber.id()].csw
     end
 end
 


### PR DESCRIPTION
It's possible to do after https://github.com/tarantool/tarantool/commit/b18dd47f50e817be5ef91013c5514fd6226d836d
And in cases when we just enumerate fibers we can disable
backtraces to improve performance in general.
