### PR TITLE
rock: bump ddl dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Changed
 - Disabling/enabling instances with ``disable_servers`` / ``enable_servers``
   mutations automatically disables/enables VShard storages.
 
+- Update ``ddl`` dependency to `1.7.1 <https://github.com/tarantool/ddl/releases/tag/1.7.1>`_.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cartridge-scm-1.rockspec
+++ b/cartridge-scm-1.rockspec
@@ -6,7 +6,7 @@ source  = {
 }
 dependencies = {
     'lua >= 5.1',
-    'ddl == 1.7.0-1',
+    'ddl == 1.7.1-1',
     'http == 1.5.0-1',
     'checks == 3.3.0-1',
     'errors == 2.2.1-1',


### PR DESCRIPTION
See [1] for the changelog.

1. https://github.com/tarantool/ddl/releases/tag/1.7.1
