### PR TITLE
draft: implement the prepare fiber canceling

### DIFF
--- a/test/integration/twophase_test.lua
+++ b/test/integration/twophase_test.lua
@@ -280,3 +280,18 @@ function g.test_timeouts()
         t.assert_equals(twophase.get_apply_config_timeout(), 111)
     end)
 end
+
+-- Check we don't lock a clusterwide config updates
+-- after exceeding of `validate_timeout_config` timeout
+-- see https://github.com/tarantool/cartridge/issues/2119
+function g.test_2pc_is_locked_after_prepare_timeout()
+    g.s1:exec(function()
+        local t = require('luatest')
+        local twophase = require('cartridge.twophase')
+        twophase.set_validate_config_timeout(0.001)
+        twophase.patch_clusterwide({})
+        twophase.set_validate_config_timeout(10) -- default
+        local _, err = twophase.patch_clusterwide({})
+        t.assert_not(err)
+    end)
+end


### PR DESCRIPTION
When applying of a clusterwide config in a highly loaded cluster, an timeout error often occurs.
In special cases, the error is caused by a timeout at the prepare phase for some instance.
https://github.com/tarantool/cartridge/blob/97a4629dcbbef99183bb178d40db0c91417eff21/cartridge/twophase.lua#L467-L470

After it happens, we get "locked" instance. (see repro in [the linked issue](https://github.com/tarantool/cartridge/issues/2119))
It happens because we abort (i.e. release lock) only prepared instances.
https://github.com/tarantool/cartridge/blob/97a4629dcbbef99183bb178d40db0c91417eff21/cartridge/twophase.lua#L521-L528

This error handling method works well in cases when the "prepare phase" didn't start or failed before a lock was caught.
But in case of a timeout there is situation when the "prepare phase" has started on an intance, but no answer is followed.
Afterwards, when the procedure has finished, it leads to lock catching and blocks the following configs updates.
For now, to fix this situation, the use of `cartridge.twophase.force_reapply` method is needed.

But it seems to me, we can resolve this case automatically.
For this, we have to make abort (i.e. release two-phase commit lock) for all instances,
which has started the execution of the "prepare phase" procedure.
For this, we need to do 2 things:
- abort all instances;
- make abort function idempotent.

Implementation of my solution is to stop fiber which performs the preparation procedure.

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation

Close #2119 
