### PR TITLE
Fix misleading error for empty etcd2 endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ and this project adheres to
 Unreleased
 -------------------------------------------------------------------------------
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Empty strings in etcd2 endpoints are now silently ignored during validation,
+  preventing misleading "Invalid URI" errors when users add trailing newlines
+  in the Web UI (`#2319 <https://github.com/tarantool/cartridge/issues/2319>`_).
+
+
 -------------------------------------------------------------------------------
 [2.16.5] - 2025-12-03
 -------------------------------------------------------------------------------

--- a/cartridge/topology.lua
+++ b/cartridge/topology.lua
@@ -660,12 +660,14 @@ local function validate_failover_schema(field, topology)
                         '%s.endpoints must be a contiguous array of strings', field
                     )
 
-                    local _, err = pool.format_uri(uri)
-                    e_config:assert(
-                        not err,
-                        '%s.endpoints[%d]: %s',
-                        field, i, err and err.err
-                    )
+                    if uri ~= '' then
+                        local _, err = pool.format_uri(uri)
+                        e_config:assert(
+                            not err,
+                            '%s.endpoints[%d]: %s',
+                            field, i, err and err.err
+                        )
+                    end
                     i = i + 1
                 end
             end

--- a/test/unit/topology_test.lua
+++ b/test/unit/topology_test.lua
@@ -397,6 +397,26 @@ failover:
     endpoints: ["localhost"]
 ...]])
 
+    -- Test that empty strings in endpoints are silently ignored (issue #2319)
+    check_config(true,
+[[---
+servers:
+  aaaaaaaa-aaaa-4000-b000-000000000001:
+    uri: localhost:3301
+    replicaset_uuid: aaaaaaaa-0000-4000-b000-000000000001
+replicasets:
+  aaaaaaaa-0000-4000-b000-000000000001:
+    master: aaaaaaaa-aaaa-4000-b000-000000000001
+    roles: {}
+failover:
+  mode: stateful
+  state_provider: etcd2
+  etcd2_params:
+    prefix: /myapp
+    endpoints: ["http://localhost:2379", "", "http://localhost:2380"]
+...]])
+
+
     check_config('topology_new.failover.etcd2_params has unknown parameter "unknown"',
 [[---
 failover:

--- a/webui/src/pages/Cluster/components/FailoverModal/components/FailoverModalForm/FailoverModalForm.form.tsx
+++ b/webui/src/pages/Cluster/components/FailoverModal/components/FailoverModalForm/FailoverModalForm.form.tsx
@@ -177,7 +177,10 @@ export const withFailoverForm = withFormik<FailoverFormProps, FailoverFormValues
           state_provider === 'etcd2'
             ? {
                 ...casted.etcd2_params,
-                endpoints: casted.etcd2_params?.endpoints?.split('\n'),
+                endpoints: casted.etcd2_params?.endpoints
+                  ?.split('\n')
+                  .map((s) => s.trim())
+                  .filter((s) => s !== ''),
               }
             : null,
       };


### PR DESCRIPTION
Fix issue where trailing newlines in etcd2 endpoint configuration caused confusing 'Invalid URI ""' validation errors.

Changes:
- Backend: Skip empty strings in topology.lua endpoint validation
- Frontend: Add trim and filter to FailoverModalForm before submission

Fixes #2319

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation
