### PR TITLE
failover: switch election mode from 'off' to 'manual' for stateful failover

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 
 - Do not expand the file tree by default on the code page.
 - Update ``vshard`` dependency to `0.1.39 <https://github.com/tarantool/vshard/releases/tag/0.1.38>`_.
+- Change election mode from 'off' to 'manual' for stateful failover to avoid split-brain.
 
 -------------------------------------------------------------------------------
 [2.16.5] - 2025-12-03

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -852,6 +852,10 @@ local function cfg(clusterwide_config, opts)
     end
 
     if vars.mode == 'stateful' and failover_cfg.mode ~= 'stateful' and failover_cfg.mode ~= 'raft' then
+        if box.cfg.election_mode then
+            box.cfg{ election_mode = 'off' }
+        end
+
         local err = synchro_demote()
         if err ~= nil then
             ApplyConfigError:new(
@@ -908,6 +912,10 @@ local function cfg(clusterwide_config, opts)
             end
         else
             vars.consistency_needed = true
+
+            if box.cfg.election_mode then
+                box.cfg{ election_mode = 'manual' }
+            end
         end
 
         if failover_cfg.state_provider == 'tarantool' then

--- a/test/integration/failover_eventual_test.lua
+++ b/test/integration/failover_eventual_test.lua
@@ -714,6 +714,9 @@ end)
 
 function g.test_sync_spaces_is_prohibited()
     t.skip_if(not helpers.tarantool_version_ge('2.6.1'))
+
+    set_failover(true)
+
     local master = cluster:server('storage-1')
     master:exec(function()
         box.schema.space.create('test', {if_not_exists = true, is_sync=true})

--- a/test/integration/fencing_test.lua
+++ b/test/integration/fencing_test.lua
@@ -13,6 +13,7 @@ local uB = helpers.uuid('b')
 local uA1 = helpers.uuid('a', 1, 1)
 local uB1 = helpers.uuid('b', 1, 1)
 local uB2 = helpers.uuid('b', 2, 2)
+local uB3 = helpers.uuid('b', 3, 3)
 local A1
 local B1
 local B2
@@ -37,6 +38,7 @@ local function setup_cluster(g)
             servers = {
                 {alias = 'B1', instance_uuid = uB1},
                 {alias = 'B2', instance_uuid = uB2},
+                {alias = 'B3', instance_uuid = uB3},
             },
         }},
     })

--- a/test/roles/storage.lua
+++ b/test/roles/storage.lua
@@ -1,7 +1,6 @@
 return {
     init = function(opts)
-        if opts.is_master then
-            assert(box.info.ro == false)
+        if opts.is_master and box.info.ro == false then
             box.schema.space.create('test', { if_not_exists = true })
             box.space.test:format{
                 {'bucket_id', 'unsigned'},


### PR DESCRIPTION
Calling `box.ctl.promote()` while election_mode is set to 'off' may cause split-brain. 
This fix changes the election mode from 'off' to 'manual' for stateful failover.
