### PR TITLE
Fix for working with ipv6 addrs

### DIFF
--- a/cartridge.lua
+++ b/cartridge.lua
@@ -597,6 +597,10 @@ local function cfg(opts, box_opts)
         return nil, CartridgeCfgError:new('Invalid port in advertise_uri %q', opts.advertise_uri)
     end
 
+    if advertise.ipv6 then
+        advertise.host = '[' .. advertise.ipv6 .. ']'
+    end
+
     local membership_new_opts, err = argparse.get_opts({
         swim_protocol_period_seconds = 'number',
         swim_anti_entropy_period_seconds = 'number',

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -636,13 +636,18 @@ local function boot_instance(clusterwide_config)
     log.info('Remote control stopped')
 
     local parts = uri_tools.parse(vars.advertise_uri)
+    local family = parts.ipv6 and 'AF_INET6' or 'AF_INET'
     local addrinfo, err = socket.getaddrinfo(
         parts.host, parts.service,
-        {family='AF_INET', type='SOCK_STREAM'}
+        {family=family, type='SOCK_STREAM'}
     )
     if err ~= nil then
         set_state('BootError', err)
         return nil, err
+    end
+
+    if parts.ipv6 then
+        addrinfo[1].host = '[' .. addrinfo[1].host .. ']'
     end
     local listen_uri = addrinfo[1].host .. ":" .. addrinfo[1].port --vars.binary_port
 
@@ -818,9 +823,10 @@ local function init(opts)
     vars.ssl_client_password = opts.ssl_client_password
 
     local parts = uri_tools.parse(opts.advertise_uri)
+    local family = parts.ipv6 and 'AF_INET6' or 'AF_INET'
     local addrinfo, err = socket.getaddrinfo(
         parts.host, parts.service,
-        {family='AF_INET', type='SOCK_STREAM'}
+        {family=family, type='SOCK_STREAM'}
     )
     if addrinfo == nil then
         set_state('InitError', err)

--- a/cartridge/pool.lua
+++ b/cartridge/pool.lua
@@ -38,6 +38,11 @@ local function format_uri(uri)
     elseif parts.service == nil then
         return nil, FormatURIError:new('Invalid URI %q (missing port)', uri)
     end
+
+    if parts.ipv6 then
+        parts.host = '[' .. parts.host .. ']'
+    end
+
     return uri_lib.format({
         host = parts.host,
         service = parts.service,


### PR DESCRIPTION
Changes a needed to support ipv6 addr for instances in cartridge

Need changes from vshard(https://github.com/tarantool/vshard/pull/450) and membership(https://github.com/tarantool/membership/pull/55) to work properly.
