### PR TITLE
Save previous member state into state_prev payload and fix member_is_healthy

### DIFF
--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -159,6 +159,7 @@ local function set_state(new_state, err)
         )
     end
 
+    membership.set_payload('state_prev', vars.state)
     membership.set_payload('state', new_state)
     vars.state = new_state
     vars.error = err

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -56,6 +56,10 @@ local function member_is_healthy(uri, instance_uuid)
         and (member.status == 'alive' or member.status == 'suspect')
         and (member.payload.uuid == instance_uuid)
         and (
+            member.payload.state_prev == 'RolesConfigured' or
+            member.payload.state_prev == 'ConfiguringRoles'
+        )
+        and (
             member.payload.state == 'ConfiguringRoles' or
             member.payload.state == 'RolesConfigured'
         )


### PR DESCRIPTION
This change fixes situation when router sends requests to not fully (first start) RolesConfigured node. When node just started it had not configured roles (defined procedures) yet.

* This change saves previous member state into `state_prev` payload;
* The member should be considered as healthy (`member_is_healthy `) if previous state were `RolesConfigured` or `ConfiguringRoles`. According to https://www.tarantool.io/en/doc/latest/book/cartridge/cartridge_dev/#configuringroles transition. Not `BoxConfigured -> ConfiguringRoles`
 

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #???
