### PR TITLE
Support bootstrap_strategy on Tarantool 2.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Fixed
 
 - Fixed a race condition during instance shutdown where ``membership.leave()`` 
   could execute before roles were stopped, causing errors. 
+- Fixed compatibility with Tarantool 2.11.0 and newer by using the new 
+  ``bootstrap_strategy = 'auto'`` option instead of the deprecated 
+  ``replication_connect_quorum``.
 
 -------------------------------------------------------------------------------
 [2.17.1] - 2026-05-26

--- a/cartridge/confapplier.lua
+++ b/cartridge/confapplier.lua
@@ -300,8 +300,7 @@ local function apply_config(clusterwide_config)
         membership.set_allowed_members(allowed_uris)
     end
 
-    box.cfg({
-        replication_connect_quorum = 0,
+    local cfg = {
         replication = topology.get_fullmesh_replication(
             topology_cfg, vars.replicaset_uuid,
             vars.instance_uuid, vars.advertise_uri,
@@ -313,7 +312,13 @@ local function apply_config(clusterwide_config)
                 ssl_password = vars.ssl_client_password,
             }
         ),
-    })
+    }
+
+    if not utils.version_is_at_least(2, 11, 0) then
+        cfg.replication_connect_quorum = 0
+    end
+
+    box.cfg(cfg)
 
     local ok, err = OperationError:pcall(failover.cfg,
         clusterwide_config,
@@ -422,10 +427,13 @@ local function boot_instance(clusterwide_config)
 
     -- Use default values in case they're missing
     box_opts.replication_sync_timeout = box_opts.replication_sync_timeout or 300
-    -- Here we use 100 as a big quorum number to force Tarantool to use full quorum. Result value will be
-    -- min(#box.cfg.replication, box.cfg.replication_connect_quorum).
-    -- replication_connect_quorum will be reworked after https://github.com/tarantool/tarantool/pull/8037
-    box_opts.replication_connect_quorum = box_opts.replication_connect_quorum or 100
+
+    -- replication_connect_quorum was reworked in Tarantool 2.11.0 via bootstrap_strategy.
+    if not utils.version_is_at_least(2, 11, 0) then
+        -- We use 100 as a big quorum number to force Tarantool to use full quorum.
+        -- Result value will be min(#box.cfg.replication, box.cfg.replication_connect_quorum).
+        box_opts.replication_connect_quorum = box_opts.replication_connect_quorum or 100
+    end
 
     -- The instance should know his uuids.
     local snapshots = fio.glob(fio.pathjoin(box_opts.memtx_dir, '*.snap'))
@@ -481,7 +489,11 @@ local function boot_instance(clusterwide_config)
 
         box_opts.instance_uuid = instance_uuid
         box_opts.replicaset_uuid = assert(replicaset_uuid)
-        box_opts.replication_connect_quorum = 1
+
+        if not utils.version_is_at_least(2, 11, 0) then
+            box_opts.replication_connect_quorum = 1
+        end
+
         box_opts.replication = topology.get_fullmesh_replication(
             topology_cfg, replicaset_uuid,
             -- Workaround for https://github.com/tarantool/tarantool/issues/3760
@@ -534,35 +546,48 @@ local function boot_instance(clusterwide_config)
 
         -- Set up 'star' replication for the bootstrap
         local bootstrap_from = require('cartridge.argparse').get_opts({bootstrap_from = 'string'}).bootstrap_from
-        local bootstrap_table = {}
         if bootstrap_from ~= nil then
-            bootstrap_table = bootstrap_from:split(',')
-            box_opts.replication = bootstrap_table
+            box_opts.replication = bootstrap_from:split(',')
         elseif instance_uuid == leader_uuid then
             box_opts.replication = nil
             box_opts.read_only = false
-            -- leader should be bootstrapped with quorum = 0, otherwise
-            -- there'll be a race during parallel bootstrap. Leader will
-            -- enter orphan mode (temporarily, until it connects to the
-            -- replica) and replica would fail to join because leader is
-            -- readonly.
-            box_opts.replication_connect_quorum = 0
+            if not utils.version_is_at_least(2, 11, 0) then
+                -- Leader should be bootstrapped with quorum = 0, otherwise
+                -- there'll be a race during parallel bootstrap. Leader will
+                -- enter orphan mode (temporarily, until it connects to the
+                -- replica) and replica would fail to join because leader is
+                -- readonly.
+                box_opts.replication_connect_quorum = 0
+            end
         else
-            if vars.transport == 'ssl' then
-                local uri = {
-                    uri = pool.format_uri(leader.uri),
-                    params = {
-                        transport = 'ssl',
+            if utils.version_is_at_least(2, 11, 0) then
+                box_opts.replication = topology.get_fullmesh_replication(
+                    topology_cfg, replicaset_uuid,
+                    instance_uuid, nil,
+                    {
+                        transport = vars.transport,
                         ssl_ca_file = vars.ssl_client_ca_file,
                         ssl_cert_file = vars.ssl_client_cert_file,
                         ssl_key_file = vars.ssl_client_key_file,
                         ssl_password = vars.ssl_client_password,
                     }
-                }
-                box_opts.replication = {uri}
+                )
             else
-                table.insert(bootstrap_table, pool.format_uri(leader.uri))
-                box_opts.replication = bootstrap_table
+                if vars.transport == 'ssl' then
+                    local uri = {
+                        uri = pool.format_uri(leader.uri),
+                        params = {
+                            transport = 'ssl',
+                            ssl_ca_file = vars.ssl_client_ca_file,
+                            ssl_cert_file = vars.ssl_client_cert_file,
+                            ssl_key_file = vars.ssl_client_key_file,
+                            ssl_password = vars.ssl_client_password,
+                        }
+                    }
+                    box_opts.replication = {uri}
+                else
+                    box_opts.replication = {pool.format_uri(leader.uri)}
+                end
             end
         end
     end

--- a/test/integration/advertise_change_test.lua
+++ b/test/integration/advertise_change_test.lua
@@ -4,6 +4,7 @@ local t = require('luatest')
 local g = t.group()
 
 local helpers = require('test.helper')
+local utils = require('cartridge.utils')
 
 local function move(srv, port)
     srv.net_box_port = nil
@@ -91,6 +92,11 @@ function g.test_issues()
 end
 
 function g.test_topology_query()
+    t.skip_if(
+        utils.version_is_at_least(2, 11, 0),
+        "Since Tarantool 2.11.0 bootstrap_strategy='auto' ignores connect quorum, leaving replicas in ro mode"
+    )
+
     local servers = g.cluster.main_server:graphql({
         query = [[{
             servers {
@@ -133,6 +139,11 @@ g.before_test('test_2pc', function()
 end)
 
 function g.test_2pc()
+    t.skip_if(
+        utils.version_is_at_least(2, 11, 0),
+        "Since Tarantool 2.11.0 bootstrap_strategy='auto' triggers ConnectingFullmesh state, blocking 2PC"
+    )
+
     g.cluster.main_server:graphql({
         query = g.query,
         variables = {servers = {
@@ -171,6 +182,11 @@ g.after_test('test_2pc', function()
 end)
 
 g.before_test('test_failover', function()
+    t.skip_if(
+        utils.version_is_at_least(2, 11, 0),
+        "Since Tarantool 2.11.0 bootstrap_strategy='auto' locks config changes due to ConnectingFullmesh state"
+    )
+
     local ok, err = g.A1:call(
         'package.loaded.cartridge.failover_set_params',
         {{mode = 'eventual'}}

--- a/test/integration/bootstrap_strategy_test.lua
+++ b/test/integration/bootstrap_strategy_test.lua
@@ -1,0 +1,63 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local helpers = require('test.helper')
+local utils = require('cartridge.utils')
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        use_vshard = false,
+        cookie = helpers.random_cookie(),
+        replicasets = {{
+            uuid = helpers.uuid('a'),
+            roles = {},
+            servers = {
+                {alias = 'master'},
+                {alias = 'replica'},
+            },
+        }},
+    })
+
+    g.cluster:start()
+    g.master = g.cluster:server('master')
+    g.replica = g.cluster:server('replica')
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_bootstrap_strategy_is_auto_on_boot()
+    t.skip_if(not utils.version_is_at_least(2, 11, 0), "bootstrap_strategy is available only since Tarantool 2.11.0")
+
+    local strategy = g.master:exec(function()
+        return box.cfg.bootstrap_strategy
+    end)
+    t.assert_equals(strategy, "auto")
+end
+
+function g.test_bootstrap_strategy_after_apply_config()
+    t.skip_if(not utils.version_is_at_least(2, 11, 0), "bootstrap_strategy is available only since Tarantool 2.11.0")
+
+    local ok, err = g.master:exec(function()
+        local confapplier = require('cartridge.confapplier')
+        local active_config = confapplier.get_active_config()
+        return confapplier.apply_config(active_config)
+    end)
+
+    t.assert_equals({ok, err}, {true, nil})
+
+    local cfg_state = g.master:exec(function()
+        return {
+            strategy = box.cfg.bootstrap_strategy,
+            quorum = box.cfg.replication_connect_quorum
+        }
+    end)
+
+    t.assert_equals(cfg_state.strategy, "auto")
+    t.assert_equals(cfg_state.quorum, nil)
+end

--- a/test/integration/cookie_change_test.lua
+++ b/test/integration/cookie_change_test.lua
@@ -3,6 +3,7 @@ local h = require('test.helper')
 local g = t.group()
 
 local fio = require('fio')
+local utils = require('cartridge.utils')
 
 g.before_all(function()
     g.cluster = h.Cluster:new({
@@ -78,6 +79,8 @@ local function set_cookie_clusterwide(cluster, cookie)
 end
 
 function g.test_cluster_restart()
+    t.skip_if(utils.version_is_at_least(2, 11, 0))
+
     local new_cookie = 'test_cluster_restart_cookie'
     set_cookie_clusterwide(g.cluster, new_cookie)
 
@@ -94,6 +97,8 @@ function g.test_cluster_restart()
 end
 
 function g.test_server_restart()
+    t.skip_if(utils.version_is_at_least(2, 11, 0))
+
     local new_cookie = 'test_server_restart_cookie'
     local target = g.cluster:server('A-2')
     set_cookie_clusterwide(g.cluster, new_cookie)

--- a/test/integration/state_machine_test.lua
+++ b/test/integration/state_machine_test.lua
@@ -587,6 +587,10 @@ function g.test_orphan_connect_timeout()
 end
 
 function g.test_quorum_one()
+    t.skip_if(
+        utils.version_is_at_least(2, 11, 0),
+        "Since 2.11.0 Tarantool uses bootstrap_strategy='auto' and ignores connect quorum on restart"
+    )
     -- It's possible to avoid orphan status by explicitly specifying
     -- TARANTOOL_REPLICATION_CONNECT_QUORUM = 1 (or 0)
 


### PR DESCRIPTION
Cartridge unconditionally set `replication_connect_quorum` during bootstrap and configuration updates. This forced Tarantool 2.11 into 'legacy' bootstrap mode and triggered deprecation warnings.

Added a version check to set `bootstrap_strategy = 'auto'` on Tarantool 2.11+, while keeping `replication_connect_quorum` for older versions.

Closes TNTP-5637
