### PR TITLE
Extend authorization tests with new error message

### DIFF
--- a/test/unit/remote_control_test.lua
+++ b/test/unit/remote_control_test.lua
@@ -435,7 +435,10 @@ end
 
 function g.test_bad_username()
     local function check_conn(conn)
-        t.assert_equals(conn.error, "User 'bad-user' is not found")
+        assertStrOneOf(conn.error, {
+            "User 'bad-user' is not found",
+            "User not found or supplied credentials are invalid"
+        })
         t.assert_equals(conn.state, "error")
     end
 
@@ -454,7 +457,10 @@ end
 
 function g.test_bad_password()
     local function check_conn(conn)
-        t.assert_equals(conn.error, "Incorrect password supplied for user 'superuser'")
+        assertStrOneOf(conn.error, {
+            "Incorrect password supplied for user 'superuser'",
+            "User not found or supplied credentials are invalid"
+	})
         t.assert_equals(conn.state, "error")
     end
 


### PR DESCRIPTION
Tarantool is going to replace an error thrown in case of entering an invalid password and entering the login of a non-existent user during authorization. The patch updates authorization tests correspondingly.