### PR TITLE
Update election fencing parameter.

### DIFF
--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -201,7 +201,7 @@ local box_opts = {
     txn_timeout              = 'number', -- **number**
     election_mode            = 'string', -- **string**
     election_timeout         = 'number', -- **number**
-    election_fencing_enabled = 'boolean', -- **boolean**
+    election_fencing_mode    = 'string', -- **string**
 }
 
 local function load_file(filename)

--- a/cartridge/failover/raft.lua
+++ b/cartridge/failover/raft.lua
@@ -102,11 +102,14 @@ local function cfg()
         -- Timeout between elections. Needed to restart elections when no leader
         -- emerges soon enough. Equals 4 * replication_timeout
         election_timeout = box_opts.election_timeout,
-        -- If set to `true`, fencing is on (default behaviour). If set to `false`, fencing is off
-        -- and the leader doesn't resign when it loses the quorum. If enabled
-        -- on the current leader when it doesn't have a quorum of alive connections,
-        -- the leader will immediately resign.
-        election_fencing_enabled = box_opts.election_fencing_enabled,
+        -- If set to `soft`, fencing is on (default behaviour).
+        -- If set to `strict`, fencing is on, and timeout for dead connection
+        -- on leader is set to 2 * replication timeout, this increases the
+        -- chances, there will be only one leader at a time.
+        -- If set to `off`, fencing is off and the leader doesn't resign when
+        -- it loses the quorum. If enabled on the current leader when it doesn't
+        -- have a quorum of alive connections, the leader will resign its leadership.
+        election_fencing_mode = box_opts.election_fencing_mode,
     }
 
     if vars.raft_trigger == nil then

--- a/cartridge/logging_whitelist.lua
+++ b/cartridge/logging_whitelist.lua
@@ -31,7 +31,7 @@ local box_opts = {
     'checkpoint_interval',
     'checkpoint_wal_threshold',
     'custom_proc_title',
-    'election_fencing_enabled',
+    'election_fencing_mode',
     'election_mode',
     'election_timeout',
     'feedback_enabled',


### PR DESCRIPTION
With strict fencing introduced, parameter `election_fencing_enabled` was renamed to `election_fencing_mode` and can now be one of `soft`,`strict`, or `off` instead of boolean.

Part of tarantool/doc#3084