### PR TITLE
ignore unknown vshard parameters during downgrade

### DIFF
--- a/cartridge/vshard-utils.lua
+++ b/cartridge/vshard-utils.lua
@@ -3,6 +3,7 @@
 local fun = require('fun')
 local checks = require('checks')
 local errors = require('errors')
+local log = require('log')
 
 local vars = require('cartridge.vars').new('cartridge.vshard-utils')
 local pool = require('cartridge.pool')
@@ -270,10 +271,9 @@ local function validate_vshard_group(field, vsgroup_new, vsgroup_old)
         ['sched_move_quota'] = true,
     }
     for k, _ in pairs(vsgroup_new) do
-        ValidateConfigError:assert(
-            known_keys[k],
-            'section %s has unknown parameter %q', field, k
-        )
+        if known_keys[k] == nil then
+            log.warn('ValidateConfigError: section %s has unknown parameter %q', field, k)
+        end
     end
 end
 

--- a/test/unit/vshard_config_test.lua
+++ b/test/unit/vshard_config_test.lua
@@ -263,15 +263,6 @@ vshard_groups:
     bootstrapped: nope
 ...]])
 
-check_config('section vshard_groups["global"] has unknown parameter "unknown"',
-[[---
-vshard_groups:
-  global:
-    bucket_count: 1
-    bootstrapped: false
-    unknown:
-...]])
-
 log.info('group assignment')
 check_config("replicasets[aaaaaaaa-0000-4000-b000-000000000001]" ..
     [[ can't be added to vshard_group "some", cluster doesn't have any]],


### PR DESCRIPTION
It's impossible to fix or test issue completely since we can't patch all previous versions. However it's possible to prevent such things in future.
Vshard 0.1.17 introduced two new options that became a part of cluster config. New versions since 2.6.0 contained more options than before. So on attempt to downgrade to e.g. 2.5.1 user faced with following error:

```
section vshard_groups[\"default\"] has unknown parameter \"sched_ref_quota\"
```

Instance start failed with InitError.

To prevent such issue in future let's replace an error with warning and just ignore unknown options.

Closes #1397
