### PR TITLE
Add doubled buckets issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Added
 
 - SSL support to HTTP server.
 
+- New issue about doubled buckets (can be enabled with TARANTOOL_CHECK_DOUBLED_BUCKETS=true).
+
 -------------------------------------------------------------------------------
 [2.12.4] - 2024-09-16
 -------------------------------------------------------------------------------

--- a/cartridge.lua
+++ b/cartridge.lua
@@ -893,6 +893,8 @@ local function cfg(opts, box_opts)
 
     local res, err = argparse.get_opts({
         disable_unrecoverable_instances = 'boolean',
+        check_doubled_buckets = 'boolean',
+        check_doubled_buckets_period = 'number',
     })
 
     if err ~= nil then
@@ -900,6 +902,7 @@ local function cfg(opts, box_opts)
     end
 
     issues.disable_unrecoverable(res.disable_unrecoverable_instances)
+    issues.check_doubled_buckets(res.check_doubled_buckets, res.check_doubled_buckets_period)
 
     if opts.upload_prefix ~= nil then
         local path = opts.upload_prefix

--- a/rst/cartridge_admin.rst
+++ b/rst/cartridge_admin.rst
@@ -1518,6 +1518,14 @@ Cartridge displays cluster and instances issues in WebUI:
     *   **warning**: "Vshard storages in replicaset ... marked as "all writable".
         You can fix it by setting ``all_rw = false`` in the replicaset configuration;
 
+    *   **warning**: "Cluster has ... doubled buckets. Call require('cartridge.vshard-utils').find_doubled_buckets() for details"
+        -- you need to call ``require('cartridge.vshard-utils').find_doubled_buckets()`` to get more info
+        and then remove all duplicated data manually and then use ``vshard.storage.bucket_force_drop(bucket_id)``
+        to remove the bucket. See https://github.com/tarantool/vshard/issues/412 for details.
+        This issue is disabled by default. You can enable it by setting
+        ``TARANTOOL_CHECK_DOUBLED_BUCKETS=true`` and then chech will run once a
+        ``TARANTOOL_CHECK_DOUBLED_BUCKETS_PERIOD`` (default is 24 hours);
+
     You can enable extra vshard issues by setting
     ``TARANTOOL_ADD_VSHARD_STORAGE_ALERTS_TO_ISSUES=true/TARANTOOL_ADD_VSHARD_ROUTER_ALERTS_TO_ISSUES=true``
     or with ``--add-vshard-storage-alerts-to-issues/--add-vshard-router-alerts-to-issues`` command-line argument.

--- a/test/integration/vshard_doubled_buckets_test.lua
+++ b/test/integration/vshard_doubled_buckets_test.lua
@@ -1,0 +1,71 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+
+g.before_all = function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        cookie = helpers.random_cookie(),
+        use_vshard = true,
+        replicasets = {
+            {
+                alias = 'router',
+                roles = {'vshard-router'},
+                servers = 1,
+            },
+            {
+                alias = 'storage-1',
+                roles = {'vshard-storage'},
+                servers = 1,
+            },
+            {
+                alias = 'storage-2',
+                roles = {'vshard-storage'},
+                servers = 1,
+            },
+        },
+        env = {
+            TARANTOOL_CHECK_DOUBLED_BUCKETS = 'true',
+            TARANTOOL_CHECK_DOUBLED_BUCKETS_PERIOD = '10',
+        },
+    })
+    g.cluster:start()
+end
+
+g.after_all = function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end
+
+function g.test_doubled_buckets()
+    local bucket = g.cluster:server('storage-2-1'):exec(function()
+        return box.space._bucket:select(nil, {limit = 1})[1]
+    end)
+
+    g.cluster:server('storage-1-1'):exec(function(bucket)
+        box.space._bucket:run_triggers(false)
+        return box.space._bucket:insert(bucket)
+    end, {bucket})
+
+    t.helpers.retrying({timeout = 20}, function()
+        t.assert_covers(helpers.list_cluster_issues(g.cluster.main_server), {
+            {
+                level = 'warning',
+                topic = 'vshard',
+                message = "Cluster has 1 doubled buckets. " ..
+                "Call require('cartridge.vshard-utils').find_doubled_buckets() for details",
+            },
+        })
+    end)
+
+    g.cluster:server('storage-1-1'):exec(function(bucket)
+        return box.space._bucket:delete(bucket[1])
+    end, {bucket})
+
+    t.helpers.retrying({timeout = 20}, function()
+        t.assert_covers(helpers.list_cluster_issues(g.cluster.main_server), {})
+    end)
+end


### PR DESCRIPTION
This pull request introduces a new feature to detect and handle doubled buckets in the cluster. The most important changes include adding configuration options, implementing the detection logic, and updating the documentation and tests.

### New Feature: Detection of Doubled Buckets

* [`cartridge.lua`](diffhunk://#diff-4510d8f4156200090fbd124d1f0c857878214d302876a93b45aeac0d64eaafdeR877-R886): Added configuration options `check_doubled_buckets` and `check_doubled_buckets_period` to enable and configure the detection of doubled buckets.
* [`cartridge/issues.lua`](diffhunk://#diff-89f2e576b4ffcfda7d676569f445c83f7e9fc01d06bd071470ccf12cbf2d4e48R756-R777): Implemented the logic to check for doubled buckets periodically and raise warnings if any are found. [[1]](diffhunk://#diff-89f2e576b4ffcfda7d676569f445c83f7e9fc01d06bd071470ccf12cbf2d4e48R756-R777) [[2]](diffhunk://#diff-89f2e576b4ffcfda7d676569f445c83f7e9fc01d06bd071470ccf12cbf2d4e48R891-R896)
* [`cartridge/vshard-utils.lua`](diffhunk://#diff-e1e73c26322586de0313e59993d21c3b1eca35fe497d2ef67500c9c629b1b24bR620-R663): Added `find_doubled_buckets` function to identify doubled buckets in the cluster. [[1]](diffhunk://#diff-e1e73c26322586de0313e59993d21c3b1eca35fe497d2ef67500c9c629b1b24bR620-R663) [[2]](diffhunk://#diff-e1e73c26322586de0313e59993d21c3b1eca35fe497d2ef67500c9c629b1b24bR811)

### Documentation Updates

* [`CHANGELOG.rst`](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR21-R22): Documented the new issue about doubled buckets and how to enable it.
* [`rst/cartridge_admin.rst`](diffhunk://#diff-ae710a1211aea9545c0b4f100e3554fe37cd32430eff8b48e7078cdff5d7f4feR1515-R1522): Updated the admin guide to include information about the doubled buckets warning and how to address it.

### Testing

* [`test/integration/vshard_doubled_buckets_test.lua`](diffhunk://#diff-fb2a84b948b106592c823dfe83e0efbbbbecd69d15f85ca3d29a9782dbd41b92R1-R72): Added integration tests to verify the detection and handling of doubled buckets.



I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

