### PR TITLE
add utils.is_email_valid tests

### DIFF
--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -289,7 +289,7 @@ local function is_email_valid(str)
     end
     local localPart = str:sub(1, (lastAt - 2)) -- Returns the substring before '@' symbol
     local domainPart = str:sub(lastAt, #str) -- Returns the substring after '@' symbol
-    -- we werent able to split the email properly
+    -- we weren't able to split the email properly
     if localPart == nil then
         return nil, "Local name is invalid"
     end
@@ -330,7 +330,7 @@ local function is_email_valid(str)
         return nil, "Too many periods in local part"
     end
     -- just a general match
-    if not str:match('[%w]*[%p]*%@+[%w]*[%.]?[%w]*') then
+    if not str:match('^[%w\'._+-]+%@[%w%.-]+%.%a+$') then
         return nil, "Email pattern test failed"
     end
     -- all our tests passed, so we are ok

--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -73,3 +73,35 @@ function g.test_http_read_body()
     t.assert_not(err)
     t.assert_equals(meta, {})
 end
+
+function g.test_is_email_valid()
+    t.assert(utils.is_email_valid('simple@example.com'), 'correct email')
+    t.assert(utils.is_email_valid('very.common@example.com'), 'correct email')
+    t.assert(utils.is_email_valid('disposable.style.email.with+symbol@example.com'), 'correct email')
+    t.assert(utils.is_email_valid('other.email-with-hyphen@example.com'), 'correct email')
+    t.assert(utils.is_email_valid('fully-qualified-domain@example.com'), 'correct email')
+    t.assert(utils.is_email_valid('x@example.com'), 'one-letter local-part')
+    t.assert(utils.is_email_valid('example-indeed@strange-example.com'), 'correct email')
+    t.assert(utils.is_email_valid('example@s.example'), 'correct email')
+    t.assert(utils.is_email_valid('username@sub.example.org'), 'correct email')
+
+    local function is_email_valid_xc(value)
+        local _, err = utils.is_email_valid(value)
+        if err ~= nil then
+            error(err)
+        end
+    end
+
+    t.assert_error_msg_contains('No TLD found in domain', is_email_valid_xc, 'aaaaa')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'aa.aa')
+    t.assert_error_msg_contains('No TLD found in domain', is_email_valid_xc, 'aa@aa')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, '@a.a')
+    t.assert_error_msg_contains('Invalid @ symbol usage in local part', is_email_valid_xc, 'a@@@a.a')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some\xfe@mail.dmn')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some@.dmn')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some@`ls>/tmp/KITTY`.dmn')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some@$HOME/.profile.dmn')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some@%01%02%03%04%0a%0d%0aADSF.dmn')
+    t.assert_error_msg_contains('Email pattern test failed', is_email_valid_xc, 'some@mail/./././././././.')
+    t.assert_error_msg_contains('Symbol @ not found', is_email_valid_xc, '')
+end


### PR DESCRIPTION
This patch adds test for utils.is_email_valid function. Initially
tests were exported from TDG where they passed some fuzzing tests.
Also this way we could keep "utils.is_email_valid" only on
cartridge side and drop that function from TDG.
