### PR TITLE
helpers: make vshard bootstrap timeout configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,19 @@ and this project adheres to
 Unreleased
 -------------------------------------------------------------------------------
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Added
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- New option ``--vshard-bootstrap-timeout`` (env ``TARANTOOL_VSHARD_BOOTSTRAP_TIMEOUT``)
+  of the ``vshard-router`` role to configure the vshard bootstrap timeout.
+  The default value remains 10 seconds, which may be not enough to distribute
+  buckets across the storages on slow CI runners.
+- Optional ``timeout`` argument to ``cartridge.test-helpers.Cluster:start``,
+  ``cartridge.test-helpers.Cluster:bootstrap`` and
+  ``cartridge.test-helpers.Cluster:bootstrap_vshard`` to extend the
+  bootstrap HTTP request timeout.
+
 -------------------------------------------------------------------------------
 [2.17.3] - 2026-08-25
 -------------------------------------------------------------------------------

--- a/cartridge/roles/vshard-router.lua
+++ b/cartridge/roles/vshard-router.lua
@@ -35,6 +35,7 @@ vars:new('routers', {
 
 vars:new('issues', {})
 vars:new('enable_alerting', false)
+vars:new('bootstrap_timeout', 10)
 
 -- Human readable router name for logging
 -- Isn't exposed in public API
@@ -80,9 +81,17 @@ local function init(_)
     local opts, _ = require('cartridge.argparse').get_opts({
         connections_limit = 'number',
         add_vshard_router_alerts_to_issues = 'boolean',
+        vshard_bootstrap_timeout = 'number',
     })
     if opts.add_vshard_router_alerts_to_issues ~= nil then
         vars.enable_alerting = opts.add_vshard_router_alerts_to_issues
+    end
+    if opts.vshard_bootstrap_timeout ~= nil then
+        local timeout = opts.vshard_bootstrap_timeout
+        if timeout <= 0 or timeout == math.huge then
+            error("vshard_bootstrap_timeout must be a finite positive number greater than 0", 0)
+        end
+        vars.bootstrap_timeout = timeout
     end
     local limit = opts.connections_limit
     if limit == nil then
@@ -214,7 +223,7 @@ local function bootstrap_group(group_name, vsgroup)
 
     log.info('Bootstrapping %s ...', router_name)
 
-    local ok, err = get(group_name):bootstrap({timeout=10})
+    local ok, err = get(group_name):bootstrap({timeout=vars.bootstrap_timeout})
     if not ok and err.code ~= vshard.error.code.NON_EMPTY then
         return nil, e_bootstrap_vshard:new(
             '%s (%s, %s)',

--- a/cartridge/test-helpers/cluster.lua
+++ b/cartridge/test-helpers/cluster.lua
@@ -236,8 +236,10 @@ function Cluster:apply_zone_distances()
     end
 end
 
--- Configure replicasets and bootstrap vshard if required.
-function Cluster:bootstrap()
+--- Configure replicasets and bootstrap vshard if required.
+-- @param[opt] timeout HTTP request timeout in seconds, forwarded to
+--   @{Cluster:bootstrap_vshard}.
+function Cluster:bootstrap(timeout)
     self.main_server = self.servers[1]
     self:apply_topology()
     self:apply_zone_distances()
@@ -247,18 +249,32 @@ function Cluster:bootstrap()
     end
 
     if self.use_vshard then
-        self:bootstrap_vshard()
+        self:bootstrap_vshard(timeout)
     end
 end
 
-function Cluster:bootstrap_vshard()
+--- Bootstrap vshard in the cluster.
+-- @param[opt] timeout HTTP request timeout in seconds. Distributing buckets
+--   across the storages may take a while, so a greater timeout may be needed
+--   on slow CI runners.
+function Cluster:bootstrap_vshard(timeout)
     local server = self.main_server
     log.debug('Bootstrapping vshard.router on ' .. server.advertise_uri)
-    log.debug({response = server:graphql({query = 'mutation { bootstrap_vshard }'})})
+
+    local http_options
+    if timeout ~= nil then
+        http_options = {http = {timeout = timeout}}
+    end
+
+    log.debug({response = server:graphql({
+        query = 'mutation { bootstrap_vshard }'
+    }, http_options)})
 end
 
 --- Bootstraps cluster if it wasn't bootstrapped before. Otherwise starts servers.
-function Cluster:start()
+-- @param[opt] timeout HTTP request timeout in seconds, forwarded to
+--   @{Cluster:bootstrap} and then to @{Cluster:bootstrap_vshard}.
+function Cluster:start(timeout)
     if self.running then
         return
     end
@@ -276,7 +292,7 @@ function Cluster:start()
             self:wait_until_healthy(server)
         end
     else
-        self:bootstrap()
+        self:bootstrap(timeout)
         self.bootstrapped = true
     end
     if self.failover ~= 'disabled' then

--- a/cartridge/test-helpers/server.lua
+++ b/cartridge/test-helpers/server.lua
@@ -239,7 +239,8 @@ function Server:graphql(request, http_options)
 
     http_options = table.copy(http_options) or {}
     if self.auth_enabled then
-        http_options.http = { headers = bauth('admin', self.cluster_cookie) }
+        http_options.http = http_options.http or {}
+        http_options.http.headers = bauth('admin', self.cluster_cookie)
     end
     http_options.json = {
         query = request.query,


### PR DESCRIPTION
The default vshard bootstrap timeout of 10 seconds may be not enough to
distribute buckets across the storages on slow CI runners.

vshard-router role:
- new option --vshard-bootstrap-timeout (env TARANTOOL_VSHARD_BOOTSTRAP_TIMEOUT)
  to configure the per-group vshard bootstrap timeout; the default value
  remains 10 seconds.

Test helpers (cartridge.test-helpers.Cluster):
- start(), bootstrap() and bootstrap_vshard() now accept an optional timeout
  that is forwarded to the bootstrap HTTP request. If it is omitted, the
  behavior is unchanged (no HTTP timeout is set). This allows tests to wait
  longer for the bootstrap to complete, e.g. cluster:start(60).

Also Server:graphql() no longer discards the caller-provided http options
when auth is enabled, so the timeout survives on auth-enabled clusters.

Part of TNTP-9875
