### PR TITLE
Not filter unelectable instanses in Raft disabling

### DIFF
--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -846,7 +846,7 @@ local function cfg(clusterwide_config, opts)
         vars.consistency_needed = false
 
         -- Raft failover can be enabled only on replicasets of 3 or more instances
-        if #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid) < 3 then
+        if #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid, nil, false) < 3 then
             first_appointments = _get_appointments_disabled_mode(topology_cfg)
             log.warn('Not enough instances to enable Raft failover')
         else

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -846,7 +846,7 @@ local function cfg(clusterwide_config, opts)
         vars.consistency_needed = false
 
         -- Raft failover can be enabled only on replicasets of 3 or more instances
-        if #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid, nil, false) < 3 then
+        if #topology.get_leaders_order(topology_cfg, vars.replicaset_uuid, nil, {only_electable=false}) < 3 then
             first_appointments = _get_appointments_disabled_mode(topology_cfg)
             log.warn('Not enough instances to enable Raft failover')
         else

--- a/cartridge/failover/raft.lua
+++ b/cartridge/failover/raft.lua
@@ -90,8 +90,9 @@ local function cfg()
     local box_opts = argparse.get_box_opts()
 
     local topology_cfg = package.loaded['cartridge.confapplier'].get_readonly('topology')
-    if topology_cfg ~= nil and not topology_cfg.servers[box.info.uuid].electable then
+    if topology_cfg ~= nil and topology_cfg.servers[box.info.uuid].electable == false then
         box_opts.election_mode = 'voter'
+        log.info("This instance is unelectable and became voter")
     end
 
     box.cfg{

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -106,24 +106,27 @@ end
 -- New order validity is ignored too.
 --
 -- By default, get_leaders_order doesn't return unelectable nodes.
--- To fix it, use only_electable argument.
+-- To fix it, use only_electable argument of `opts`.
 --
 -- @function get_leaders_order
 -- @local
 -- @tparam table topology_cfg
 -- @tparam string replicaset_uuid
 -- @tparam ?table new_order
--- @tparam ?boolean only_electable
+-- @tparam ?table opts
 -- @treturn {string,...} array of leaders uuids
-local function get_leaders_order(topology_cfg, replicaset_uuid, new_order, only_electable)
-    checks('table', 'string', '?table', '?boolean')
+local function get_leaders_order(topology_cfg, replicaset_uuid, new_order, opts)
+    checks('table', 'string', '?table', '?table')
 
     local servers = topology_cfg.servers
     local replicasets = topology_cfg.replicasets
     local ret = table.copy(new_order) or {}
 
-    if only_electable == nil then
-        only_electable = true
+    if opts == nil then
+        opts = {}
+    end
+    if opts.only_electable == nil then
+        opts.only_electable = true
     end
 
     local replicaset = replicasets and replicasets[replicaset_uuid]
@@ -150,7 +153,7 @@ local function get_leaders_order(topology_cfg, replicaset_uuid, new_order, only_
     if servers ~= nil then
         local ret_tail = {}
         for _, instance_uuid, server in fun.filter(not_expelled, servers):
-            filter(only_electable and electable or every_node)
+            filter(opts.only_electable and electable or every_node)
         do
             if server.replicaset_uuid == replicaset_uuid then
                 if not utils.table_find(ret, instance_uuid) then

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -645,6 +645,5 @@ g_unelectable.test_raft_is_disabled = function()
         api_topology.set_unelectable_servers(uuids)
     end, {{storage_3_uuid}})
 
-    g_unelectable.cluster:retrying({}, function() t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'voter') end)
-
+    t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'voter')
 end

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -5,6 +5,7 @@ local t = require('luatest')
 local g = t.group()
 local g_unsupported = t.group('integration.raft_unsupported')
 local g_not_enough_instances = t.group('integration.raft_not_enough_instances')
+local g_unelectable = t.group('integration.raft_unelectable')
 local h = require('test.helper')
 
 local replicaset_uuid = h.uuid('b')
@@ -575,4 +576,75 @@ g_not_enough_instances.test_raft_is_disabled = function()
         return box.info.ro
     end))
     t.assert_equals(get_election_cfg(g_not_enough_instances, 'storage-2'), 'off')
+end
+
+
+----------------------------------------------------------------
+
+g_unelectable.before_all = function()
+    t.skip_if(not h.tarantool_version_ge('2.10.0'))
+    g_unelectable.cluster = h.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = true,
+        server_command = h.entrypoint('srv_basic'),
+        cookie = h.random_cookie(),
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = h.uuid('a'),
+                roles = {
+                    'vshard-router',
+                },
+                servers = 1,
+            },
+            {
+                alias = 'storage',
+                uuid = replicaset_uuid,
+                roles = {
+                    'vshard-storage',
+                },
+                servers = {
+                    {
+                        instance_uuid = storage_1_uuid,
+                    },
+                    {
+                        instance_uuid = storage_2_uuid,
+                    },
+                    {
+                        instance_uuid = storage_3_uuid,
+                    },
+                },
+            },
+        },
+        env = {
+            TARANTOOL_ELECTION_TIMEOUT = 1,
+            TARANTOOL_REPLICATION_TIMEOUT = 0.25,
+            TARANTOOL_SYNCHRO_TIMEOUT = 1,
+            TARANTOOL_REPLICATION_SYNCHRO_QUORUM = 'N/2 + 1',
+        }
+    })
+    g_unelectable.cluster:start()
+end
+
+g_unelectable.after_all = function()
+    g_unelectable.cluster:stop()
+    fio.rmtree(g_unelectable.cluster.datadir)
+end
+
+g_unelectable.test_raft_is_disabled = function()
+    t.assert_equals(set_failover_params(g_unelectable, { mode = 'raft' }), { mode = 'raft' })
+
+    t.assert_equals(get_election_cfg(g_unelectable, 'storage-1'), 'candidate')
+
+    t.assert_equals(get_election_cfg(g_unelectable, 'storage-2'), 'candidate')
+
+    t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'candidate')
+
+    g_unelectable.cluster.main_server:exec(function(uuids)
+        local api_topology = require('cartridge.lua-api.topology')
+        api_topology.set_unelectable_servers(uuids)
+    end, {{storage_3_uuid}})
+
+    g_unelectable.cluster:retrying({}, function() t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'voter') end)
+
 end


### PR DESCRIPTION
I didn't forget about

- [x] Tests
- [x] Documentation

Close #1919 
