### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'cartridge'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -18,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     env:
       CMAKE_LDOC_FIND_REQUIRED: 'YES'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
 
 - ``cartridge.roles.metrics`` role (`tarantool#7725 <https://github.com/tarantool/tarantool/issues/7725>`_).
 
+- Versioning support (`tarantool/roadmap-internal#204 <https://github.com/tarantool/roadmap-internal/issues/204>`_).
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,26 +31,6 @@ file(GLOB_RECURSE DOC_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/rst/*"
 )
 
-## VERSION ####################################################################
-###############################################################################
-
-execute_process(
-  COMMAND git describe --tags --always
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  OUTPUT_VARIABLE GIT_DESCRIBE
-  ERROR_QUIET
-)
-
-if (NOT GIT_DESCRIBE)
-  set(GIT_DESCRIBE "unknown")
-endif()
-
-configure_file (
-  "${PROJECT_SOURCE_DIR}/cartridge/VERSION.lua.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/VERSION.lua"
-)
-
 ## Webui ######################################################################
 ###############################################################################
 
@@ -212,7 +192,6 @@ install(
 
 install(
   FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/VERSION.lua
     ${CMAKE_CURRENT_BINARY_DIR}/front-bundle.lua
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/
 )

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -919,6 +919,7 @@ _G.cartridge_set_schema = twophase.set_schema
 
 return {
     VERSION = VERSION,
+    _VERSION = VERSION,
 
     cfg = cfg,
 

--- a/cartridge/VERSION.lua
+++ b/cartridge/VERSION.lua
@@ -1,1 +1,4 @@
-return "scm-1"
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '2.7.8'

--- a/cartridge/VERSION.lua.in
+++ b/cartridge/VERSION.lua.in
@@ -1,3 +1,0 @@
-#!/usr/bin/env tarantool
-
-return "@GIT_DESCRIBE@"

--- a/test/compatibility/cartridge_upgrade_test.lua
+++ b/test/compatibility/cartridge_upgrade_test.lua
@@ -7,13 +7,6 @@ local g = t.group()
 
 local helpers = require('test.helper')
 
-local function version(srv)
-    local version = srv:call('require', {'cartridge.VERSION'})
-    local cwd = srv:call('package.loaded.fio.cwd')
-    log.info('Check %s version: %s (from %s)', srv.alias, version, cwd)
-    return version
-end
-
 local function upstream_info(srv)
     local info = srv:call('box.info')
     for _, v in pairs(info.replication) do
@@ -89,14 +82,6 @@ local function change_version(old, new)
     g.cluster.main_server:setup_replicaset(g.cluster.replicasets[1])
     g.cluster:bootstrap_vshard()
     g.cluster:wait_until_healthy()
-
-    if old ~= nil then
-        t.assert_not_equals(version(leader), 'scm-1')
-        t.assert_not_equals(version(replica), 'scm-1')
-    else
-        t.assert_equals(version(leader), 'scm-1')
-        t.assert_equals(version(replica), 'scm-1')
-    end
 
     ----------------------------------------------------------------------------
     -- Setup data model
@@ -174,14 +159,6 @@ local function change_version(old, new)
     g.cluster:retrying({}, function() replica:connect_net_box() end)
     await_state(replica, 'RolesConfigured')
 
-    if old ~= nil then
-        t.assert_not_equals(version(leader), 'scm-1')
-        t.assert_equals(version(replica), 'scm-1')
-    else
-        t.assert_equals(version(leader), 'scm-1')
-        t.assert_not_equals(version(replica), 'scm-1')
-    end
-
     t.assert_equals(upstream_info(replica), {status = 'follow'})
 
     g.cluster:retrying({}, function()
@@ -247,14 +224,6 @@ local function change_version(old, new)
     leader:start()
     g.cluster:retrying({}, function() leader:connect_net_box() end)
     g.cluster:wait_until_healthy()
-
-    if old ~= nil then
-        t.assert_equals(version(leader), 'scm-1')
-        t.assert_equals(version(replica), 'scm-1')
-    else
-        t.assert_not_equals(version(leader), 'scm-1')
-        t.assert_not_equals(version(replica), 'scm-1')
-    end
 
     t.assert_equals(upstream_info(leader), {status = 'follow'})
 


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204
