### PR TITLE
topology: fix is_electable

### DIFF
--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -71,7 +71,11 @@ local function disabled(uuid, srv)
 end
 
 local function electable(_, srv)
-    return srv ~= nil and srv.electable ~= nil and srv.electable or true
+    if srv ~= nil and srv.electable ~= nil then
+        return srv.electable
+    else
+        return true
+    end
 end
 
 local function not_expelled(_, srv)


### PR DESCRIPTION
This function was broken because of complex "ternary operator" which was used wrong. Changed "ternary operator" to if-else statement and added checks to tests.

Closes #1903