### PR TITLE
Disable failover on replicasets where number of instances less than 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changed
 
 - Update ``graphql`` dependency to 0.2.0.
 
-- Disable failover on replicasets where number of instances less than 3.
+- Disable Raft failover on replicasets where number of instances less than 3.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changed
 
 - Update ``graphql`` dependency to 0.2.0.
 
+- Disable failover on replicasets where number of instances less than 3.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Added
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -744,7 +744,14 @@ local function cfg(clusterwide_config, opts)
         raft_failover.disable()
     end
 
-    if failover_cfg.mode == 'disabled' then
+    local raft_not_enough_instances = failover_cfg.mode == 'raft' and
+        #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid) < 3
+
+    if raft_not_enough_instances then
+        log.info('Not enough instances to enable Raft failover')
+    end
+
+    if failover_cfg.mode == 'disabled' or raft_not_enough_instances then
         log.info('Failover disabled')
         vars.fencing_enabled = false
         vars.consistency_needed = false

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -845,14 +845,17 @@ local function cfg(clusterwide_config, opts)
         vars.fencing_enabled = false
         vars.consistency_needed = false
 
+        -- Raft failover can be enabled only on replicasets of 3 or more instances
         if #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid) < 3 then
             first_appointments = _get_appointments_disabled_mode(topology_cfg)
+            log.warn('Not enough instances to enable Raft failover')
         else
             local ok, err = ApplyConfigError:pcall(raft_failover.cfg)
             if not ok then
                 return nil, err
             end
             first_appointments = raft_failover.get_appointments(topology_cfg)
+            log.info('Raft failover enabled')
         end
 
         vars.failover_fiber = fiber.new(failover_loop, {
@@ -862,8 +865,6 @@ local function cfg(clusterwide_config, opts)
             end,
         })
         vars.failover_fiber:name('cartridge.raft-failover')
-
-        log.info('Raft failover enabled')
     else
         return nil, ApplyConfigError:new(
             'Unknown failover mode %q',

--- a/cartridge/failover/raft.lua
+++ b/cartridge/failover/raft.lua
@@ -76,12 +76,16 @@ local function on_election_trigger()
     membership.set_payload('raft_term', election.term)
 end
 
-local function cfg()
+local function check_version()
     if box.ctl.on_election == nil then
-       return nil, UnsupportedError:new(
-           "Your Tarantool version doesn't support raft failover mode, need Tarantool 2.10 or higher"
+        return nil, UnsupportedError:new(
+        "Your Tarantool version doesn't support raft failover mode, need Tarantool 2.10 or higher"
         )
     end
+    return true
+end
+
+local function cfg()
     log.warn('Raft failover is in beta-version')
     local box_opts = argparse.get_box_opts()
 
@@ -162,6 +166,7 @@ end
 
 return {
     cfg = cfg,
+    check_version = check_version,
     disable = disable,
     get_appointments = get_appointments,
     promote = promote,

--- a/cartridge/failover/raft.lua
+++ b/cartridge/failover/raft.lua
@@ -79,7 +79,7 @@ end
 local function check_version()
     if box.ctl.on_election == nil then
         return nil, UnsupportedError:new(
-        "Your Tarantool version doesn't support raft failover mode, need Tarantool 2.10 or higher"
+            "Your Tarantool version doesn't support raft failover mode, need Tarantool 2.10 or higher"
         )
     end
     return true

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -172,6 +172,8 @@ It's needed to use Cartridge RPC calls. The user can control an instance's
 election mode using the argparse option ``TARANTOOL_ELECTION_MODE`` or
 ``--election-mode`` or use ``box.cfg{election_mode = ...}`` API in runtime.
 
+Raft failover can be enabled only on replicasets of 3 or more instances.
+
 Note that Raft failover in Cartridge is in beta.
 Don't use it in production.
 

--- a/test/entrypoint/srv_raft.lua
+++ b/test/entrypoint/srv_raft.lua
@@ -2,6 +2,7 @@
 
 require('strict').on()
 _G.is_initialized = function() return false end
+_G.__TEST = true
 
 local log = require('log')
 local errors = require('errors')

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -44,7 +44,7 @@ g.before_all = function()
         datadir = fio.tempdir(),
         use_vshard = true,
         server_command = h.entrypoint('srv_raft'),
-        cookie = 'secret', --h.random_cookie(),
+        cookie = h.random_cookie(),
         replicasets = {
             {
                 alias = 'router',


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1865 
