### PR TITLE
POC: `clusterwide-config.save` in a worker thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ add_test(
 ## Install ####################################################################
 ###############################################################################
 
+add_subdirectory(${PROJECT_NAME})
+
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}

--- a/cartridge/CMakeLists.txt
+++ b/cartridge/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (APPLE)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} \
+        -undefined suppress -flat_namespace")
+endif(APPLE)
+
+add_library(cwinternal SHARED clusterwide-config.c)
+
+set_target_properties(cwinternal PROPERTIES PREFIX "" OUTPUT_NAME "cwinternal")
+install(TARGETS cwinternal LIBRARY DESTINATION ${TARANTOOL_INSTALL_LIBDIR}/cartridge)

--- a/cartridge/clusterwide-config.c
+++ b/cartridge/clusterwide-config.c
@@ -76,24 +76,17 @@ static int cw_save(char* path, char* random_path, char** sections_k, char** sect
     if(file_write(tmp_path, sections_v[i]) == -1) {
       say_error("file_write() error: %s", strerror(errno));
       sprintf(err, "%s: %s", tmp_path, strerror(errno));
-      goto rollback;
+      return -1;
     }
   }
 
   if(rename(random_path, path) == -1) {
     say_error("rename() error: %s", strerror(errno));
     sprintf(err, "%s: %s", path, strerror(errno));
-    goto rollback;
+    return -1;
   }
 
   say_verbose("%s has renamed to %s", random_path, path);
-  goto exit;
-rollback:
-  if(remove(random_path) == -1) {
-    say_warn("remove error: %s, path: %s", strerror(errno), random_path);
-  }
-  return -1;
-exit:
   return 0;
 }
 

--- a/cartridge/clusterwide-config.c
+++ b/cartridge/clusterwide-config.c
@@ -117,7 +117,9 @@ static int lua_cw_save(lua_State *L) {
     if(!lua_isstring(L, -1)) {
       const char* _type = luaL_typename(L, -1);
       say_error("wrong format of table field at index %d: expect string, actual is %s", v, _type);
-      return -1;
+      lua_pushnil(L);
+      lua_pushstring(L, "error");
+      return 2;
     }
     sections_v[v-1] = lua_tostring(L, -1);
     lua_pop(L, 1);
@@ -135,7 +137,9 @@ static int lua_cw_save(lua_State *L) {
     if(!lua_isstring(L, -1)) {
       const char* _type = luaL_typename(L, -1);
       say_error("wrong format of table field at index %d: expect string, actual is %s", k, _type);
-      return -1;
+      lua_pushnil(L);
+      lua_pushstring(L, "error");
+      return 2;
     }
     sections_k[k-1] = lua_tostring(L, -1);
     lua_pop(L, 1);
@@ -144,18 +148,21 @@ static int lua_cw_save(lua_State *L) {
 
   if(k != v) {
     say_error("count of keys and count of values are different");
-    lua_pushnumber(L, -1);
-    return -1;
+    lua_pushnil(L);
+    lua_pushstring(L, "error");
+    return 2;
   }
 
   if(coio_call(va_cw_save, path, random_path, sections_k, sections_v, k-1) == -1) {
     say_error("coio_call() error");
-    lua_pushnumber(L, -1);
-    return -1;
+    lua_pushnil(L);
+    lua_pushstring(L, "deep error");
+    return 2;
   }
 
-  lua_pushnumber(L, 0);
-  return 0;
+  lua_pushboolean(L, 1);
+  lua_pushnil(L);
+  return 2;
 }
 
 static const struct luaL_Reg functions[] = {

--- a/cartridge/clusterwide-config.c
+++ b/cartridge/clusterwide-config.c
@@ -1,0 +1,172 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <tarantool/module.h>
+#include <tarantool/lua.h>
+#include <tarantool/lauxlib.h>
+
+// NOTE: Open flags like in clusterwide-config.save
+// NOTE: Open mode value is ok for this purpose, i guess
+static int file_write(const char* path, const char* data) {
+  int fd = open(path, O_CREAT | O_EXCL | O_WRONLY | O_SYNC,
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if(fd == -1) {
+    say_error("open() error: %s, path: %s", strerror(errno), path);
+    return -1;
+  }
+  int count = strlen(data);
+  ssize_t nr = write(fd, data, count);
+  if(nr == -1){
+    say_error("error while write(): %s", strerror(errno));
+    return -1;
+  }
+  if(nr == 0 || nr != count) {
+    say_warn("data wasn't written correctly, count of written bytes: %ld, expected: %d", nr, count);
+  }
+  if(close(fd) == -1) {
+    say_error("close() error: %s", strerror(errno));
+    return -1;
+  }
+  say_verbose("%s has written", path);
+  return 0;
+}
+
+static int mktree(char* path) {
+  char* tmp_path = strdup(path);
+  // FIXME: here possible buffer overflow
+  char current_dir[512] = "";
+  char* ctxptr;
+  struct stat st;
+  char* dir = strtok(tmp_path, "/");
+  while(dir != NULL) {
+    char* tmp_dir = strdup(current_dir);
+    sprintf(current_dir, "%s/%s", tmp_dir, dir);
+    mode_t mode = 0744;
+    int stat_rc = stat(current_dir, &st);
+    say_info("current_dir: %s", current_dir);
+    if(stat_rc == -1) {
+      if(mkdir(current_dir, mode) ==  -1) {
+        say_error("mkdir() error: %s, path: %s, mode: %x", strerror(errno), current_dir, mode);
+        return -1;
+      } else {
+        say_info("Directory '%s' has created", current_dir);
+      }
+    } else if(!S_ISDIR(st.st_mode)) {
+      say_warn("path: %s : %s", current_dir, strerror(EEXIST));
+      return -1;
+    }
+    dir = strtok(NULL, "/");
+  }
+  return 0;
+}
+
+static int cw_save(char* path, char* random_path, char** sections_k, char** sections_v, int section_l) {
+  if(mktree(random_path) == -1 ) {
+    say_error("mktree() error");
+    return -1;
+  }
+
+  for (int i = 0; i < section_l; i++) {
+    char tmp_path[512];
+    sprintf(tmp_path, "%s/%s", random_path, sections_k[i]);
+    if(file_write(tmp_path, sections_v[i]) == -1) {
+      say_error("file_write() error: %s", strerror(errno));
+      goto rollback;
+    }
+  }
+
+  if(rename(random_path, path) == -1) {
+    say_error("rename() error: %s", strerror(errno));
+    goto rollback;
+  }
+
+  say_verbose("%s has renamed to %s", random_path, path);
+  goto exit;
+rollback:
+  if(remove(path) == -1) {
+    say_error("remove error: %s, path: %s", strerror(errno), path);
+  }
+  return -1;
+exit:
+  return 0;
+}
+
+static ssize_t va_cw_save(va_list argp) {
+  char* path = va_arg(argp, char*);
+  char* random_path = va_arg(argp, char*);
+  char** keys = va_arg(argp, char**);
+  char** values = va_arg(argp, char**);
+  int l = va_arg(argp, int);
+  return cw_save(path, random_path, keys, values, l);
+}
+
+static int lua_cw_save(lua_State *L) {
+  const char* path = luaL_checkstring(L, 1);
+  const char* random_path = luaL_checkstring(L, 2);
+  int v = 1;
+  const char* sections_v[100];
+    do {
+    lua_pushnumber(L, v);
+    lua_gettable(L, 4);
+    if(lua_isnoneornil(L, -1))
+      break;
+
+    if(!lua_isstring(L, -1)) {
+      const char* _type = luaL_typename(L, -1);
+      say_error("wrong format of table field at index %d: expect string, actual is %s", v, _type);
+      return -1;
+    }
+    sections_v[v-1] = lua_tostring(L, -1);
+    lua_pop(L, 1);
+    v++;
+  } while(true);
+
+  const char* sections_k[100];
+  int k = 1;
+  do {
+    lua_pushnumber(L, k);
+    lua_gettable(L, 3);
+    if(lua_isnoneornil(L, -1))
+      break;
+
+    if(!lua_isstring(L, -1)) {
+      const char* _type = luaL_typename(L, -1);
+      say_error("wrong format of table field at index %d: expect string, actual is %s", k, _type);
+      return -1;
+    }
+    sections_k[k-1] = lua_tostring(L, -1);
+    lua_pop(L, 1);
+    k++;
+  } while(true);
+
+  if(k != v) {
+    say_error("count of keys and count of values are different");
+    lua_pushnumber(L, -1);
+    return -1;
+  }
+
+  if(coio_call(va_cw_save, path, random_path, sections_k, sections_v, k-1) == -1) {
+    say_error("coio_call() error");
+    lua_pushnumber(L, -1);
+    return -1;
+  }
+
+  lua_pushnumber(L, 0);
+  return 0;
+}
+
+static const struct luaL_Reg functions[] = {
+  {"save", lua_cw_save},
+  {NULL, NULL}
+};
+
+// NOTE: why i need to use "luaopen_" prefix?
+LUA_API int luaopen_cartridge_cwinternal(lua_State *L) {
+  lua_newtable(L);
+  luaL_register(L, NULL, functions);
+  return 1;
+}
+

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -61,6 +61,7 @@ local errno = require('errno')
 local errors = require('errors')
 
 local utils = require('cartridge.utils')
+local internal = require('cartridge.cwinternal')
 
 yaml.cfg({
     encode_load_metatables = false,
@@ -485,6 +486,19 @@ end
 local function save(clusterwide_config, path)
     checks('ClusterwideConfig', 'string')
     local random_path = utils.randomize_path(path)
+
+    local sections_k = {}
+    local sections_v = {}
+    for k, v in pairs(clusterwide_config._plaintext) do
+        table.insert(sections_k, k)
+        table.insert(sections_v, v)
+    end
+    local rc = internal.save(path, random_path, sections_k, sections_v)
+    if rc == -1 then
+        return nil, SaveConfigError:new("error in c")
+    end
+
+    if true then return true end
 
     local ok, err = utils.mktree(random_path)
     if not ok then

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -501,7 +501,7 @@ local function save(clusterwide_config, path)
                 random_path, err
             )
         end
-        return nil, SaveConfigError:new("%s: %s", path, err)
+        return nil, SaveConfigError:new("%s", err)
     end
     return true
 end

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -494,6 +494,13 @@ local function save(clusterwide_config, path)
     end
     local ok, err = internal.save(path, random_path, sections_k, sections_v)
     if not ok and err then
+        local _, rm_err = fio.rmtree(random_path)
+        if rm_err then
+            log.warn(
+                "Error removing %s: %s",
+                random_path, err
+            )
+        end
         return nil, SaveConfigError:new("%s: %s", path, err)
     end
     return true

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -492,9 +492,9 @@ local function save(clusterwide_config, path)
         table.insert(sections_k, k)
         table.insert(sections_v, v)
     end
-    local rc = internal.save(path, random_path, sections_k, sections_v)
-    if rc == -1 then
-        return nil, SaveConfigError:new("error in c")
+    local ok, err = internal.save(path, random_path, sections_k, sections_v)
+    if not ok and err then
+        return nil, SaveConfigError:new("%s: %s", path, err)
     end
     return true
 end

--- a/cartridge/clusterwide-config.lua
+++ b/cartridge/clusterwide-config.lua
@@ -486,7 +486,6 @@ end
 local function save(clusterwide_config, path)
     checks('ClusterwideConfig', 'string')
     local random_path = utils.randomize_path(path)
-
     local sections_k = {}
     local sections_v = {}
     for k, v in pairs(clusterwide_config._plaintext) do
@@ -497,53 +496,7 @@ local function save(clusterwide_config, path)
     if rc == -1 then
         return nil, SaveConfigError:new("error in c")
     end
-
-    if true then return true end
-
-    local ok, err = utils.mktree(random_path)
-    if not ok then
-        return nil, err
-    end
-
-    for section, content in pairs(clusterwide_config._plaintext) do
-        local abspath = fio.pathjoin(random_path, section)
-        local dirname = fio.dirname(abspath)
-
-        ok, err = utils.mktree(dirname)
-        if not ok then
-            goto rollback
-        end
-
-        ok, err = utils.file_write(
-            abspath, content,
-            {'O_CREAT', 'O_EXCL', 'O_WRONLY', 'O_SYNC'}
-        )
-        if not ok then
-            goto rollback
-        end
-    end
-
-    ok = fio.rename(random_path, path)
-    if not ok then
-        err = SaveConfigError:new(
-            '%s: %s',
-            path, errno.strerror()
-        )
-        goto rollback
-    else
-        return true
-    end
-
-::rollback::
-    local ok, _err = fio.rmtree(random_path)
-    if not ok then
-        log.warn(
-            "Error removing %s: %s",
-            random_path, _err
-        )
-    end
-
-    return nil, err
+    return true
 end
 
 --- Load object from filesystem.


### PR DESCRIPTION
> **Disclaimer**: Пока что прохождения CI не гарантируется.
Как указано в название - это только *proof-of-concept* для проверки идеи.
После обсуждения жизнеспособности данного подхода, в случае его апрува ПР будет "доведен до ума" для мерджа.

# Описание

ПР содержит реализацию `cartridge.clustedwide-config.save` , которая выполняет все операции с файловой системой в отдельном треде с помощью `coio_call`. Подобная реализация позволяет убрать зависимость времени выполнения функции от количества секций в cw-конфиге.

Таким образом, при увеличении количества секций в конфиге количество йилдов не увеличивается, а значит и не увеличивается время работы функции, что позитивно сказывается на скорости и стабильности применения конфига в целом, вне зависимости от реализации бизнес-логики приложения.

В таблице можно посмотреть замеры для настоящей и предложенной реализаций функции `save`

| with coio | # sections | event loop (ms) | duration (ms) | # yields |
| --- | --- | --- | --- | --- |
| no | 4 (default) | 25 | 1532 | 59 |
| no | 4 (default) | 50 | 3084 | 59 |
| no | 8 | 25 | 2966 | 107 |
| no | 8 | 50 | 5682 | 107 |
| no | 16 | 25 | 5596 | 203 |
| no | 16 | 50 | 10822 | 203 |
| yes | 4 (default) | 25 | 30 | 1 |
| yes | 4 (default) | 50 | 59 | 1 |
| yes | 8 | 25 | 28 | 1 |
| yes | 8 | 50 | 57 | 1 |
| yes | 16 | 25 | 31 | 1 |
| yes | 16 | 50 | 57 | 1 |

Алгоритм тестирования аналогичен указанному в [gist](https://gist.github.com/palage4a/994c23f7b6d3ef2ea8e0e4b65ab6fa5f)

Related to #2141

I didn't forget about

- [ ] Tests
- [ ] Changelog
- [ ] Documentation
