### PR TITLE
cfg: fix syslog availability check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Changed
 
 - Update ``cartridge-metrics-role`` dependency to `0.1.1 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.1>`_.
 
+- Don't require systemd to default to syslog logging. Only check that syslog UNIX socket is available.
+
 -------------------------------------------------------------------------------
 [2.8.0] - 2023-05-25
 -------------------------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changed
 
 - Don't require systemd to default to syslog logging. Only check that syslog UNIX socket is available.
 
+- Fix syslog UNIX socket check for older RHEL-based distros: check both SOCK_STREAM and SOCK_DGRAM.
+
 -------------------------------------------------------------------------------
 [2.8.0] - 2023-05-25
 -------------------------------------------------------------------------------

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -397,6 +397,15 @@ local function cfg(opts, box_opts)
     -- Using syslog driver, when available, by default
     if box_opts.log == nil then
         local syslog, _ = socket.connect('unix/', '/dev/log')
+
+        -- On RHEL 7.9 and Centos 7.9 /dev/log is a UDP socket, not TCP
+        if not syslog then
+            local s = socket('AF_UNIX', 'SOCK_DGRAM', 0)
+            if s:sysconnect('unix/', '/dev/log') then
+                syslog = s
+            end
+        end
+
         if not syslog then
             syslog, _ = socket.connect('unix/', '/var/run/syslog')
         end

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -394,10 +394,8 @@ local function cfg(opts, box_opts)
         ssl_client_password = opts.ssl_client_password,
     })
 
-    -- Using syslog driver when running under systemd
-    -- makes it possible to filter by severity with
-    -- systemctl
-    if utils.under_systemd() and box_opts.log == nil then
+    -- Using syslog driver, when available, by default
+    if box_opts.log == nil then
         local syslog, _ = socket.connect('unix/', '/dev/log')
         if not syslog then
             syslog, _ = socket.connect('unix/', '/var/run/syslog')

--- a/cartridge/utils.lua
+++ b/cartridge/utils.lua
@@ -268,19 +268,6 @@ local function set_readonly(tbl, ro)
     return tbl
 end
 
---- Return true if we run under systemd.
--- systemd detection based on http://unix.stackexchange.com/a/164092
-local function under_systemd()
-    local rv = os.execute("systemctl 2>/dev/null | grep '\\-\\.mount' " ..
-                              "1>/dev/null 2>/dev/null")
-    if rv == 0 and ffi.C.getppid() == 1 then
-        return true
-    end
-
-    return false
-end
-
-
 local function is_email_valid(str)
     if type(str) ~= 'string' then
         return nil, "Expected string"
@@ -557,7 +544,6 @@ return {
     file_exists = file_exists,
     randomize_path = randomize_path,
 
-    under_systemd = under_systemd,
     is_email_valid = is_email_valid,
 
     table_setro = function(tbl)


### PR DESCRIPTION
Historically log defaulted to syslog, only if the instance was started in systemd environment. Sometime after additional check was added because of #1361. New check, checks if syslog UNIX socket is available. No need to check for systemd if we already check that syslog socket exists and even functions.

First commit removes the systemd check from log initialization because:
1) It is kinda hacky (and doesn't work on Centos 7.9 and RHEL 7.9)
2) It is not needed

Second commit tries to treat `/dev/log` as a UDP socket (SOCK_DGRAM), again, on RHEL 7.9 and Centos 7.9 it is that way, and simple `socket.connect` returns "Protocol wrong type for socket" error. But syslog works fine.
