### PR TITLE
log: add logging to failover module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Added
 
 - New ``config_applied`` variable in ``cartridge.twophase`` module to track
   clusterwide configuration status.
+- Improved failover and leader election logging:
+
+  - Added structured logs explaining why a leader appointment was made or skipped.
+  - Logs now include replicaset aliases and number of candidates evaluated.
+  - Control loop logs clearer start and wait states.
 
 -------------------------------------------------------------------------------
 [2.16.0] - 2025-06-20

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -217,7 +217,7 @@ end
 local function _get_replicaset_alias_by_replicaset_uuid(server_uuid)
     local topology_cfg = vars.clusterwide_config:get_readonly('topology')
 
-    local replicaset = topology_cfg.replicasets[server_uuid]
+    local replicaset = topology_cfg.replicasets[replicaset_uuid]
     if replicaset ~= nil and replicaset.alias ~= nil then
         return replicaset.alias
     end

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -214,7 +214,7 @@ local function _get_appointments_stateful_mode(client, timeout)
     return client:longpoll(timeout)
 end
 
-local function _get_replicaset_alias_by_replicaset_uuid(server_uuid)
+local function _get_replicaset_alias_by_replicaset_uuid(replicaset_uuid)
     local topology_cfg = vars.clusterwide_config:get_readonly('topology')
 
     local replicaset = topology_cfg.replicasets[replicaset_uuid]

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -221,8 +221,7 @@ local function describe(uuid)
     if uuid == vars.instance_uuid then
         return string.format('%s (me)', uuid)
     elseif servers[uuid] ~= nil then
-        local alias = servers[uuid].alias or '-'
-        return string.format('%s (%s, %q)', uuid, alias, servers[uuid].uri)
+        return string.format('%s (%q)', uuid, servers[uuid].uri)
     else
         return uuid
     end
@@ -462,8 +461,6 @@ local function synchro_promote()
             log.error('synchro_promote: fiber was cancelled in synchro_promote')
             return err
         end
-    else
-        log.warn('synchro_promote: skipped (conditions not met)')
     end
 end
 

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -216,8 +216,9 @@ end
 
 local function _get_replicaset_alias_by_replicaset_uuid(replicaset_uuid)
     local topology_cfg = vars.clusterwide_config:get_readonly('topology')
+    local replicaset_map = assert(topology_cfg.replicasets)
+    local replicaset = replicaset_map[replicaset_uuid]
 
-    local replicaset = topology_cfg.replicasets[replicaset_uuid]
     if replicaset ~= nil and replicaset.alias ~= nil then
         return replicaset.alias
     end

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -65,7 +65,8 @@ local function pack_decision(leader_uuid)
 end
 
 local function _get_replicaset_alias_by_replicaset_uuid(replicaset_uuid)
-    local replicaset = vars.topology_cfg.replicasets[replicaset_uuid]
+    local replicaset_map = assert(vars.topology_cfg.replicasets)
+    local replicaset = replicaset_map[replicaset_uuid]
 
     if replicaset ~= nil and replicaset.alias ~= nil then
         return replicaset.alias
@@ -73,7 +74,7 @@ local function _get_replicaset_alias_by_replicaset_uuid(replicaset_uuid)
 end
 
 local function describe(uuid)
-    local servers = vars.topology_cfg.servers
+    local servers = assert(vars.topology_cfg.servers)
     local srv = servers[uuid]
 
     if srv ~= nil then

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -176,7 +176,7 @@ local function control_loop(session)
 
         local updates = {}
 
-        for replicaset_uuid, data in pairs(vars.topology_cfg.replicasets) do
+        for replicaset_uuid, replicaset in pairs(vars.topology_cfg.replicasets) do
             local prev = ctx.decisions[replicaset_uuid]
             local decision, info = make_decision(ctx, replicaset_uuid)
             local prev_leader_uuid = prev and prev.leader or 'none'

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -73,7 +73,7 @@ local function _get_replicaset_alias_by_replicaset_uuid(replicaset_uuid)
 end
 
 local function describe(uuid)
-    local servers = assert(vars.topology_cfg.servers)
+    local servers = vars.topology_cfg.servers
     local srv = servers[uuid]
 
     if srv ~= nil then

--- a/cartridge/roles/coordinator.lua
+++ b/cartridge/roles/coordinator.lua
@@ -93,6 +93,7 @@ end
 -- taking into account immunity timeout and health status.
 --
 -- @function make_decision
+-- @local
 -- @tparam table ctx The failover context table (must include .members and .decisions)
 -- @tparam string replicaset_uuid UUID of the replicaset
 --


### PR DESCRIPTION
What has been done:
Added structured logging to failover.lua and coordinator.lua. Now logs cover leader switches (with aliases and URIs), quorum and health checks, immunity status, and errors during failover decisions.

Why:
Previously, the failover process lacked visibility. It was hard to trace leader election logic or investigate why a leader was changed without deep manual inspection.

What problem is being solved:
This change improves observability of failover and leader appointment workflows. It makes it easier to debug production incidents and analyze unexpected leader transitions.

I didn't forget about

- [ ] Tests
- [x] Changelog
- [ ] Documentation

Close TNTP-3341
