### PR TITLE
Fixed index nil labels & added informative error

### DIFF
--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -165,6 +165,15 @@ function g.test_routing()
     t.assert_equals(res.uuid, B1.instance_uuid)
     t.assert_not_equals(res.peer, B1:call('box.session.peer'))
 
+    -- Test opts.labels with non-existent label
+    --------------------------------------------------------------------
+    local res, err = rpc_call(B1, 'myrole', 'void', nil, {labels = {['meta'] = 'unknown'}})
+    t.assert_not(res)
+    t.assert_covers(err, {
+        class_name = 'RemoteCallError',
+        err = 'No remotes with role "myrole" and labels {"meta":"unknown"} available'
+    })
+
     -- Test opts.labels with one label
     --------------------------------------------------------------------
     local res, err = rpc_call(B1,


### PR DESCRIPTION
This patch solves the problem with nullable server.labels and expands the information content of the error when instances by labels are not found.

- [X] Tests
- [X] Changelog (related to #1958)
- [X] Documentation (related to #1958)

Close #1966
