### PR TITLE
Disable Raft failover on ALL_RW replicasets

### DIFF
--- a/test/unit/rpc_candidates_test.lua
+++ b/test/unit/rpc_candidates_test.lua
@@ -63,6 +63,8 @@ g.before_all(function()
                 ['topology.yml'] = yaml.encode(topology_cfg)
             }):lock()
             require('membership').set_payload = function() end
+            local conf_vars = require('cartridge.vars').new('cartridge.confapplier')
+            conf_vars.replicaset_uuid = 'A'
             local failover = require('cartridge.failover')
             _G.box = {
                 cfg = function() end,


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #1858 
