### PR TITLE
update vshard to 0.1.26

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -181,8 +181,8 @@ jobs:
     strategy:
       matrix:
         sdk-version: [
-          "gc64-2.11.0-rc1-0-r543",
-          "nogc64-2.11.0-rc1-0-r543",
+          "gc64-2.11.2-0-r609",
+          "nogc64-2.11.2-0-r609",
           ]
         etcd: ['v2.3.8', 'v3.5.0']
       fail-fast: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,7 @@ Fixed
 Changed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Update ``vshard`` dependency to `0.1.25 <https://github.com/tarantool/vshard/releases/tag/0.1.25>`_.
+- Update ``vshard`` dependency to `0.1.26 <https://github.com/tarantool/vshard/releases/tag/0.1.26>`_.
 
 -------------------------------------------------------------------------------
 [2.8.4] - 2023-10-31

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     'http == 1.5.0-1',
     'checks == 3.3.0-1',
     'errors == 2.2.1-1',
-    'vshard == 0.1.25-1',
+    'vshard == 0.1.26-1',
     'membership == 2.4.1-1',
     'frontend-core == 8.2.2-1',
     'cartridge-metrics-role == 0.1.1',


### PR DESCRIPTION
See https://github.com/tarantool/vshard/releases/tag/0.1.26
