### PR TITLE
Added filtering by labels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,14 @@ Added
 
 - ``O_SYNC`` flag for ClusterwideConfig.save.
 
+- Introduced way to filter instances by labels in rpc calls.
+  You can mark certain instances with the same role with different labels,
+  and then make an rpc call with label. Adding labels is possible via the
+  edit_topology method or via graphql.
+  ``rpc.call('role', 'func', {}, { labels = { ['msk'] = 'dc' } })``
+  ``rpc.get_candidates('role', { labels = { ['msk'] = 'dc', ['meta'] = 'runner' } })``
+  ``rpc.get_connection('role', { labels = { ['msk'] = 'dc' } })``
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/label-utils.lua
+++ b/cartridge/label-utils.lua
@@ -88,8 +88,20 @@ local function validate_schema_labels(field, object)
     return true
 end
 
+local function labels_match(subset_labels, labels)
+    local subset_included = true
+    for name, value in pairs(subset_labels) do
+        if labels[name] ~= value then
+            subset_included = false
+            break
+        end
+    end
+    return subset_included
+end
+
 return {
     validate_labels = function(...)
         return e_label_config:pcall(validate_schema_labels, ...)
-    end
+    end,
+    labels_match = labels_match,
 }

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -87,8 +87,9 @@ end
 --   and its SWIM status is either `alive` or `suspect`
 --   (added in v1.1.0-11, default: **true**)
 -- @tparam ?table opts.labels
---   Filter instances that have the specified labels
---   Example: {['msk'] = 'dc'}
+--   Filter instances that have the specified labels. Adding labels is possible via the
+--   edit_topology method or via graphql
+--   Example: rpc.get_candidates('role', { labels = {['msk'] = 'dc'} })
 --
 -- @treturn[1] {string,...} URIs
 local function get_candidates(role_name, opts)
@@ -231,8 +232,9 @@ end
 --   Conflicts with `opts.leader_only = true`.
 --   (added in v1.2.0-63)
 -- @tparam ?table opts.labels
---   Filter instances that have the specified labels
---   Example: {['msk'] = 'dc'}
+--   Filter instances that have the specified labels. Adding labels is possible via the
+--   edit_topology method or via graphql.
+--   Example: rpc.call('role', 'func', {}, { labels = { ['msk'] = 'dc' } })
 -- @param opts.remote_only (*deprecated*) Use `prefer_local` instead.
 -- @param opts.timeout passed to `net.box` `conn:call` options.
 -- @param opts.buffer passed to `net.box` `conn:call` options.

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -16,6 +16,7 @@ local failover = require('cartridge.failover')
 local confapplier = require('cartridge.confapplier')
 local twophase = require('cartridge.twophase')
 local service_registry = require('cartridge.service-registry')
+local label_utils = require('cartridge.label-utils')
 
 local RemoteCallError = errors.new_class('RemoteCallError')
 
@@ -85,6 +86,9 @@ end
 --   it reports either `ConfiguringRoles` or `RolesConfigured` state
 --   and its SWIM status is either `alive` or `suspect`
 --   (added in v1.1.0-11, default: **true**)
+-- @tparam ?table opts.labels
+--   Filter instances that have the specified labels
+--   Example: {['msk'] = 'dc'}
 --
 -- @treturn[1] {string,...} URIs
 local function get_candidates(role_name, opts)
@@ -95,7 +99,8 @@ local function get_candidates(role_name, opts)
 
     checks('string', {
         leader_only = '?boolean',
-        healthy_only = '?boolean'
+        healthy_only = '?boolean',
+        labels = '?table'
     })
 
     local topology_cfg = confapplier.get_readonly('topology')
@@ -118,6 +123,7 @@ local function get_candidates(role_name, opts)
         if roles.get_enabled_roles(replicaset.roles)[role_name]
         and (not opts.healthy_only or member_is_healthy(server.uri, instance_uuid))
         and (not opts.leader_only or active_leaders[replicaset_uuid] == instance_uuid)
+        and (not opts.labels or label_utils.labels_match(opts.labels, server.labels))
         then
             table.insert(candidates, server.uri)
         end
@@ -138,6 +144,7 @@ end
 -- @tparam[opt] table opts
 -- @tparam ?boolean opts.prefer_local
 -- @tparam ?boolean opts.leader_only
+-- @tparam ?table opts.labels
 --
 -- @return[1] `net.box` connection
 -- @treturn[2] nil
@@ -147,9 +154,10 @@ local function get_connection(role_name, opts)
     checks('string', {
         prefer_local = '?boolean',
         leader_only = '?boolean',
+        labels = '?table',
     })
 
-    local candidates = get_candidates(role_name, {leader_only = opts.leader_only})
+    local candidates = get_candidates(role_name, {leader_only = opts.leader_only, labels = opts.labels})
     if next(candidates) == nil then
         return nil, RemoteCallError:new('No remotes with role %q available', role_name)
     end
@@ -222,6 +230,9 @@ end
 --   Disregards member status and `opts.prefer_local`.
 --   Conflicts with `opts.leader_only = true`.
 --   (added in v1.2.0-63)
+-- @tparam ?table opts.labels
+--   Filter instances that have the specified labels
+--   Example: {['msk'] = 'dc'}
 -- @param opts.remote_only (*deprecated*) Use `prefer_local` instead.
 -- @param opts.timeout passed to `net.box` `conn:call` options.
 -- @param opts.buffer passed to `net.box` `conn:call` options.
@@ -236,6 +247,7 @@ local function call_remote(role_name, fn_name, args, opts)
     checks('string', 'string', '?table', {
         prefer_local = '?boolean',
         leader_only = '?boolean',
+        labels = '?table',
         remote_only = '?boolean', -- deprecated
         uri = '?string',
         timeout = '?', -- for net.box.call
@@ -244,9 +256,9 @@ local function call_remote(role_name, fn_name, args, opts)
         on_push_ctx = '?', -- for net.box.call
     })
 
-    if opts.uri ~= nil and opts.leader_only then
+    if opts.uri ~= nil and (opts.leader_only or opts.labels) then
         local err = "bad argument opts.uri to rpc_call" ..
-            " (conflicts with opts.leader_only=true)"
+            " (conflicts with opts.leader_only=true or opts.labels={...})"
         error(err, 2)
     end
 
@@ -282,6 +294,7 @@ local function call_remote(role_name, fn_name, args, opts)
         conn, err = get_connection(role_name, {
             prefer_local = prefer_local,
             leader_only = leader_only,
+            labels = opts.labels,
         })
     end
 

--- a/test/unit/labels_test.lua
+++ b/test/unit/labels_test.lua
@@ -61,3 +61,40 @@ function g.test_labels_error()
     check_error({labels = {["io.tarantool..vshard"] = "1234"}})
     check_error({labels = {["io.tarantool/vshard"] = "1234"}})
 end
+
+function g.test_labels_match()
+    t.assert_equals(
+        label_utils.labels_match({['msk']='dc'}, {['msk']='dc1'}),
+        false, "label value does not match"
+    )
+    t.assert_equals(
+        label_utils.labels_match({['msk1']='dc'}, {['msk2']='dc'}),
+        false, "label name does not match"
+    )
+
+    t.assert_equals(
+        label_utils.labels_match({['msk']='dc'}, {['msk']='dc', ['spb']='dc'}),
+        true, "the right subset of labels is included in the left set"
+    )
+
+    t.assert_equals(
+        label_utils.labels_match({['msk']='dc5'}, {['msk']='dc', ['spb']='dc'}),
+        false, "the right subset of labels is NOT included in the left set"
+    )
+
+    t.assert_equals(
+        label_utils.labels_match(
+            {['msk']='dc', ['spb']='dc', ['nsk']='dc'},
+            {['msk']='dc', ['spb']='dc'}
+        ),
+        false, "the right subset consisting of more label members than the left set"
+    )
+
+    t.assert_equals(
+        label_utils.labels_match(
+            {['msk']='dc', ['spb']='dc'},
+            {['msk']='dc', ['spb']='dc'}
+        ),
+        true, "the right subset of labels is equal to left set"
+    )
+end


### PR DESCRIPTION
This patch adds the ability to filter instances by labels in rpc methods.

- [X] Tests
- [x] Changelog
- [x] Documentation

Close #1957
