### PR TITLE
Filtering by labels: nil case

### DIFF
--- a/cartridge/label-utils.lua
+++ b/cartridge/label-utils.lua
@@ -89,14 +89,17 @@ local function validate_schema_labels(field, object)
 end
 
 local function labels_match(subset_labels, labels)
-    local subset_included = true
-    for name, value in pairs(subset_labels) do
-        if labels[name] ~= value then
-            subset_included = false
-            break
+    if labels ~= nil then
+        local subset_included = true
+        for name, value in pairs(subset_labels) do
+            if labels[name] ~= value then
+                subset_included = false
+                break
+            end
         end
+        return subset_included
     end
-    return subset_included
+    return false
 end
 
 return {

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -125,7 +125,7 @@ local function get_candidates(role_name, opts)
         if roles.get_enabled_roles(replicaset.roles)[role_name]
         and (not opts.healthy_only or member_is_healthy(server.uri, instance_uuid))
         and (not opts.leader_only or active_leaders[replicaset_uuid] == instance_uuid)
-        and (not (opts.labels and server.labels) or label_utils.labels_match(opts.labels, server.labels))
+        and (not opts.labels or label_utils.labels_match(opts.labels, server.labels))
         then
             table.insert(candidates, server.uri)
         end

--- a/test/integration/rpc_test.lua
+++ b/test/integration/rpc_test.lua
@@ -165,6 +165,15 @@ function g.test_routing()
     t.assert_equals(res.uuid, B1.instance_uuid)
     t.assert_not_equals(res.peer, B1:call('box.session.peer'))
 
+    -- Test opts.labels with non-existent label
+    --------------------------------------------------------------------
+    local res, err = rpc_call(B1, 'myrole', 'void', nil, {labels = {['meta'] = 'unknown'}})
+    t.assert_not(res)
+    t.assert_covers(err, {
+        class_name = 'RemoteCallError',
+        err = 'No remotes with role "myrole" and labels {"meta":"unknown"} available'
+    })
+
     -- Test opts.labels with one label
     --------------------------------------------------------------------
     local res, err = rpc_call(B1,


### PR DESCRIPTION
This patch changes the logic for selecting an instance by label and adds more tests.

Before this path, instances that had no labels were always selected.

- [X] Tests
- [X] Changelog (Related to [commit](https://github.com/tarantool/cartridge/pull/1968/commits/f813d9790c45702225d00e7c62e6e2e5e3d6413c))
- [X] Documentation (Related to [commit](https://github.com/tarantool/cartridge/pull/1968/commits/f813d9790c45702225d00e7c62e6e2e5e3d6413c))

