### PR TITLE
metrics: fix cartridge code dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,8 @@ Fixed
 
 - Incorrect memory statistics in WebUI when using large tuples.
 
+- Compatibility with metrics package.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -18,7 +18,6 @@ local confapplier = require('cartridge.confapplier')
 local twophase = require('cartridge.twophase')
 local service_registry = require('cartridge.service-registry')
 local label_utils = require('cartridge.label-utils')
-local health = require('cartridge.health')
 
 local RemoteCallError = errors.new_class('RemoteCallError')
 
@@ -52,6 +51,23 @@ local function call_local(role_name, fn_name, args)
     end
 end
 
+local function member_is_healthy(uri, instance_uuid)
+    local member = membership.get_member(uri)
+    return (
+        (member ~= nil)
+        and (member.status == 'alive' or member.status == 'suspect')
+        and (member.payload.uuid == instance_uuid)
+        and (
+            member.payload.state_prev == nil or -- for backward compatibility with old versions
+            member.payload.state_prev == 'RolesConfigured' or
+            member.payload.state_prev == 'ConfiguringRoles'
+        )
+        and (
+            member.payload.state == 'ConfiguringRoles' or
+            member.payload.state == 'RolesConfigured'
+        )
+    )
+end
 
 --- List candidates suitable for performing a remote call.
 -- Candidates are deduced from a local config and membership, which may
@@ -106,7 +122,7 @@ local function get_candidates(role_name, opts)
         local replicaset = replicasets[replicaset_uuid]
 
         if roles.get_enabled_roles(replicaset.roles)[role_name]
-        and (not opts.healthy_only or health.member_is_healthy(server.uri, instance_uuid))
+        and (not opts.healthy_only or member_is_healthy(server.uri, instance_uuid))
         and (not opts.leader_only or active_leaders[replicaset_uuid] == instance_uuid)
         and (not opts.labels or label_utils.labels_match(opts.labels, server.labels))
         then


### PR DESCRIPTION
Remove cartridge rpc code dependency on cartridge/health.lua code. Originally it was made to remove code copypaste, but if metrics code overwrites cartridge.health, cartridge rpc fails.
