### PR TITLE
Remote control suspend resume

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
 
 - Introduced SSL support for Tarantool Enterprise from 2.10.2.
 
+- Introduced Remote Control Suspend/Resume methods to pause producing requests.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -562,6 +562,7 @@ local function boot_instance(clusterwide_config)
     end
 
     do
+        remote_control.suspend()
         local read_only = box.cfg.read_only
 
         if vars.upgrade_schema then
@@ -587,6 +588,7 @@ local function boot_instance(clusterwide_config)
         end
 
         box.cfg({read_only = read_only})
+        remote_control.resume()
     end
 
     -- Box is ready, start listening full-featured iproto protocol

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -563,8 +563,12 @@ local function boot_instance(clusterwide_config)
 
     do
         local read_only = box.cfg.read_only
-        if read_only then
+        local user = box.space[box.schema.USER_ID].index.name:get(username)
+
+        local remote_control_suspended = false
+        if vars.upgrade_schema or (user == nil or user.auth['chap-sha1'] ~= box.schema.user.password(password)) then
             remote_control.suspend()
+            remote_control_suspended = true
         end
 
         if vars.upgrade_schema then
@@ -578,7 +582,7 @@ local function boot_instance(clusterwide_config)
         -- Function `passwd` is safe to be called on multiple replicas,
         -- it never cause replication conflict
         -- But don't commit anything if it's already ok.
-        local user = box.space[box.schema.USER_ID].index.name:get(username)
+
         -- https://github.com/tarantool/tarantool/blob/2.7.3/src/box/lua/schema.lua#L2719-L2724
         if user == nil or user.auth['chap-sha1'] ~= box.schema.user.password(password) then
             log.info('Setting password for user %q ...', username)
@@ -590,7 +594,7 @@ local function boot_instance(clusterwide_config)
         end
 
         box.cfg({read_only = read_only})
-        if read_only then
+        if remote_control_suspended then
             remote_control.resume()
         end
     end

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -562,8 +562,10 @@ local function boot_instance(clusterwide_config)
     end
 
     do
-        remote_control.suspend()
         local read_only = box.cfg.read_only
+        if read_only then
+            remote_control.suspend()
+        end
 
         if vars.upgrade_schema then
             log.info('Upgrading schema ...')
@@ -588,7 +590,9 @@ local function boot_instance(clusterwide_config)
         end
 
         box.cfg({read_only = read_only})
-        remote_control.resume()
+        if read_only then
+            remote_control.resume()
+        end
     end
 
     -- Box is ready, start listening full-featured iproto protocol

--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -519,6 +519,12 @@ local function drop_connections()
     end
 end
 
+--- Pause to handle requests for all clients.
+--
+-- It doesn't interrupt any existing connections.
+--
+-- @function suspend
+-- @local
 local function suspend()
     if vars.server == nil or vars.accept == false then
         return
@@ -528,6 +534,12 @@ local function suspend()
     vars.suspend_cond:broadcast()
 end
 
+--- Resume to handle requests for all clients.
+--
+-- It doesn't interrupt any existing connections.
+--
+-- @function suspend
+-- @local
 local function resume()
     if vars.server == nil or vars.accept == false then
         return

--- a/cartridge/remote-control.lua
+++ b/cartridge/remote-control.lua
@@ -188,6 +188,10 @@ local function communicate(s)
         body = msgpack.decode(buf, pos)
     end
 
+    while vars.suspend do
+        vars.suspend_cond:wait(1)
+    end
+
     local code = header[0x00]
     local sync = header[0x01]
 
@@ -342,9 +346,6 @@ local function rc_handle(s)
     end
 
     while vars.handlers[s] ~= nil or next(handler.storage.tasks) ~= nil do
-        while vars.suspend do
-            vars.suspend_cond:wait(1)
-        end
         local ok, err = RemoteControlError:pcall(communicate, s)
         if err ~= nil then
             log.error('%s', err)


### PR DESCRIPTION
Introduce `Remote Control` `suspend`/`resume` methods to pause producing requests.

- [x] Tests
- [x] Changelog
- [ ] Documentation

Close #1878 