### PR TITLE
test: send logs to stderr in tests

### DIFF
--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -203,6 +203,9 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
     -- which doesn't support it yet.
     upload_prefix = package.loaded['cartridge.upload'] and '../upload',
     disable_errstack = disable_errstack,
+},
+{
+    log = '',
 })
 if not ok then
     log.error('%s', err)

--- a/test/entrypoint/srv_multisharding.lua
+++ b/test/entrypoint/srv_multisharding.lua
@@ -24,6 +24,9 @@ local ok, err = cartridge.cfg({
         'cartridge.roles.vshard-storage',
         'cartridge.roles.vshard-router',
     },
+},
+{
+    log = '',
 })
 
 if not ok then

--- a/test/entrypoint/srv_raft.lua
+++ b/test/entrypoint/srv_raft.lua
@@ -24,6 +24,9 @@ local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
         'test.roles.storage',
     },
     enable_sychro_mode = true,
+},
+{
+    log = '',
 })
 if not ok then
     log.error('%s', err)

--- a/test/entrypoint/srv_vshardless.lua
+++ b/test/entrypoint/srv_vshardless.lua
@@ -26,6 +26,9 @@ local ok, err = cartridge.cfg({
     roles = {
         'mymodule',
     },
+},
+{
+    log = '',
 })
 
 if not ok then

--- a/test/entrypoint/srv_woauth.lua
+++ b/test/entrypoint/srv_woauth.lua
@@ -19,6 +19,9 @@ end
 local ok, err = cartridge.cfg({
     roles = {},
     auth_backend_name = 'no-auth',
+},
+{
+    log = '',
 })
 
 if not ok then


### PR DESCRIPTION
After 5d60dfa86c08 logs are being sent syslog during tests. This makes it hard to access them. Lets return old behaviour during tests.
