### PR TITLE
Update the instructions for installing the php client

### DIFF
--- a/webui/src/components/DemoInfo.js
+++ b/webui/src/components/DemoInfo.js
@@ -60,10 +60,9 @@ python3 example.py
     markdown: `
 ## Connect to Tarantool Cartridge using [PHP client](https://github.com/tarantool-php/client)
 
-**Install** *messagepack* and *tarantool client* using *composer*:
+**Install** *tarantool client* using *composer*:
 
 \`\`\`bash
-composer require rybakit/msgpack
 composer require tarantool/client
 \`\`\`
 


### PR DESCRIPTION
Since version [0.10.0](https://github.com/tarantool-php/client/releases/tag/v0.10.0) the `rybakit/msgpack` package is installed by default.