### PR TITLE
Provide valid memtx_memory value in the docs

### DIFF
--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -344,12 +344,12 @@ end
 --- Parse command line arguments, environment variables, and configuration files.
 --
 -- For example, running an application as follows:
---    TARANTOOL_MY_CUSTOM_ARG='value' ./init.lua --alias router --memtx-memory 100
+--    TARANTOOL_MY_CUSTOM_ARG='value' ./init.lua --alias router --memtx-memory 33554432
 -- results in:
 --    local argparse = require('cartridge.argparse')
 --    argparse.parse()
 --    ---
---    - memtx_memory: '100'
+--    - memtx_memory: 33554432
 --      my_custom_arg: value
 --      alias: router
 --    ...


### PR DESCRIPTION
The minimum `memtx_memory` value is 33554432.

https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_api/modules/cartridge.argparse/#parse
This description contained an invalid value of memtx_memory. I provided the valid value just in case.

However, it looks like nothing changes whether you run this command with a valid or invalid `--memtx-memory` flag value (33554436 or 100 – no difference).

Part of tarantool/doc#2313