### PR TITLE
Allow to call box.ctl.promote on any instance

### DIFF
--- a/cartridge/lua-api/failover.lua
+++ b/cartridge/lua-api/failover.lua
@@ -250,17 +250,9 @@ local function promote(replicaset_leaders, opts)
     })
 
     local mode = get_params().mode
-    if mode ~= 'stateful' and mode ~= 'raft' then
-        return nil, PromoteLeaderError:new(
-            'Promotion only works with stateful or raft failover,' ..
-            ' not in %q mode', mode
-        )
-    end
 
     local coordinator, ok, err
-    if mode == 'raft' then
-        return raft_failover.promote(replicaset_leaders, opts)
-    elseif mode == 'stateful' then
+    if mode == 'stateful' then
         coordinator, err = failover.get_coordinator()
         if err ~= nil then
             return nil, err
@@ -276,6 +268,8 @@ local function promote(replicaset_leaders, opts)
             {replicaset_leaders},
             { uri = coordinator.uri }
         )
+    else
+        return raft_failover.promote(replicaset_leaders, opts)
     end
     if ok == nil then
         return nil, err

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -574,26 +574,6 @@ g.test_switchover = function()
     set_master(replicaset_uuid, storage_2_uuid)
     cluster:retrying({}, check_active_master, storage_2_uuid)
     t.assert_equals(get_master(replicaset_uuid), {storage_2_uuid, storage_2_uuid})
-
-    -- Promotion is not available for disabled failover
-    local ok, err = cluster.main_server:eval([[
-        return require('cartridge').failover_promote(...)
-    ]], {{[replicaset_uuid] = storage_1_uuid}})
-    t.assert_equals(ok, nil)
-    t.assert_covers(err, {
-        class_name = 'PromoteLeaderError',
-        err = 'Promotion only works with stateful or raft failover, not in "disabled" mode',
-    })
-
-    set_failover(true)
-    local ok, err = cluster.main_server:eval([[
-        return require('cartridge').failover_promote(...)
-    ]], {{[replicaset_uuid] = storage_1_uuid}})
-    t.assert_equals(ok, nil)
-    t.assert_covers(err, {
-        class_name = 'PromoteLeaderError',
-        err = 'Promotion only works with stateful or raft failover, not in "eventual" mode',
-    })
 end
 
 g.test_sigkill = function()


### PR DESCRIPTION
I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #2079
