### PR TITLE
Add new option disable_raft_on_small_clusters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Added
 
 - new issue about vshard storages marked as ``ALL_RW``.
 
+- ``cartridge.cfg`` option ``disable_raft_on_small_clusters`` to disable Raft
+  failover on clusters with less than 3 instances (default: ``true``).
+
 -------------------------------------------------------------------------------
 [2.8.4] - 2023-10-31
 -------------------------------------------------------------------------------

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -302,6 +302,7 @@ local function cfg(opts, box_opts)
         enable_failover_suppressing = '?boolean',
         enable_sychro_mode = '?boolean',
         enable_synchro_mode = '?boolean',
+        disable_raft_on_small_clusters = '?boolean',
 
         transport = '?string',
         ssl_ciphers = '?string',
@@ -887,6 +888,7 @@ local function cfg(opts, box_opts)
         upgrade_schema = opts.upgrade_schema,
         enable_failover_suppressing = opts.enable_failover_suppressing,
         enable_synchro_mode = opts.enable_synchro_mode,
+        disable_raft_on_small_clusters = opts.disable_raft_on_small_clusters,
 
         transport = opts.transport,
         ssl_ciphers = opts.ssl_ciphers,

--- a/cartridge/argparse.lua
+++ b/cartridge/argparse.lua
@@ -109,6 +109,7 @@ local cluster_opts = {
     ssl_client_password = 'string', -- **string**
     disable_errstack = 'boolean', -- **boolean**
     enable_synchro_mode = 'boolean', -- **boolean**
+    disable_raft_on_small_clusters = 'boolean', -- **boolean**
     enable_failover_suppressing = 'boolean', -- **boolean**
 }
 

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -60,6 +60,7 @@ vars:new('upgrade_schema', nil)
 
 vars:new('enable_failover_suppressing', nil)
 vars:new('enable_synchro_mode', nil)
+vars:new('disable_raft_on_small_clusters', nil)
 
 vars:new('transport', nil)
 vars:new('ssl_options', {
@@ -314,6 +315,7 @@ local function apply_config(clusterwide_config)
         {
             enable_failover_suppressing = vars.enable_failover_suppressing,
             enable_synchro_mode = vars.enable_synchro_mode,
+            disable_raft_on_small_clusters = vars.disable_raft_on_small_clusters,
         }
     )
     if not ok then
@@ -780,6 +782,7 @@ local function init(opts)
         upgrade_schema = '?boolean',
         enable_failover_suppressing = '?boolean',
         enable_synchro_mode = '?boolean',
+        disable_raft_on_small_clusters = '?boolean',
 
         transport = '?string',
         ssl_ciphers = '?string',
@@ -802,6 +805,7 @@ local function init(opts)
     vars.upgrade_schema = opts.upgrade_schema
     vars.enable_failover_suppressing = opts.enable_failover_suppressing
     vars.enable_synchro_mode = opts.enable_synchro_mode
+    vars.disable_raft_on_small_clusters = opts.disable_raft_on_small_clusters
     vars.transport = opts.transport
     vars.ssl_ciphers = opts.ssl_ciphers
     vars.ssl_server_ca_file = opts.ssl_server_ca_file

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -63,6 +63,7 @@ vars:new('failover_fiber')
 vars:new('failover_err')
 vars:new('cookie_check_err', nil)
 vars:new('enable_synchro_mode', false)
+vars:new('disable_raft_on_small_clusters', true)
 vars:new('schedule', {})
 vars:new('client')
 vars:new('cache', {
@@ -758,6 +759,10 @@ local function cfg(clusterwide_config, opts)
 
     vars.enable_synchro_mode = opts.enable_synchro_mode
 
+    if opts.disable_raft_on_small_clusters ~= nil then
+        vars.disable_raft_on_small_clusters = opts.disable_raft_on_small_clusters
+    end
+
     fencing_cancel()
     leader_autoreturn.cancel()
     schedule_clear()
@@ -912,7 +917,8 @@ local function cfg(clusterwide_config, opts)
         vars.consistency_needed = false
 
         -- Raft failover can be enabled only on replicasets of 3 or more instances
-        if #topology.get_leaders_order(
+        if vars.disable_raft_on_small_clusters
+        and #topology.get_leaders_order(
             topology_cfg, vars.replicaset_uuid, nil, {only_electable=false, only_enabled = true}) < 3
         then
             first_appointments = _get_appointments_disabled_mode(topology_cfg)

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -217,7 +217,8 @@ election mode using the argparse option ``TARANTOOL_ELECTION_MODE`` or
 ``--election-mode`` or use ``box.cfg{election_mode = ...}`` API in runtime.
 
 Raft failover can be enabled only on replicasets of 3 or more instances
-and can't be enabled with ``ALL_RW`` replicasets.
+(you can change the behavior by using ``cartridge.cfg`` option
+``disable_raft_on_small_clusters``) and can't be enabled with ``ALL_RW`` replicasets.
 
 ..  important::
 


### PR DESCRIPTION
There are cases (e.g.) maintenance when you need to enable raft even if there are not enough instances in replicaset. I decided not to remove disable at all, but to give users an opportunity to change the behavior manually.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Close #2124
