### PR TITLE
ci: bump actions/download-artifact in reusable-backend-test.yml

### DIFF
--- a/.github/workflows/reusable-backend-test.yml
+++ b/.github/workflows/reusable-backend-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Setup tarantool
       - name: 'Download the tarantool build artifact'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
       - name: 'Install tarantool'


### PR DESCRIPTION
Bump version of the `actions/download-artifact` action to v4 for fixing the following GitHub warning:

    The following actions uses node12 which is deprecated and will be
    forced to run on node16
