### PR TITLE
docs: deprecate Cartridge CLI in favor of tt CLI

### DIFF
--- a/rst/cartridge_admin.rst
+++ b/rst/cartridge_admin.rst
@@ -42,6 +42,13 @@ Then :ref:`start the instances <cartridge-run>`, for example using
 
     $ cartridge start my_app --cfg demo.yml --run-dir ./tmp/run
 
+.. important::
+
+    ``cartridge-cli`` is deprecated in favor of the :ref:`tt CLI utility <tt-cli>`.
+    This guide uses ``cartridge-cli`` as a native tool for Cartridge applications
+    development. However, we encourage you to switch to ``tt`` in order to simplify
+    the migration to Tarantool 3.0 and newer versions.
+
 And bootstrap the cluster.
 You can do this via the Web interface which is available at
 ``http://<instance_hostname>:<instance_http_port>``
@@ -875,11 +882,12 @@ YAML format.
 To connect to a Tarantool instance via the console, you can choose
 one of the commands:
 
-*   Old-fashioned way:
+
+*   Using the ``tt`` CLI utility:
 
     ..  code-block:: bash
 
-        $ tarantoolctl connect <instance_hostname>:<port>
+        $ tt connect <instance_hostname>:<port>
 
 *   If you have cartridge-cli installed:
 
@@ -892,6 +900,12 @@ one of the commands:
     ..  code-block:: bash
 
         $ cartridge enter <node_name>
+
+*   Old-fashioned way with ``tarantoolctl``:
+
+    ..  code-block:: bash
+
+        $ tarantoolctl connect <instance_hostname>:<port>
 
 where the ``<instance_hostname>:<port>`` is the instance's URI.
 

--- a/rst/cartridge_dev.rst
+++ b/rst/cartridge_dev.rst
@@ -44,6 +44,13 @@ Installing Tarantool Cartridge
    ``cartridge-cli``, a command-line tool for developing, deploying, and
    managing Tarantool applications.
 
+   .. important::
+
+     ``cartridge-cli`` is deprecated in favor of the :ref:`tt CLI utility <tt-cli>`.
+     This guide uses ``cartridge-cli`` as a native tool for Cartridge applications
+     development. However, we encourage you to switch to ``tt`` in order to simplify
+     the migration to Tarantool 3.0 and newer versions.
+
 #. `Install <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`__
    ``git``, a version control system.
 
@@ -1141,7 +1148,7 @@ entities are additionally created:
             -   ``srwxr-xr-x``
             -   ``tarantool:tarantool``
             -   Unix socket to connect to the instance via the
-                `tarantoolctl <https://www.tarantool.io/en/doc/latest/reference/tarantoolctl/>`_
+                `tt CLI <https://www.tarantool.io/en/doc/latest/reference/tooling/tt_cli/>`_
                 utility.
 
 .. _cartridge-deploy-tgz:
@@ -1233,7 +1240,7 @@ This deployment method is intended for local testing only.
 
     ..  code-block:: bash
 
-        $ tarantoolctl rocks make
+        $ tt rocks make
 
 #.  Configure the instance(s).
     Create a file called ``/etc/tarantool/conf.d/instances.yml``.

--- a/rst/troubleshooting.rst
+++ b/rst/troubleshooting.rst
@@ -57,7 +57,7 @@ instances.
 
     ..  code-block:: bash
 
-        tarantoolctl connect unix/:/var/run/tarantool/<app-name>.<instance-name>.control
+        tt connect /var/run/tarantool/<app-name>.<instance-name>.control
 
 #.  Inspect what's going on.
 
@@ -126,8 +126,8 @@ option to zero. It may be accomplished in two ways:
 
     ..  code-block:: bash
 
-        echo "box.cfg({replication_connect_quorum = 0})" | tarantoolctl connect \
-        unix/:/var/run/tarantool/<app-name>.<instance-name>.control
+        echo "box.cfg({replication_connect_quorum = 0})" | tt connect \
+        /var/run/tarantool/<app-name>.<instance-name>.control -f -
 
 I want to run an instance with a new advertise_uri
 --------------------------------------------------
@@ -310,8 +310,8 @@ To change instance advertise URI you have to perform these actions:
 
     ..  code-block:: bash
 
-        echo "return box.info().uuid" | tarantoolctl connect \
-        unix/:/var/run/tarantool/<app-name>.<instance-name>.control
+        echo "return box.info().uuid" | tt connect \
+        /var/run/tarantool/<app-name>.<instance-name>.control -f -
 
 #.  Now we need to update instance advertise URI in all instances cluster-wide
     configuration files on each machine. Run ``cartridge repair set-advertise-uri``
@@ -386,8 +386,8 @@ You can remove instance from cluster using ``cartridge repair`` command.
 
     ..  code-block:: bash
 
-        echo "return box.info().uuid" | tarantoolctl connect \
-        unix/:/var/run/tarantool/<app-name>.<instance-name>.control
+        echo "return box.info().uuid" | tt connect \
+        /var/run/tarantool/<app-name>.<instance-name>.control -f -
 
 #.  Now we need to update cluster-wide config for all instances on each machine.
     Run ``cartridge repair remove-instance`` with ``--dry-run`` flag on each


### PR DESCRIPTION
Add deprecation note for Cartridge CLI on doc pages
Add `tt` CLI as a recommended CLI
Replace `tarantoolctl` calls with `tt`

I didn't forget about:

- [x] Tests - no test: documentation update
- [x] Changelog - no changelog: documentation update
- [x] Documentation - doc update

Part of https://github.com/tarantool/doc/issues/3501