### PR TITLE
Update ddl to 1.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Changed
   It configures with ``failover_suppress_threshold`` and
   ``failover_suppress_timeout`` options of argparse.
 
+- Update ``ddl`` dependency to 1.6.1.
+  (`Changelog <https://github.com/tarantool/ddl/releases/tag/1.6.1>`__).
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,7 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
-    'ddl == 1.6.0-1',
+    'ddl == 1.6.1-1',
     'http == 1.2.0-1',
     'checks == 3.1.0-1',
     'errors == 2.2.1-1',


### PR DESCRIPTION
Update ddl to 1.6.1
See also https://github.com/tarantool/ddl/releases/tag/1.6.1

- [x] Changelog

Close #1846
