### PR TITLE
ci: fix nightly build after etcd action update

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -8,8 +8,6 @@ on:
 env:
   # Skip building frontend in tarantoolctl rocks make
   CMAKE_DUMMY_WEBUI: true
-  # Prerequisite for some etcd-related tests
-  ETCD_PATH: etcd-v2.3.8/etcd
 
 jobs:
   run-tests:
@@ -50,6 +48,9 @@ jobs:
         run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
 
       - run: .rocks/bin/luatest -v
+        env:
+          # Prerequisite for some etcd-related tests
+          ETCD_PATH: etcd-v2.3.8/etcd
 
       # Cleanup cached paths
       - run: tarantoolctl rocks remove cartridge


### PR DESCRIPTION
The regression is introduced in #2196. The fix follows a way how another workflow is fixed in #2202.

The problem is that the new setup-etcd action sets the `ETCD_PATH` environment variable on its own. The action sets it as a path to the directory with the `etcd` executable. However, cartridge testing expects a path to the executable itself in this variable.

The workflow-level environment variable definition is rewritten by the action. The fix is to move the environment variable definition down to the job step level to overwrite action's `ETCD_PATH`.

Reported-by: @rosik
