### PR TITLE
issue #1890 Tarantool binds to 0.0.0.0 despite advertise_uri settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,11 @@ Added
 - Allow to bootstrap cartridge from existing cluster via argparse option
   ``TARANTOOL_BOOTSTRAP_FROM`` or ``--bootstrap_from``.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix tarantool binds to 0.0.0.0 despite advertise_uri settings.
 
 -------------------------------------------------------------------------------
 [2.7.6] - 2022-08-22

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -620,6 +620,17 @@ local function boot_instance(clusterwide_config)
             }})
     end
 
+    local parts = uri_tools.parse(vars.advertise_uri)
+    local addrinfo, err = socket.getaddrinfo(
+        parts.host, parts.service,
+        {family='AF_INET', type='SOCK_STREAM'}
+    )
+    if err ~= nil then
+        set_state('BootError', err)
+        return nil, err
+    end
+    local listen_uri_new = addrinfo[1].host .. ":" .. addrinfo[1].port
+    listen_uri = listen_uri_new
     local _, err = BoxError:pcall(
         box.cfg, {listen = listen_uri}
     )

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -104,12 +104,12 @@ function g.test_topology_query()
         uri = 'localhost:13311',
         uuid = g.A1.instance_uuid,
         alias = 'A-1',
-        boxinfo = {general = {listen = '13311', ro = false}},
+        boxinfo = {general = {listen = '127.0.0.1:13311', ro = false}},
     }, {
         uri = 'localhost:13312',
         uuid = g.B1.instance_uuid,
         alias = 'B-1',
-        boxinfo = {general = {listen = '13312', ro = false}},
+        boxinfo = {general = {listen = '127.0.0.1:13312', ro = false}},
     }})
 end
 
@@ -197,10 +197,10 @@ function g.test_failover()
 
     t.assert_items_include(servers, {{
         uuid = g.B1.instance_uuid,
-        boxinfo = {general = {listen = '13312', ro = true}},
+        boxinfo = {general = {listen = '127.0.0.1:13312', ro = true}},
     }, {
         uuid = g.B2.instance_uuid,
-        boxinfo = {general = {listen = '13303', ro = false}},
+        boxinfo = {general = {listen = '127.0.0.1:13303', ro = false}},
     }})
 end
 

--- a/test/integration/vshard_api_test.lua
+++ b/test/integration/vshard_api_test.lua
@@ -52,13 +52,13 @@ function g.test_get_cfg()
                     replicas = {
                         [g.B1.instance_uuid] = {
                             master = true,
-                            name = "127.0.0.1:13302",
-                            uri = "admin:qwerty123@127.0.0.1:13302",
+                            name = "localhost:13302",
+                            uri = "admin:qwerty123@localhost:13302",
                         },
                         [g.B2.instance_uuid] = {
                             master = false,
-                            name = "127.0.0.1:13303",
-                            uri = "admin:qwerty123@127.0.0.1:13303",
+                            name = "localhost:13303",
+                            uri = "admin:qwerty123@localhost:13303",
                         },
                     },
                     weight = 1,
@@ -131,8 +131,8 @@ function g.test_get_cfg_multisharding()
                     replicas = {
                         [g.storage_hot.instance_uuid] = {
                             master = true,
-                            name = "127.0.0.1:13302",
-                            uri = "admin:ytrewq321@127.0.0.1:13302",
+                            name = "localhost:13302",
+                            uri = "admin:ytrewq321@localhost:13302",
                         },
                     },
                     weight = 1,
@@ -154,8 +154,8 @@ function g.test_get_cfg_multisharding()
                     replicas = {
                         [g.storage_cold.instance_uuid] = {
                             master = true,
-                            name = "127.0.0.1:13303",
-                            uri = "admin:ytrewq321@127.0.0.1:13303",
+                            name = "localhost:13303",
+                            uri = "admin:ytrewq321@localhost:13303",
                         },
                     },
                     weight = 1,

--- a/test/integration/vshard_api_test.lua
+++ b/test/integration/vshard_api_test.lua
@@ -52,13 +52,13 @@ function g.test_get_cfg()
                     replicas = {
                         [g.B1.instance_uuid] = {
                             master = true,
-                            name = "localhost:13302",
-                            uri = "admin:qwerty123@localhost:13302",
+                            name = "127.0.0.1:13302",
+                            uri = "admin:qwerty123@127.0.0.1:13302",
                         },
                         [g.B2.instance_uuid] = {
                             master = false,
-                            name = "localhost:13303",
-                            uri = "admin:qwerty123@localhost:13303",
+                            name = "127.0.0.1:13303",
+                            uri = "admin:qwerty123@127.0.0.1:13303",
                         },
                     },
                     weight = 1,
@@ -131,8 +131,8 @@ function g.test_get_cfg_multisharding()
                     replicas = {
                         [g.storage_hot.instance_uuid] = {
                             master = true,
-                            name = "localhost:13302",
-                            uri = "admin:ytrewq321@localhost:13302",
+                            name = "127.0.0.1:13302",
+                            uri = "admin:ytrewq321@127.0.0.1:13302",
                         },
                     },
                     weight = 1,
@@ -154,8 +154,8 @@ function g.test_get_cfg_multisharding()
                     replicas = {
                         [g.storage_cold.instance_uuid] = {
                             master = true,
-                            name = "localhost:13303",
-                            uri = "admin:ytrewq321@localhost:13303",
+                            name = "127.0.0.1:13303",
+                            uri = "admin:ytrewq321@127.0.0.1:13303",
                         },
                     },
                     weight = 1,


### PR DESCRIPTION
What has been done? Why? What problem is being solved?


To check on macOS:
`sudo lsof -i -P | grep LISTEN | grep 330`

I didn't forget about

- [ ] Tests
- [x] Changelog

Close #1890 
