### PR TITLE
Forbid to enable Raft failover with `ALL_RW` replicasets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changed
 
 - Check Raft failover availability on validate_config.
 
+- Forbid to enable Raft failover with ``ALL_RW`` replicasets.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Added
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -843,6 +843,9 @@ local function cfg(clusterwide_config, opts)
             return nil, err
         end
 
+        if topology_cfg.replicasets[vars.replicaset_uuid].all_rw then
+            return ApplyConfigError:new("Raft failover can't be enabled with ALL_RW replicasets")
+        end
         vars.fencing_enabled = false
         vars.consistency_needed = false
 

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -390,6 +390,10 @@ local function validate_failover_schema(field, topology)
         if topology.failover.mode == 'raft' then
             local ok, err = package.loaded['cartridge.failover.raft'].check_version()
             e_config:assert(ok, err)
+
+            for _, rs in pairs(topology.replicasets) do
+                e_config:assert(not rs.all_rw, "Raft failover can't be enabled with ALL_RW replicasets")
+            end
         end
 
         if topology.failover.failover_timeout ~= nil then

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -338,6 +338,9 @@ local function validate_schema(field, topology)
             '%s.all_rw must be a boolean, got %s', field, type(replicaset.all_rw)
         )
 
+        if topology.failover and topology.failover.mode == 'raft' then
+            e_config:assert(not replicaset.all_rw, "Raft failover can't be enabled with ALL_RW replicasets")
+        end
         local known_keys = {
             ['roles'] = true,
             ['master'] = true,
@@ -390,10 +393,6 @@ local function validate_failover_schema(field, topology)
         if topology.failover.mode == 'raft' then
             local ok, err = package.loaded['cartridge.failover.raft'].check_version()
             e_config:assert(ok, err)
-
-            for _, rs in pairs(topology.replicasets) do
-                e_config:assert(not rs.all_rw, "Raft failover can't be enabled with ALL_RW replicasets")
-            end
         end
 
         if topology.failover.failover_timeout ~= nil then

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -172,7 +172,8 @@ It's needed to use Cartridge RPC calls. The user can control an instance's
 election mode using the argparse option ``TARANTOOL_ELECTION_MODE`` or
 ``--election-mode`` or use ``box.cfg{election_mode = ...}`` API in runtime.
 
-Raft failover can be enabled only on replicasets of 3 or more instances.
+Raft failover can be enabled only on replicasets of 3 or more instances
+and can't be enabled with ``ALL_RW`` replicasets.
 
 Note that Raft failover in Cartridge is in beta.
 Don't use it in production.

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -654,7 +654,7 @@ end
 
 ----------------------------------------------------------------
 
-    g_all_rw.before_all = function()
+g_all_rw.before_all = function()
     t.skip_if(not h.tarantool_version_ge('2.10.0'))
     g_all_rw.cluster = h.Cluster:new({
         datadir = fio.tempdir(),

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -6,6 +6,7 @@ local g = t.group()
 local g_unsupported = t.group('integration.raft_unsupported')
 local g_not_enough_instances = t.group('integration.raft_not_enough_instances')
 local g_unelectable = t.group('integration.raft_unelectable')
+local g_all_rw = t.group('integration.raft_all_rw')
 local h = require('test.helper')
 
 local replicaset_uuid = h.uuid('b')
@@ -649,4 +650,57 @@ g_unelectable.test_raft_is_disabled = function()
     end, {{storage_3_uuid}})
 
     t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'voter')
+end
+
+
+ ----------------------------------------------------------------
+
+ g_all_rw.before_all = function()
+    t.skip_if(not h.tarantool_version_ge('2.10.0'))
+    g_all_rw.cluster = h.Cluster:new({
+        datadir = fio.tempdir(),
+        use_vshard = true,
+        server_command = h.entrypoint('srv_basic'),
+        cookie = 'secret', -- h.random_cookie(),
+        replicasets = {
+            {
+                alias = 'router',
+                uuid = h.uuid('a'),
+                roles = {
+                    'vshard-router',
+                },
+                servers = 1,
+            },
+            {
+                alias = 'storage',
+                uuid = replicaset_uuid,
+                roles = {
+                    'vshard-storage',
+                },
+                servers = 3,
+                all_rw = true,
+            },
+        },
+        env = {
+            TARANTOOL_ELECTION_TIMEOUT = 1,
+            TARANTOOL_REPLICATION_TIMEOUT = 0.25,
+            TARANTOOL_SYNCHRO_TIMEOUT = 1,
+            TARANTOOL_REPLICATION_SYNCHRO_QUORUM = 'N/2 + 1',
+        }
+    })
+    g_all_rw.cluster:start()
+end
+
+g_all_rw.after_all = function()
+    g_all_rw.cluster:stop()
+    fio.rmtree(g_all_rw.cluster.datadir)
+end
+
+g_all_rw.test_raft_in_all_rw_mode_fails = function()
+    t.assert_error_msg_contains(
+        "Raft failover can't be enabled with ALL_RW replicasets",
+        set_failover_params, g_all_rw, { mode = 'raft' })
+    t.assert_equals(g_all_rw.cluster.main_server:exec(function()
+        return require('cartridge.confapplier').get_state()
+    end), 'RolesConfigured')
 end

--- a/test/integration/raft_test.lua
+++ b/test/integration/raft_test.lua
@@ -652,16 +652,15 @@ g_unelectable.test_raft_is_disabled = function()
     t.assert_equals(get_election_cfg(g_unelectable, 'storage-3'), 'voter')
 end
 
+----------------------------------------------------------------
 
- ----------------------------------------------------------------
-
- g_all_rw.before_all = function()
+    g_all_rw.before_all = function()
     t.skip_if(not h.tarantool_version_ge('2.10.0'))
     g_all_rw.cluster = h.Cluster:new({
         datadir = fio.tempdir(),
         use_vshard = true,
         server_command = h.entrypoint('srv_basic'),
-        cookie = 'secret', -- h.random_cookie(),
+        cookie = h.random_cookie(),
         replicasets = {
             {
                 alias = 'router',


### PR DESCRIPTION
I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #1858 
