### PR TITLE
test-helpers: fix returning nil on Cluster inherit

### DIFF
--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -27,6 +27,7 @@ local Cluster = {
 function Cluster:inherit(object)
     setmetatable(object, self)
     self.__index = self
+    return object
 end
 
 --- Build cluster object.


### PR DESCRIPTION
I wanted to inherit Cluster class for my own luatest helper. It failed with following error:
```log
test/helpers/cluster.lua:12: attempt to index local 'Cluster' (a nil value)
stack traceback:
	....rocks/share/tarantool/luatest/capture.lua:144: in function '__newindex'
	...test/helpers/cluster.lua:12: in main chunk
	[C]: in function 'require'
	/__w/test/helpers.lua:17: in main chunk
	[C]: in function 'require'
	...test/integration/tcf_status_toggle_test.lua:5: in main chunk
	[C]: in function 'require'
	....rocks/share/tarantool/luatest/loader.lua:43: in function 'load_tests'
	....rocks/share/tarantool/luatest/runner.lua:271: in function <....rocks/share/tarantool/luatest/runner.lua:268>
	[C]: in function 'xpcall'
	....rocks/share/tarantool/luatest/utils.lua:38: in function 'bootstrap'
	....rocks/share/tarantool/luatest/runner.lua:277: in function <....rocks/share/tarantool/luatest/runner.lua:276>
	[C]: in function 'xpcall'
	....rocks/share/tarantool/luatest/capturing.lua:74: in function <....rocks/share/tarantool/luatest/capturing.lua:72>
	[C]: in function 'xpcall'
	....rocks/share/tarantool/luatest/runner.lua:52: in function 'fn'
	....rocks/share/tarantool/luatest/sandboxed_runner.lua:14: in function 'run'
	....rocks/share/tarantool/luatest/cli_entrypoint.lua:4: in function <....rocks/share/tarantool/luatest/cli_entrypoint.lua:3>
	....rocks/share/tarantool/rocks/luatest/scm-1/bin/luatest:5: in main chunk
Tarantool version is 2.10.7-0-g60f7e1858
```
This happens because nothing is returned in `Cluster:inherit(object)`. Lets fix it.