### PR TITLE
Custom health handler + refactoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,11 @@ Added
 
 - ``cartridge.roles.metrics`` role (`tarantool#7725 <https://github.com/tarantool/tarantool/issues/7725>`_).
 
+- Function ``set_is_health_handler`` has been added to role ``cartridge.roles.metrics``,
+  allowing you to set your own handle to check health
+  (`tarantool/cartridge#2097 <https://github.com/tarantool/cartridge/issues/2097>`_).
+  Main case - customizing the response format.
+
 - Versioning support (`tarantool/roadmap-internal#204 <https://github.com/tarantool/roadmap-internal/issues/204>`_).
 
 - ``rpc_call`` supports ``is_async`` net.box option.

--- a/cartridge/rpc.lua
+++ b/cartridge/rpc.lua
@@ -51,6 +51,12 @@ local function call_local(role_name, fn_name, args)
     end
 end
 
+-- TODO
+-- During the transfer of the metrics module to Tarantool, the same implementation of this function will occur
+-- several times:
+-- * https://github.com/tarantool/metrics/blob/master/cartridge/health.lua
+-- * https://github.com/tarantool/cartridge/blob/master/cartridge/health.lua
+-- * https://github.com/tarantool/cartridge/blob/master/cartridge/rpc.lua
 local function member_is_healthy(uri, instance_uuid)
     local member = membership.get_member(uri)
     return (


### PR DESCRIPTION
See problem description [here](https://github.com/tarantool/cartridge/issues/2097)
I propose to give the user the function of setting their own handler to check health.

``` lua
local metrics = require('cartridge.roles.metrics')
metrics.set_custom_is_health_handler(function(req)
    local health = require('cartridge.health')
    local resp = req:render{
        json = {
            my_healthcheck_format = health.is_healthy()
        }
    }
    resp.status = 200
    return resp
end)
```

# Changes
- `metrics.lua` - added function `set_custom_health_handler`, subj
- `health.lua` - divided one function `is_healthy` to three: `is_healthy`, `is_healthy_handler`, `member_is_healthy` - the content of each of which is consistent with the title
- `rpc.lua` - We have a code repetition, and a text link to the original piece is made from the health module. So, replaced code to use `health.member_is_healthy`, and rename `member_is_healthy` to `instance_is_healthy`, because he argument is instance

# Checklist
- [x] Tests
- [x] Changelog
- [x] Documentation

# Links
Close #2097 
