### PR TITLE
ci: use ubuntu-20.04 instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   misc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         tarantool: ['1.10', '2.7', '2.8', '2.10']
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-python@v2
         with:
@@ -136,6 +136,12 @@ jobs:
         if: steps.cache-pytest.outputs.cache-hit != 'true'
 
       - run: tarantoolctl rocks make
+
+      # Stop Mono server. This server starts and listens to 8084 port that is
+      # used for tests.
+      - name: 'Stop Mono server'
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - run: .rocks/bin/luatest -v
 
       - name: Run pytest -v
@@ -149,7 +155,7 @@ jobs:
   tests-ee:
     if: |
       github.event_name == 'push'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         sdk-version: [
@@ -211,6 +217,12 @@ jobs:
         if: steps.cache-pytest.outputs.cache-hit != 'true'
 
       - run: tarantoolctl rocks make
+
+      # Stop Mono server. This server starts and listens to 8084 port that is
+      # used for tests.
+      - name: 'Stop Mono server'
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
       - run: .rocks/bin/luatest -v
 
       - name: Run pytest -v

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -23,7 +23,7 @@ jobs:
           - tarantool: '1.10'
             cartridge: '2.7.0'
             downgrade: true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CARTRIDGE_OLDER_PATH: cartridge-${{ matrix.cartridge }}
       CARTRIDGE_OLDER_VERSION: ${{ matrix.cartridge }}-1

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   set-build-id:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - id: set-build-id
         run: echo "::set-output name=build-id::$(date +%s)"
@@ -27,7 +27,7 @@ jobs:
           - frontend
           - cypress-1
           - cypress-2
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: set-build-id
     steps:
       - uses: actions/checkout@v2
@@ -92,6 +92,11 @@ jobs:
       ##################################################################
 
       - run: tarantoolctl rocks make
+
+      # Stop Mono server. This server starts and listens to 8084 port that is
+      # used for tests.
+      - name: 'Stop Mono server'
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
       - if: matrix.script == 'frontend'
         run: ./frontend-test.sh

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         tarantool: ['1.10', '2.7', '2.8']
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1


### PR DESCRIPTION
The ubuntu-18.04 environment is deprecated. For more details see [1].

[1] https://github.com/actions/virtual-environments/issues/6002
