### PR TITLE
doc: Cartridge doesn't support etcd 3.6.0+

### DIFF
--- a/rst/cartridge_admin.rst
+++ b/rst/cartridge_admin.rst
@@ -921,7 +921,7 @@ Stateful failover
 
     The stateful failover mode with Tarantool Stateboard is **not recommended**
     for use on large clusters in production. If you have a high load production
-    cluster, use the stateful failover with ``etcd`` instead.
+    cluster, use the stateful failover with etcd instead.
 
 Leader appointments are polled from the external state provider.
 Decisions are made by one of the instances with the ``failover-coordinator``
@@ -932,6 +932,12 @@ role enabled. There are two options of external state provider:
 
 - etcd v2 - you need to run and configure etcd cluster. Note that **only etcd v2
   API is supported**, so you can still use etcd v3 with ``ETCD_ENABLE_V2=true``.
+
+  ..  note::
+
+      etcd 3.6.0 and higher does not support the ``ETCD_ENABLE_V2`` option.
+      Use etcd versions below 3.6.0 to ensure that the stateful failover mode works correctly with etcd.
+
 
 To enable stateful failover:
 

--- a/rst/topics/failover.rst
+++ b/rst/topics/failover.rst
@@ -12,6 +12,7 @@ more than one.
 
 Which instance will become a leader depends on topology settings and
 failover configuration.
+For more information about the failover configuration in Cartridge, see :ref:`Enabling automatic failover <cartridge-node-failure>`.
 
 An important topology parameter is the **failover priority** within
 a replica set. This is an ordered list of instances. By default, the first


### PR DESCRIPTION
Close https://github.com/tarantool/doc/issues/5187

Deployment: https://docs.d.tarantool.io/en/doc/doc-gh-5187-etcd-360/book/cartridge/cartridge_admin/#stateful-failover