### PR TITLE
Remove error stack from twophase commit result

### DIFF
--- a/cartridge/twophase.lua
+++ b/cartridge/twophase.lua
@@ -669,6 +669,11 @@ local function patch_clusterwide(patch)
     vars.locks['clusterwide'] = false
 
     if not ok then
+        err.stack = nil
+        local _, f = err.err:find("^.*: ")
+        if f ~= nil then
+            err.err = err.err:sub(f + 1)
+        end
         return nil, err
     end
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #1932 
