### PR TITLE
Retry box.ctl.promote() on conflict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,11 @@ Unreleased
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Fixed a race condition during instance shutdown where ``membership.leave()`` 
-  could execute before roles were stopped, causing errors. 
+- Fixed a race condition during instance shutdown where ``membership.leave()``
+  could execute before roles were stopped, causing errors.
+- When ``box.ctl.promote()`` returns ER_INTERFERING_PROMOTE during failover
+  retry promotion 3 times with 1 second delay so the new master will not
+  be stuck in read-only mode.
 
 -------------------------------------------------------------------------------
 [2.17.1] - 2026-05-26

--- a/cartridge/failover.lua
+++ b/cartridge/failover.lua
@@ -454,27 +454,53 @@ local function fencing_start()
     vars.fencing_fiber:name('cartridge.fencing')
 end
 
+local SYNCHRO_PROMOTE_RETRY_ATTEMPTS = 3
+local SYNCHRO_PROMOTE_RETRY_DELAY = 1
+
 local function synchro_promote()
-    if vars.enable_synchro_mode == true
-    and vars.mode == 'stateful'
-    and vars.promote_for_leader_required
-    and vars.cache.is_leader
-    and not vars.failover_paused
-    and not vars.failover_suppressed
-    and box.ctl.promote ~= nil
-    then
+    local ok, err
+    for attempt = 1, SYNCHRO_PROMOTE_RETRY_ATTEMPTS do
+        if vars.enable_synchro_mode ~= true
+        or vars.mode ~= 'stateful'
+        or not vars.promote_for_leader_required
+        or not vars.cache.is_leader
+        or vars.failover_paused
+        or vars.failover_suppressed
+        or box.ctl.promote == nil
+        then
+            return
+        end
+
         log.info('Attempting box.ctl.promote()')
 
-        local ok, err = pcall(box.ctl.promote)
-        if ok ~= true then
-            log.error('Failed to promote: %s', err or 'unknown')
-            return err
+        ok, err = pcall(box.ctl.promote)
+        -- Retry only if interfering promote happened
+        if ok or not err or err.code ~= box.error.INTERFERING_PROMOTE then
+            break
         end
-        ok, err = pcall(fiber.testcancel)
-        if ok ~= true then
-            log.error('Fiber was cancelled in synchro_promote')
-            return err
+
+        -- No need to sleep after last failed attempt
+        if attempt < SYNCHRO_PROMOTE_RETRY_ATTEMPTS then
+            log.warn('Failed to promote (will retry): %s.', err)
+            fiber.sleep(SYNCHRO_PROMOTE_RETRY_DELAY)
+
+            local cancel_ok, cancel_err = pcall(fiber.testcancel)
+            if cancel_ok ~= true then
+                log.error('Fiber was cancelled in synchro_promote')
+                return cancel_err
+            end
         end
+    end
+
+    if ok ~= true then
+        log.error('Failed to promote: %s', err or 'unknown')
+        return err
+    end
+
+    ok, err = pcall(fiber.testcancel)
+    if ok ~= true then
+        log.error('Fiber was cancelled in synchro_promote')
+        return err
     end
 end
 

--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -349,8 +349,9 @@ function Cluster:join_server(server)
 end
 
 --- Blocks fiber until `cartridge.is_healthy()` returns true on main_server.
-function Cluster:wait_until_healthy(server)
-    self:retrying({}, function ()
+function Cluster:wait_until_healthy(server, opts)
+    opts = opts or {}
+    self:retrying(opts, function ()
         (server or self.main_server).net_box:eval([[
             local cartridge = package.loaded['cartridge']
             return assert(cartridge) and assert(cartridge.is_healthy())

--- a/test/integration/failover_synchro_test.lua
+++ b/test/integration/failover_synchro_test.lua
@@ -261,6 +261,120 @@ local function promote_errors_test(g)
     end)
 end
 
+local function promotion_conflict_test(g)
+    local res
+
+    h.retrying({timeout = 20}, function()
+        promote(g.cluster, storage_1_uuid)
+    end)
+    local master_id
+    h.retrying({timeout = 20}, function()
+        master_id = g.cluster:server(find_alias_by_uuid(storage_1_uuid)):exec(function()
+            assert(box.info.ro == false)
+            assert(box.info.synchro.quorum == 2)
+            assert(box.info.synchro.queue.owner == box.info.id)
+            return box.info.id
+        end)
+    end)
+
+    h.retrying({timeout = 20}, function()
+        g.cluster:server(find_alias_by_uuid(storage_2_uuid)):exec(function(master_id)
+            assert(box.info.ro == true)
+            assert(box.info.synchro.quorum == 2)
+            assert(box.info.synchro.queue.owner == master_id)
+        end, { master_id })
+    end)
+    h.retrying({timeout = 20}, function()
+        g.cluster:server(find_alias_by_uuid(storage_3_uuid)):exec(function(master_id)
+            assert(box.info.ro == true)
+            assert(box.info.synchro.quorum == 2)
+            assert(box.info.synchro.queue.owner == master_id)
+        end, { master_id })
+    end)
+
+    -- Kill storages 2 and 3 to lack quorum
+    kill_server(g, 'storage-2')
+    kill_server(g, 'storage-3')
+
+    -- Add an insert request and kill storage-1 so the request will be stuck in storage-1 limbo
+    -- and storage-1 will have synchro queue term greater than storages 2 and 3.
+    local future = g.cluster:server(find_alias_by_uuid(storage_1_uuid)):exec(function()
+        return box.space.test:insert({123, 'test_key_1', 'test_value_1'})
+    end, {}, { is_async = true })
+    kill_server(g, 'storage-1')
+    res = future:wait_result(20)
+    t.assert_equals(res, nil)
+
+    -- Start all storages
+    start_server(g, 'storage-2')
+    start_server(g, 'storage-3')
+    g.cluster:server(find_alias_by_uuid(storage_2_uuid)):exec(function()
+        rawset(_G, 'old_promote', box.ctl.promote)
+        rawset(_G, 'promotion_log', {
+            attempts = 0,
+            errors = {},
+        })
+        rawset(box.ctl, 'promote', function()
+            _G.promotion_log.attempts = _G.promotion_log.attempts + 1
+            local ok, err = pcall(_G.old_promote)
+            if not ok then
+                table.insert(_G.promotion_log.errors, err)
+                error(err)
+            end
+        end)
+    end)
+
+    require('fiber').sleep(5)
+    start_server(g, 'storage-1')
+
+    g.cluster:wait_until_healthy(nil, { timeout = 20 })
+
+    local storage_2_replica_id = g.cluster:server(find_alias_by_uuid(storage_2_uuid)):exec(function()
+        return box.info.id
+    end)
+
+    -- Storage 2 has a promotion conflict, but retries and becomes the queue owner.
+    h.retrying({timeout = 20}, function()
+        for i, uuid in pairs({storage_1_uuid, storage_2_uuid, storage_3_uuid}) do
+            res = g.cluster:server(find_alias_by_uuid(uuid)):exec(function()
+                return {
+                    ro = box.info.ro,
+                    ro_reason = box.info.ro_reason,
+                    synchro = box.info.synchro,
+                }
+            end)
+
+            -- Storage 2 is RW, other storages are RO
+            if i == 2 then
+                t.assert_equals(res.ro, false)
+                t.assert_equals(res.ro_reason, nil)
+            else
+                t.assert_equals(res.ro, true)
+                t.assert_equals(res.ro_reason, 'synchro')
+            end
+
+            -- Synchro queue is owned by storage 2, it has replica_id = 3
+            t.assert_equals(res.synchro.queue.owner, storage_2_replica_id)
+            t.assert_equals(res.synchro.queue.busy, false)
+            t.assert_equals(res.synchro.queue.len, 0)
+            t.assert_gt(res.synchro.queue.term, 3)
+        end
+    end)
+
+    res = g.cluster:server(find_alias_by_uuid(storage_2_uuid)):exec(function()
+        rawset(box.ctl, 'promote', _G.old_promote)
+        rawset(_G, 'old_promote', nil)
+        local prom_log = rawget(_G, 'promotion_log')
+        rawset(_G, 'promotion_log', nil)
+        return prom_log
+    end)
+
+    -- Check that there were 2 attempts to promote and only 1 promotion conflict.
+    t.assert_equals(res.attempts, 2)
+    t.assert_equals(#res.errors, 1)
+    t.assert_equals(res.errors[1].code, box.error.INTERFERING_PROMOTE)
+end
+
 local function cleanup(g)
     if g.state_provider ~= nil then
         g.state_provider:stop()
@@ -362,6 +476,7 @@ end)
 
 g_stateboard.test_kill_master_stateboard = stateful_test
 g_stateboard.test_promote_errors = promote_errors_test
+g_stateboard.test_promotion_conflict = promotion_conflict_test
 
 g_stateboard.after_all(function(g)
     cleanup(g)
@@ -396,6 +511,7 @@ end)
 
 g_etcd2.test_kill_master = stateful_test
 g_etcd2.test_promote_errors = promote_errors_test
+g_etcd2.test_promotion_conflict = promotion_conflict_test
 
 g_etcd2.after_all(function(g)
     cleanup(g)


### PR DESCRIPTION
When `box.ctl.promote()` returns ER_INTERFERING_PROMOTE during failover retry promotion 3 times with 1 second delay so the new master will not be stuck in read-only mode.
