### PR TITLE
Add O_SYNC flag for ClusterwideConfig.save

### DIFF
--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -502,7 +502,7 @@ local function save(clusterwide_config, path)
 
         ok, err = utils.file_write(
             abspath, content,
-            {'O_CREAT', 'O_EXCL', 'O_WRONLY'}
+            {'O_CREAT', 'O_EXCL', 'O_WRONLY', 'O_SYNC'}
         )
         if not ok then
             goto rollback


### PR DESCRIPTION
ClusterwideConfig.save is a cluster critical function that rely on OS cache. In case server was not properly shutdown or failure or Cloud Provider Preempted some data would not be committed to FS. This change add SYNC flag for all config-related changes.

Open question - Could call `fio.sync()` be a better more reliable solution? Because `fio.rename` could still lead to inconsistency. But, that could be solved by `dirsync` mount option, or file attributes (`chattr`) on a Linux file system.
[clusterwide-config.lua#L512 ](https://github.com/tarantool/cartridge/blob/master/cartridge/clusterwide-config.lua#L512 )